### PR TITLE
Force stop already running gapidapk before starting

### DIFF
--- a/gapidapk/deviceinfo.go
+++ b/gapidapk/deviceinfo.go
@@ -108,6 +108,9 @@ func fetchDeviceInfo(ctx context.Context, d adb.Device) error {
 		return nil
 	}
 
+	// Close any previous runs of the apk
+	apk.Stop(ctx)
+
 	driver, err := d.GraphicsDriver(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
The current instance of gapidapk is kept alive in the device and resumed
during the loadDevices phase. This causes a prolonged wait and eventual
failure to find the android device, if the driver is updated and gapid is
launched without restarting the device.

Bug: 149109076

Moved from gapid PR : https://github.com/google/gapid/pull/3777