### PR TITLE
Add basic validation framework for Mali.

### DIFF
--- a/gapis/trace/android/BUILD.bazel
+++ b/gapis/trace/android/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//gapis/service:go_default_library",
         "//gapis/service/path:go_default_library",
         "//gapis/trace/android/adreno:go_default_library",
+        "//gapis/trace/android/mali:go_default_library",
         "//gapis/trace/android/validate:go_default_library",
         "//gapis/trace/tracer:go_default_library",
         "//tools/build/third_party/perfetto:config_go_proto",

--- a/gapis/trace/android/mali/BUILD.bazel
+++ b/gapis/trace/android/mali/BUILD.bazel
@@ -1,0 +1,26 @@
+# Copyright (C) 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["validate.go"],
+    importpath = "github.com/google/gapid/gapis/trace/android/mali",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//gapis/perfetto:go_default_library",
+        "//gapis/trace/android/validate:go_default_library",
+    ],
+)

--- a/gapis/trace/android/mali/validate.go
+++ b/gapis/trace/android/mali/validate.go
@@ -1,0 +1,48 @@
+// Copyright (C) 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mali
+
+import (
+	"context"
+
+	"github.com/google/gapid/gapis/perfetto"
+	"github.com/google/gapid/gapis/trace/android/validate"
+)
+
+var (
+	// All counters must be inside this array.
+	counters = []validate.GpuCounter{}
+)
+
+type MaliValidator struct {
+}
+
+func (v *MaliValidator) Validate(ctx context.Context, processor *perfetto.Processor) error {
+	if err := validate.ValidateGpuCounters(ctx, processor, v.GetCounters()); err != nil {
+		return err
+	}
+	if err := validate.ValidateGpuSlices(ctx, processor); err != nil {
+		return err
+	}
+	if err := validate.ValidateVulkanEvents(ctx, processor); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (v *MaliValidator) GetCounters() []validate.GpuCounter {
+	return counters
+}

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -50,6 +50,7 @@ import (
 	perfetto_android "github.com/google/gapid/gapis/perfetto/android"
 	"github.com/google/gapid/gapis/service"
 	"github.com/google/gapid/gapis/trace/android/adreno"
+	"github.com/google/gapid/gapis/trace/android/mali"
 	"github.com/google/gapid/gapis/trace/android/validate"
 	"github.com/google/gapid/gapis/trace/tracer"
 )
@@ -79,6 +80,8 @@ func newValidator(dev bind.Device) validate.Validator {
 	gpu := dev.Instance().GetConfiguration().GetHardware().GetGPU()
 	if strings.Contains(gpu.GetName(), "Adreno") {
 		return &adreno.AdrenoValidator{}
+	} else if strings.Contains(gpu.GetName(), "Mali") {
+		return &mali.MaliValidator{}
 	}
 	return nil
 }


### PR DESCRIPTION
This patch sets up the basic validation framework for Mali with empty GPU
counters list. Currently, Mali platform doesn't implement Vulkan Event and
attach proper submission id, hence this validation will fail for now.

Bug: b/149346641