### PR TITLE
Update Kokoro to GCC 9.2 and Bazel 2.0.0

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,6 +1,6 @@
 # Building Android GPU Inspector
 
-AGI uses the [Bazel build system](https://bazel.build/). The recommended version of Bazel is **1.2.0**.
+AGI uses the [Bazel build system](https://bazel.build/). The recommended version of Bazel is **2.0.0**.
 
 Bazel is able to fetch most of the dependencies required to build AGI, but currently the Android SDK and NDK both need to be downloaded and installed by hand.
 
@@ -37,9 +37,9 @@ Using the msys64 shell at `C:\tools\msys64\mingw64`:
 1. Update MSYS with: `pacman -Syu`.
 2. If the update ends with “close the window and run it again”, close and reopen the window and repeat 1.
 3. Fetch required tools with: `pacman -S curl git zip unzip patch`
-4. Download gcc with: `curl -O http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-7.3.0-2-any.pkg.tar.xz`
-5. Download gcc-libs with: `curl -O http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-7.3.0-2-any.pkg.tar.xz`
-6. Install gcc with: `pacman -U mingw-w64-x86_64-gcc*-7.3.0-2-any.pkg.tar.xz`
+4. Download gcc with: `curl -O http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-9.2.0-2-any.pkg.tar.xz`
+5. Download gcc-libs with: `curl -O http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-9.2.0-2-any.pkg.tar.xz`
+6. Install gcc with: `pacman -U mingw-w64-x86_64-gcc*-9.2.0-2-any.pkg.tar.xz`
 7. Close the MSYS terminal
 
 ### Install Java Development Kit 8

--- a/kokoro/linux-test/test.sh
+++ b/kokoro/linux-test/test.sh
@@ -20,7 +20,7 @@ BUILD_ROOT=$PWD
 SRC=$PWD/github/agi/
 
 # Get bazel
-BAZEL_VERSION=1.2.0
+BAZEL_VERSION=2.0.0
 curl -L -k -O -s https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
 mkdir bazel
 bash bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh --prefix=$PWD/bazel
@@ -29,8 +29,8 @@ bash bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh --prefix=$PWD/bazel
 sudo rm /etc/apt/sources.list.d/cuda.list*
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get -q update
-sudo apt-get -qy install gcc-8 g++-8
-export CC=/usr/bin/gcc-8
+sudo apt-get -qy install gcc-9 g++-9
+export CC=/usr/bin/gcc-9
 
 cd $SRC
 BUILD_SHA=${KOKORO_GITHUB_COMMIT:-$KOKORO_GITHUB_PULL_REQUEST_COMMIT}

--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -20,17 +20,17 @@ BUILD_ROOT=$PWD
 SRC=$PWD/github/agi/
 
 # Get bazel.
-BAZEL_VERSION=1.2.0
+BAZEL_VERSION=2.0.0
 curl -L -k -O -s https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
 mkdir bazel
 bash bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh --prefix=$PWD/bazel
 
-# Get GCC 8
+# Get GCC 9
 sudo rm /etc/apt/sources.list.d/cuda.list*
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get -q update
-sudo apt-get -qy install gcc-8 g++-8
-export CC=/usr/bin/gcc-8
+sudo apt-get -qy install gcc-9 g++-9
+export CC=/usr/bin/gcc-9
 
 # Get the Android NDK
 curl -L -k -O -s https://dl.google.com/android/repository/android-ndk-r20b-linux-x86_64.zip

--- a/kokoro/macos/build.sh
+++ b/kokoro/macos/build.sh
@@ -30,7 +30,7 @@ export ANDROID_HOME=$PWD/android
 export ANDROID_NDK_HOME=$PWD/android/android-ndk-r20b
 
 # Get bazel.
-BAZEL_VERSION=1.2.0
+BAZEL_VERSION=2.0.0
 curl -L -k -O -s https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh
 mkdir bazel
 sh bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh --prefix=$PWD/bazel

--- a/kokoro/presubmit/build.sh
+++ b/kokoro/presubmit/build.sh
@@ -20,7 +20,7 @@ BUILD_ROOT=$PWD
 SRC=$PWD/github/agi/
 
 # Get bazel.
-BAZEL_VERSION=1.2.0
+BAZEL_VERSION=2.0.0
 curl -L -k -O -s https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
 mkdir bazel
 bash bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh --prefix=$PWD/bazel

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -41,17 +41,17 @@ unzip -q -d wix wix311-binaries.zip
 set WIX=%cd%\wix
 
 REM Fix up the MSYS environment.
-wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-7.3.0-2-any.pkg.tar.xz
-wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-7.3.0-2-any.pkg.tar.xz
+wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-9.2.0-2-any.pkg.tar.xz
+wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-9.2.0-2-any.pkg.tar.xz
 c:\tools\msys64\usr\bin\bash --login -c "pacman -R --noconfirm catgets libcatgets"
 c:\tools\msys64\usr\bin\bash --login -c "pacman -Syu --noconfirm"
 c:\tools\msys64\usr\bin\bash --login -c "pacman -Sy --noconfirm mingw-w64-x86_64-crt-git patch"
-c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm mingw-w64-x86_64-gcc*-7.3.0-2-any.pkg.tar.xz"
+c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm mingw-w64-x86_64-gcc*-9.2.0-2-any.pkg.tar.xz"
 set PATH=c:\tools\msys64\mingw64\bin;c:\tools\msys64\usr\bin;%PATH%
 set BAZEL_SH=C:\tools\msys64\usr\bin\bash.exe
 
 REM Install Bazel.
-set BAZEL_VERSION=1.2.0
+set BAZEL_VERSION=2.0.0
 wget -q https://github.com/bazelbuild/bazel/releases/download/%BAZEL_VERSION%/bazel-%BAZEL_VERSION%-windows-x86_64.zip
 unzip -q bazel-%BAZEL_VERSION%-windows-x86_64.zip
 set PATH=C:\python27;%PATH%

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -41,11 +41,13 @@ unzip -q -d wix wix311-binaries.zip
 set WIX=%cd%\wix
 
 REM Fix up the MSYS environment.
+wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-binutils-2.33.1-1-any.pkg.tar.xz
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-9.2.0-2-any.pkg.tar.xz
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-9.2.0-2-any.pkg.tar.xz
 c:\tools\msys64\usr\bin\bash --login -c "pacman -R --noconfirm catgets libcatgets"
 c:\tools\msys64\usr\bin\bash --login -c "pacman -Syu --noconfirm"
 c:\tools\msys64\usr\bin\bash --login -c "pacman -Sy --noconfirm mingw-w64-x86_64-crt-git patch"
+c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm mingw-w64-x86_64-binutils-2.33.1-1-any.pkg.tar.xz"
 c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm mingw-w64-x86_64-gcc*-9.2.0-2-any.pkg.tar.xz"
 set PATH=c:\tools\msys64\mingw64\bin;c:\tools\msys64\usr\bin;%PATH%
 set BAZEL_SH=C:\tools\msys64\usr\bin\bash.exe


### PR DESCRIPTION
Update Kokoro to use the same major GCC version as we have on our gLinux machines, and to the Bazel version which matches the .bazelversion file. Also update BUILDING doc.

b/148534979