### PR TITLE
Fix GPU counter's config update issue.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
@@ -488,8 +488,8 @@ public class TraceConfigDialog extends DialogBase {
 
           gpuCountersLabels[0] = createLabel(counterGroup, sGpu.getCounterIdsCount() + " selected");
           gpuCountersSelect = Widgets.createButton(counterGroup, "Select", e -> {
-            GpuCountersDialog dialog =
-                new GpuCountersDialog(getShell(), theme, caps, sGpu.getCounterIdsList());
+            List<Integer> currentIds = settings.perfetto().getGpuOrBuilder().getCounterIdsList();
+            GpuCountersDialog dialog = new GpuCountersDialog(getShell(), theme, caps, currentIds);
             if (dialog.open() == Window.OK) {
               List<Integer> newIds = dialog.getSelectedIds();
               settings.writePerfetto().getGpuBuilder()


### PR DESCRIPTION
 - Populate the remembered counter selection from the most updated
 perfetto settings, rather than from a possibly outdated copy.
 - Bug: http://b/149737345.