### PR TITLE
Remove internet permission of the apk.

### DIFF
--- a/gapidapk/android/apk/AndroidManifest.xml.in
+++ b/gapidapk/android/apk/AndroidManifest.xml.in
@@ -23,7 +23,6 @@
     <uses-sdk
         android:minSdkVersion="21"
         android:targetSdkVersion="26" />
-    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:allowBackup="true"
         android:icon="@drawable/logo"


### PR DESCRIPTION
Previously gathering gpu slices require internet permission because the data
producer created TCP/IP socket to communicate with the driver. Now that the
architecture has changed, the data producer no longer needs to create it and
hence we can remove internet permission.

Bug: b/144872032
Test: bazel run gapit -- validate_gpu_profiling --os android