### PR TITLE
Update DEVDOC with one extra instruction.

### DIFF
--- a/DEVDOC.md
+++ b/DEVDOC.md
@@ -18,6 +18,9 @@ mkdir <path-outside-agi-source>/agi-gofuse
 # Run gofuse with the previous directory as a target
 bazel run //cmd/gofuse -- -dir <path-to-agi-gofuse>
 
+# If you build with bazel build -c dbg pkg, the <path-to-bazelout> is `k8-dbg` on Linux.
+bazel run //cmd/gofuse -- -dir <path-to-agi-gofuse> -bazelout <path-to-bazelout>
+
 # Add agi-gofuse directory to your GOPATH environment variable.
 # On Linux, with a bash shell, you can add the following to your ~/.bashrc file:
 export GOPATH="${GOPATH:+${GOPATH}:}<path-to-agi-gofuse>"


### PR DESCRIPTION
It's often unclear that one should specify the bazel output directory if AGI is
built debuggable, update the DEVDOC with this instruction.

Bug: N/A