### PR TITLE
Fix Vulkan sample cube distortion.

### DIFF
--- a/cmd/vulkan_sample/main.cpp
+++ b/cmd/vulkan_sample/main.cpp
@@ -1717,7 +1717,7 @@ int main(int argc, const char** argv) {
     vkCmdEndRenderPass(render_command_buffers[frame_parity]);
 
     REQUIRE_SUCCESS(vkEndCommandBuffer(render_command_buffers[frame_parity]));
-    VkPipelineStageFlags flags = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+    VkPipelineStageFlags flags = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
 
     VkSubmitInfo submit{VK_STRUCTURE_TYPE_SUBMIT_INFO,
                         nullptr,


### PR DESCRIPTION
Previously the submission will wait inside BOTTOM_OF_PIPE for the
swapchain_image_ready_semaphores. This means that it will do all the rendering
and writing out to the image before the swapchain image is actually ready.
Instead we need to wait for the submission inside TOP_OF_PIPE so that the work
is blocked until the image is ready.

Bug: b/149113751