### PR TITLE
Hide the validation related components when no device is selected

### DIFF
--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -612,8 +612,12 @@ public class TracerDialog {
 
       private void runValidationCheck(DeviceCaptureInfo dev) {
         if (dev == null) {
+          validationStatusLoader.setVisible(false);
+          validationStatusText.setVisible(false);
           return;
         }
+        validationStatusLoader.setVisible(true);
+        validationStatusText.setVisible(true);
         setValidationStatus(models.devices.getValidationStatus(dev));
         if (!models.devices.getValidationStatus(dev).passed) {
           validationStatusLoader.startLoading();


### PR DESCRIPTION
When there are more than one android device connected, AGI resets the device to be null. When this happens, it is ideal to not show any validation related details on the screen.

Currently, the previous validation data is shown or on startup, failed message is shown.

Bug: 141712515