### PR TITLE
Revert "Name replay profiler 'Surface' slices according to their matc…

### DIFF
--- a/gapis/trace/android/adreno/profiling_data.go
+++ b/gapis/trace/android/adreno/profiling_data.go
@@ -196,10 +196,6 @@ func processGpuSlices(ctx context.Context, processor *perfetto.Processor, captur
 			Value: &service.ProfilingData_GpuSlices_Slice_Extra_IntValue{IntValue: uint64(hwQueueIds[i])},
 		})
 
-		if names[i] == "Surface" {
-			names[i] = fmt.Sprintf("%v", groups[groupIds[i]].Link.Indices)
-		}
-
 		slices[i] = &service.ProfilingData_GpuSlices_Slice{
 			Ts:      uint64(timestamps[i]),
 			Dur:     uint64(durations[i]),


### PR DESCRIPTION
…hed command id"

This reverts commit 7ee4b228b7cf52f57c1a367bc41f0fe051ef74e9.

This commit leads to crashes:
panic: runtime error: index out of range
  gapis/trace/android/adreno/profiling_data.go:200

Bug: b/149693499