### PR TITLE
Downgrade to gcc8 on Linux builds

### DIFF
--- a/kokoro/linux-test/test.sh
+++ b/kokoro/linux-test/test.sh
@@ -29,8 +29,8 @@ bash bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh --prefix=$PWD/bazel
 sudo rm /etc/apt/sources.list.d/cuda.list*
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get -q update
-sudo apt-get -qy install gcc-9 g++-9
-export CC=/usr/bin/gcc-9
+sudo apt-get -qy install gcc-8 g++-8
+export CC=/usr/bin/gcc-8
 
 cd $SRC
 BUILD_SHA=${KOKORO_GITHUB_COMMIT:-$KOKORO_GITHUB_PULL_REQUEST_COMMIT}

--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -25,12 +25,12 @@ curl -L -k -O -s https://github.com/bazelbuild/bazel/releases/download/${BAZEL_V
 mkdir bazel
 bash bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh --prefix=$PWD/bazel
 
-# Get GCC 9
+# Get GCC 8
 sudo rm /etc/apt/sources.list.d/cuda.list*
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get -q update
-sudo apt-get -qy install gcc-9 g++-9
-export CC=/usr/bin/gcc-9
+sudo apt-get -qy install gcc-8 g++-8
+export CC=/usr/bin/gcc-8
 
 # Get the Android NDK
 curl -L -k -O -s https://dl.google.com/android/repository/android-ndk-r20b-linux-x86_64.zip


### PR DESCRIPTION
Building with gcc9 creates a runtime dependency on GLIBCXX_3.4.26,
which is not yet widely available.

Bug: none