### PR TITLE
Use Perfetto Client API in tracing.

### DIFF
--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -1123,6 +1123,13 @@ public class TracerDialog {
           ErrorDialog.showErrorDialog(getShell(), analytics, getErrorMessage(), error));
       errorButton.setVisible(false);
 
+      // Make sure the stop signal is issued when the dialog is closed.
+      getShell().addListener(SWT.Close, e -> {
+          if (!successful()) {
+              trace.stop();
+          }
+      });
+
       update();
 
       Widgets.scheduleUntilDisposed(getShell(), STATUS_INTERVAL_MS, trace::getStatus);

--- a/gapis/perfetto/android/BUILD.bazel
+++ b/gapis/perfetto/android/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//core/app:go_default_library",
+        "//core/app/crash:go_default_library",
         "//core/event/task:go_default_library",
         "//core/log:go_default_library",
         "//core/os/android:go_default_library",
@@ -32,7 +33,9 @@ go_library(
         "//core/os/file:go_default_library",
         "//core/text:go_default_library",
         "//gapidapk:go_default_library",
+        "//gapis/perfetto:go_default_library",
         "//gapis/service:go_default_library",
         "//tools/build/third_party/perfetto:config_go_proto",
+        "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )


### PR DESCRIPTION
Previously we used Perfetto CLI to trace, however, when tracing is started,
some ftrace are not set up yet, which results in a gap of empty data at the
beginning of the trace. With Perfetto Client API, we now can do deferred start
by setting deferred_start field to true, and always make sure we only start the
tracing session when things are ready.

Bug: b/147490759