### PR TITLE
Do the app cleanup for validation in the background context

### DIFF
--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -181,7 +181,7 @@ func (t *androidTracer) Validate(ctx context.Context) error {
 
 	// Force to stop the application, ignore any error that happens as it
 	// doesn't affect validation.
-	defer d.ForceStop(ctx, gapidPackage)
+	defer d.ForceStop(context.Background(), gapidPackage)
 
 	var buf bytes.Buffer
 	var written int64


### PR DESCRIPTION
Force stopping the app after validation is currently happening in the same context as the validation process. This is fine in the normal case, but if the validation is interrupted by switching to another device, the old context is cancelled, and while calling ForceStop(ctx, app), the cancelled context is used. The force stop hence, fails, and the app keeps running on the first device forever.
Doing the force stop on the background context, which never stops, seems to be one way to address this.

Bug: 149394413