### PR TITLE
Revert "Fix the reporting issue in MEC by setting cmdID to 0 for all the"

### DIFF
--- a/gapis/api/gles/replay.go
+++ b/gapis/api/gles/replay.go
@@ -293,7 +293,7 @@ func (a API) Replay(
 	if profile == nil {
 		cmds = []api.Cmd{} // DeadCommandRemoval generates commands.
 	}
-	return transforms.TransformAll(ctx, cmds, 0, out)
+	return transforms.Transform(ctx, cmds, out)
 }
 
 func (a API) QueryIssues(

--- a/gapis/api/sync/sync.go
+++ b/gapis/api/sync/sync.go
@@ -152,7 +152,7 @@ func MutationCmdsFor(ctx context.Context, c *path.Capture, data *Data, cmds []ap
 		return cmds[0 : id+1], nil
 	}
 	w := &writer{rc.NewState(ctx), nil}
-	if err := transforms.TransformAll(ctx, cmds, 0, w); err != nil {
+	if err := transforms.Transform(ctx, cmds, w); err != nil {
 		return nil, err
 	}
 

--- a/gapis/api/transform/transforms.go
+++ b/gapis/api/transform/transforms.go
@@ -24,9 +24,9 @@ import (
 // Transforms is a list of Transformer objects.
 type Transforms []Transformer
 
-// TransformAll sequentially transforms the commands by each of the transformers in
+// Transform sequentially transforms the commands by each of the transformers in
 // the list, before writing the final output to the output command Writer.
-func (l Transforms) TransformAll(ctx context.Context, cmds []api.Cmd, numberOfInitialCommands uint64, out Writer) error {
+func (l Transforms) Transform(ctx context.Context, cmds []api.Cmd, out Writer) error {
 	chain := out
 	for i := len(l) - 1; i >= 0; i-- {
 		s := chain.State()
@@ -43,12 +43,7 @@ func (l Transforms) TransformAll(ctx context.Context, cmds []api.Cmd, numberOfIn
 		chain = TransformWriter{s, l[i], chain}
 	}
 	err := api.ForeachCmd(ctx, cmds, true, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
-		captureCmdID := api.CmdNoID
-		if uint64(id) > numberOfInitialCommands {
-			captureCmdID = id - api.CmdID(numberOfInitialCommands)
-		}
-
-		return chain.MutateAndWrite(ctx, captureCmdID, cmd)
+		return chain.MutateAndWrite(ctx, id, cmd)
 	})
 	if err != nil {
 		return err

--- a/gapis/api/vulkan/find_issues.go
+++ b/gapis/api/vulkan/find_issues.go
@@ -63,6 +63,7 @@ func isValidationLayer(n string) bool {
 type findIssues struct {
 	replay.EndOfReplay
 	state           *api.GlobalState
+	numInitialCmds  int
 	issues          []replay.Issue
 	reportCallbacks map[VkInstance]VkDebugReportCallbackEXT
 }
@@ -70,6 +71,7 @@ type findIssues struct {
 func newFindIssues(ctx context.Context, c *capture.GraphicsCapture, numInitialCmds int) *findIssues {
 	t := &findIssues{
 		state:           c.NewState(ctx),
+		numInitialCmds:  numInitialCmds,
 		reportCallbacks: map[VkInstance]VkDebugReportCallbackEXT{},
 	}
 	t.state.OnError = func(err interface{}) {
@@ -284,21 +286,18 @@ func (t *findIssues) Flush(ctx context.Context, out transform.Writer) error {
 			var issue replay.Issue
 			msg := eMsg.GetMsg()
 			label := eMsg.GetLabel()
-			issue.Command = api.CmdID(label)
-			issue.Severity = service.Severity(uint32(eMsg.GetSeverity()))
-
-			if issue.Command == api.CmdNoID {
+			if int(label) < t.numInitialCmds {
 				// The debug report is issued for state rebuilding command
 				// TODO: Fix all the errors reported for initial commands.
-				// TODO: Provide a way for the UI to distinguish these issues
-				// from issues on command 0.
 				issue.Command = api.CmdID(0)
-				issue.Error = fmt.Errorf("[State rebuilding command : %s]	", msg)
-			} else {
-				// The debug report is issued for a trace command
-				issue.Error = fmt.Errorf("%s", msg)
+				issue.Error = fmt.Errorf("[State rebuilding command, linearized ID: %d]: %s", label, msg)
+				// For now hide such errors from the report view so users won't get confused.
+				return
 			}
-
+			// The debug report is issued for a trace command
+			issue.Command = api.CmdID(label - uint64(t.numInitialCmds))
+			issue.Error = fmt.Errorf("%s", msg)
+			issue.Severity = service.Severity(uint32(eMsg.GetSeverity()))
 			t.issues = append(t.issues, issue)
 		})
 	}))

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -845,7 +845,7 @@ func (a API) GetInitialPayload(ctx context.Context,
 	initialCmds, im, _ := initialcmds.InitialCommands(ctx, capture)
 	out.State().Allocator.ReserveRanges(im)
 
-	return transforms.TransformAll(ctx, initialCmds, uint64(len(initialCmds)), out)
+	return transforms.Transform(ctx, initialCmds, out)
 }
 
 func (a API) CleanupResources(ctx context.Context,
@@ -853,7 +853,7 @@ func (a API) CleanupResources(ctx context.Context,
 	out transform.Writer) error {
 	transforms := transform.Transforms{}
 	transforms.Add(&destroyResourcesAtEOS{})
-	return transforms.TransformAll(ctx, []api.Cmd{}, 0, out)
+	return transforms.Transform(ctx, []api.Cmd{}, out)
 }
 
 func (a API) Replay(
@@ -1090,7 +1090,7 @@ func (a API) Replay(
 		}
 	}
 
-	numberOfInitialCmds, err := expandCommands(optimize)
+	_, err = expandCommands(optimize)
 	if err != nil {
 		return err
 	}
@@ -1173,7 +1173,7 @@ func (a API) Replay(
 		transforms.Add(replay.NewMappingExporterWithPrint(ctx, "mappings.txt"))
 	}
 
-	return transforms.TransformAll(ctx, cmds, uint64(numberOfInitialCmds), out)
+	return transforms.Transform(ctx, cmds, out)
 }
 
 func (a API) QueryFramebufferAttachment(


### PR DESCRIPTION
Reverts google/agi#14

This change broke replay profiling.  We use `numInitialCommands` to set the wait fence in the correct place in the command stream.