### PR TITLE
Fix ordering of reported issues

### DIFF
--- a/gapis/service/report.go
+++ b/gapis/service/report.go
@@ -156,6 +156,8 @@ func (b *ReportBuilder) processMessage(msg *stringtable.Msg) (*MsgRef, error) {
 func (b *ReportBuilder) processGroups() error {
 	groupItems := map[string][]uint32{}
 	groups := map[string]*MsgRef{}
+	emitted := map[string]bool{}
+
 	for i, item := range b.report.Items {
 		ref := item.Message
 		key := ref.key()
@@ -166,11 +168,17 @@ func (b *ReportBuilder) processGroups() error {
 			groups[key] = ref
 		}
 	}
-	for key, items := range groupItems {
-		b.report.Groups = append(b.report.Groups, &ReportGroup{
-			Name:  groups[key],
-			Items: items,
-		})
+
+	for _, item := range b.report.Items {
+		key := item.Message.key()
+		if _, ok := emitted[key]; !ok {
+			emitted[key] = true
+			b.report.Groups = append(b.report.Groups, &ReportGroup{
+				Name:  groups[key],
+				Items: groupItems[key],
+			})
+		}
 	}
+
 	return nil
 }


### PR DESCRIPTION
Previously we were passing all the issues through a map and so losing
the order in which they were generated. This change still keeps the
grouping behavior, but emits the messages in the order of their first
occurrence.

Bug: b/150221484