### PR TITLE
Use Android NDK r21 and VK_LAYER_KHRONOS_validation

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -59,7 +59,7 @@ cd <sdk-path>
 tools\bin\sdkmanager.bat "platforms;android-26" "build-tools;29.0.2" ndk-bundle
 ```
 
-Note: this will install the latest NDK in `<sdk-path>\ndk-bundle`. The minimum required version of the NDK is r16b.
+Note: this will install the latest NDK in `<sdk-path>\ndk-bundle`. The minimum required version of the NDK is **r21**.
 
 If you do not have adb installed you can do so with:
 ```

--- a/gapis/api/templates/vulkan_gfx_api_extras.tmpl
+++ b/gapis/api/templates/vulkan_gfx_api_extras.tmpl
@@ -73,7 +73,7 @@
     return std::any_of(std::begin(kValidationLayerNames),
                        std::end(kValidationLayerNames),
                        [layer](const char* val) -> bool {
-                         return strcmp(layer, val) == 0;
+                         return std::strcmp(layer, val) == 0;
                        });
   }
 ¶

--- a/gapis/api/templates/vulkan_gfx_api_extras.tmpl
+++ b/gapis/api/templates/vulkan_gfx_api_extras.tmpl
@@ -55,8 +55,11 @@
 ¶
   const char kVirtualSwapchainLayerName[] = "VirtualSwapchain";
   const char kGraphicsSpyLayerName[] = "GraphicsSpy";
-  const char kValidationMetaLayerName[] = "VK_LAYER_LUNARG_standard_validation";
   const char* kValidationLayerNames[] = {
+    // Meta layers
+    "VK_LAYER_KHRONOS_validation",
+    "VK_LAYER_LUNARG_standard_validation",
+    // Regular layers
     "VK_LAYER_GOOGLE_threading",
     "VK_LAYER_LUNARG_parameter_validation",
     "VK_LAYER_LUNARG_object_tracker",
@@ -65,6 +68,14 @@
   };
   const char kDebugReportExtensionName[] = "VK_EXT_debug_report";
 
+¶
+  bool isValidationLayerName(const char* layer) {
+    return std::any_of(std::begin(kValidationLayerNames),
+                       std::end(kValidationLayerNames),
+                       [layer](const char* val) -> bool {
+                         return strcmp(layer, val) == 0;
+                       });
+  }
 ¶
   std::vector<Vulkan::VkPhysicalDevice> getVkPhysicalDevices(§
       LazyResolved<Vulkan::PFNVKENUMERATEPHYSICALDEVICES> vkEnumeratePhysicalDevices, Vulkan::VkInstance instance) {
@@ -119,14 +130,7 @@ bool Vulkan::replayCreateVkInstanceImpl(Stack* stack,
               return true;
             }
             if (dropValidationLayersAndDebugReport) {
-              if (strcmp(kValidationMetaLayerName, layer) == 0) {
-                return true;
-              }
-              return std::any_of(std::begin(kValidationLayerNames),
-                                 std::end(kValidationLayerNames),
-                                 [layer](const char* val) -> bool {
-                                   return strcmp(layer, val) == 0;
-                                 });
+              return isValidationLayerName(layer);
             }
             return false;
           }),
@@ -179,14 +183,7 @@ bool Vulkan::replayCreateVkDeviceImpl(Stack* stack, size_val physicalDevice,
       std::remove_if(layers.begin(), layers.end(),
                      [dropValidationLayers](const char* layer) -> bool {
                        if (dropValidationLayers) {
-                         if (strcmp(kValidationMetaLayerName, layer) == 0) {
-                           return true;
-                         }
-                         return std::any_of(std::begin(kValidationLayerNames),
-                                            std::end(kValidationLayerNames),
-                                            [layer](const char* val) -> bool {
-                                              return strcmp(layer, val) == 0;
-                                            });
+                         return isValidationLayerName(layer);
                        }
                        return false;
                      }),
@@ -733,11 +730,7 @@ bool Vulkan::replayDebugReportCallback(uint32_t flags, uint32_t objectType,
 ¶
 bool Vulkan::hasValidationLayers(const char* const* layers, uint32_t count) {
   return std::any_of(layers, layers + count, [](const char* layer) -> bool {
-    return std::any_of(
-      std::begin(kValidationLayerNames), std::end(kValidationLayerNames),
-      [layer](const char* val) -> bool {
-        return strcmp(layer, val) == 0;
-      }) || strcmp(layer, kValidationMetaLayerName) == 0;
+    return isValidationLayerName(layer);
   });
 }
 ¶

--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -33,9 +33,9 @@ sudo apt-get -qy install gcc-8 g++-8
 export CC=/usr/bin/gcc-8
 
 # Get the Android NDK
-curl -L -k -O -s https://dl.google.com/android/repository/android-ndk-r20b-linux-x86_64.zip
-unzip -q android-ndk-r20b-linux-x86_64.zip
-export ANDROID_NDK_HOME=$PWD/android-ndk-r20b
+curl -L -k -O -s https://dl.google.com/android/repository/android-ndk-r21-linux-x86_64.zip
+unzip -q android-ndk-r21-linux-x86_64.zip
+export ANDROID_NDK_HOME=$PWD/android-ndk-r21
 
 # Get recent build tools
 echo y | $ANDROID_HOME/tools/bin/sdkmanager --install 'build-tools;29.0.2'

--- a/kokoro/macos/build.sh
+++ b/kokoro/macos/build.sh
@@ -24,10 +24,10 @@ curl -L -k -O -s https://dl.google.com/android/repository/tools_r25.2.3-macosx.z
 mkdir android
 unzip -q tools_r25.2.3-macosx.zip -d android
 echo y | ./android/tools/bin/sdkmanager build-tools\;29.0.2 platforms\;android-26
-curl -L -k -O -s https://dl.google.com/android/repository/android-ndk-r20b-darwin-x86_64.zip
-unzip -q android-ndk-r20b-darwin-x86_64.zip -d android
+curl -L -k -O -s https://dl.google.com/android/repository/android-ndk-r21-darwin-x86_64.zip
+unzip -q android-ndk-r21-darwin-x86_64.zip -d android
 export ANDROID_HOME=$PWD/android
-export ANDROID_NDK_HOME=$PWD/android/android-ndk-r20b
+export ANDROID_NDK_HOME=$PWD/android/android-ndk-r21
 
 # Get bazel.
 BAZEL_VERSION=2.0.0

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -31,9 +31,9 @@ copy /Y "%SRC%\kokoro\windows\android-sdk-license" "%ANDROID_HOME%\licenses\"
 
 REM Install Android SDK platform, build tools and NDK
 call %ANDROID_HOME%\tools\bin\sdkmanager.bat platforms;android-26 build-tools;29.0.2
-wget -q https://dl.google.com/android/repository/android-ndk-r20b-windows-x86_64.zip
-unzip -q android-ndk-r20b-windows-x86_64.zip
-set ANDROID_NDK_HOME=%CD%\android-ndk-r20b
+wget -q https://dl.google.com/android/repository/android-ndk-r21-windows-x86_64.zip
+unzip -q android-ndk-r21-windows-x86_64.zip
+set ANDROID_NDK_HOME=%CD%\android-ndk-r21
 
 REM Install WiX Toolset.
 wget -q https://github.com/wixtoolset/wix3/releases/download/wix311rtm/wix311-binaries.zip

--- a/tools/build/rules/android.bzl
+++ b/tools/build/rules/android.bzl
@@ -107,18 +107,16 @@ android_native_app_glue = repository_rule(
 )
 
 # Retrieve Vulkan validation layers from the Android NDK
-
+# Since NDK r21, use the single VK_LAYER_KHRONOS_validation
 def _ndk_vk_validation_layer(ctx):
     build = ""
     for abi in ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]:
-
-        for layer in ["core_validation", "object_tracker", "parameter_validation", "threading", "unique_objects"]:
-            layerpath = abi + "/libVkLayer_" + layer + ".so"
-            ctx.symlink(
-                ctx.path(ctx.os.environ["ANDROID_NDK_HOME"] +
-                         "/sources/third_party/vulkan/src/build-android/jniLibs/" + layerpath),
-                ctx.path(layerpath),
-            )
+        layerpath = abi + "/libVkLayer_khronos_validation.so"
+        ctx.symlink(
+            ctx.path(ctx.os.environ["ANDROID_NDK_HOME"] +
+                        "/sources/third_party/vulkan/src/build-android/jniLibs/" + layerpath),
+            ctx.path(layerpath),
+        )
 
         build += "\n".join([
             "cc_library(",


### PR DESCRIPTION
Upgrade the NDK to r21. This let us use the unified
VK_LAYER_KHRONOS_validation meta validation layer, which is available
on both Desktop and Android.

This change does a bit of refactoring of the code handling the
validation layers, to make use of the new unified one.

Bug: b/148519068