### PR TITLE
DO NOT MERGE Generate links to renderpasses from gpu slices

### DIFF
--- a/gapis/api/cmd_id.go
+++ b/gapis/api/cmd_id.go
@@ -53,5 +53,7 @@ func (id CmdID) String() string {
 // TODO(apbodnar) find a more appropriate place for this
 type CommandSubmissionKey struct {
 	SubmissionOrder uint64
-	CommandBuffer   int64
+	CommandBuffer   uint64
+	RenderPass      uint64
+	Framebuffer     uint64
 }

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -832,7 +832,7 @@ type profileRequest struct {
 	handler        *replay.SignalHandler
 	buffer         *bytes.Buffer
 	handleMappings *map[uint64][]service.VulkanHandleMappingItem
-	submissionIds  *map[api.CommandSubmissionKey][]uint64
+	submissionIds  *map[api.CommandSubmissionKey][][]uint64
 }
 
 func (a API) GetInitialPayload(ctx context.Context,
@@ -1237,7 +1237,7 @@ func (a API) Profile(
 	handler := replay.NewSignalHandler()
 	var buffer bytes.Buffer
 	handleMappings := make(map[uint64][]service.VulkanHandleMappingItem)
-	submissionIds := make(map[api.CommandSubmissionKey][]uint64)
+	submissionIds := make(map[api.CommandSubmissionKey][][]uint64)
 	r := profileRequest{traceOptions, handler, &buffer, &handleMappings, &submissionIds}
 	_, err := mgr.Replay(ctx, intent, c, r, a, hints, true)
 	handler.DoneSignal.Wait(ctx)

--- a/gapis/trace/android/adreno/profiling_data.go
+++ b/gapis/trace/android/adreno/profiling_data.go
@@ -29,9 +29,9 @@ import (
 
 var (
 	slicesQuery = "" +
-		"SELECT s.context_id, s.render_target, s.frame_id, s.submission_id, s.hw_queue_id, s.command_buffer, s.ts, s.dur, s.name, depth, arg_set_id, track_id, t.name " +
+		"SELECT s.context_id, s.render_target, s.frame_id, s.submission_id, s.hw_queue_id, s.command_buffer, s.render_pass, s.ts, s.dur, s.name, depth, arg_set_id, track_id, t.name " +
 		"FROM gpu_track t LEFT JOIN gpu_slice s " +
-		"ON s.track_id = t.id WHERE t.scope = 'gpu_render_stage'"
+		"ON s.track_id = t.id WHERE t.scope = 'gpu_render_stage' ORDER BY s.ts"
 	argsQueryFmt = "" +
 		"SELECT key, string_value FROM args WHERE args.arg_set_id = %d"
 	queueSubmitQuery = "" +
@@ -40,9 +40,10 @@ var (
 		"SELECT id, name, unit, description FROM gpu_counter_track ORDER BY id"
 	countersQueryFmt = "" +
 		"SELECT ts, value FROM counter c WHERE c.track_id = %d ORDER BY ts"
+	renderPassSliceName = "Surface"
 )
 
-func ProcessProfilingData(ctx context.Context, processor *perfetto.Processor, capture *path.Capture, desc *device.GpuCounterDescriptor, handleMapping *map[uint64][]service.VulkanHandleMappingItem, submissionIds *map[api.CommandSubmissionKey][]uint64) (*service.ProfilingData, error) {
+func ProcessProfilingData(ctx context.Context, processor *perfetto.Processor, capture *path.Capture, desc *device.GpuCounterDescriptor, handleMapping *map[uint64][]service.VulkanHandleMappingItem, submissionIds *map[api.CommandSubmissionKey][][]uint64) (*service.ProfilingData, error) {
 	slices, err := processGpuSlices(ctx, processor, capture, handleMapping, submissionIds)
 	if err != nil {
 		log.Err(ctx, err, "Failed to get GPU slices")
@@ -77,7 +78,7 @@ func extractTraceHandles(ctx context.Context, replayHandles *[]int64, replayHand
 	}
 }
 
-func processGpuSlices(ctx context.Context, processor *perfetto.Processor, capture *path.Capture, handleMapping *map[uint64][]service.VulkanHandleMappingItem, subCommandIndicesMap *map[api.CommandSubmissionKey][]uint64) (*service.ProfilingData_GpuSlices, error) {
+func processGpuSlices(ctx context.Context, processor *perfetto.Processor, capture *path.Capture, handleMapping *map[uint64][]service.VulkanHandleMappingItem, subCommandIndicesMap *map[api.CommandSubmissionKey][][]uint64) (*service.ProfilingData_GpuSlices, error) {
 	slicesQueryResult, err := processor.Query(slicesQuery)
 	if err != nil {
 		return nil, log.Errf(ctx, err, "SQL query failed: %v", slicesQuery)
@@ -114,27 +115,45 @@ func processGpuSlices(ctx context.Context, processor *perfetto.Processor, captur
 	commandBuffers := slicesColumns[5].GetLongValues()
 	extractTraceHandles(ctx, &commandBuffers, "VkCommandBuffer", handleMapping)
 
+	renderPasses := slicesColumns[6].GetLongValues()
+	extractTraceHandles(ctx, &renderPasses, "VkRenderPass", handleMapping)
+
+	frameIds := slicesColumns[2].GetLongValues()
 	submissionIds := slicesColumns[3].GetLongValues()
-	currentSubId := int64(-1)
-	subCommandGroupMap := make(map[api.CommandSubmissionKey]bool)
+	hwQueueIds := slicesColumns[4].GetLongValues()
+	timestamps := slicesColumns[7].GetLongValues()
+	durations := slicesColumns[8].GetLongValues()
+	names := slicesColumns[9].GetStringValues()
+	depths := slicesColumns[10].GetLongValues()
+	argSetIds := slicesColumns[11].GetLongValues()
+	trackIds := slicesColumns[12].GetLongValues()
+	trackNames := slicesColumns[13].GetStringValues()
+
+	subCommandGroupMap := make(map[api.CommandSubmissionKey]int)
 	for i, v := range submissionIds {
-		if v != currentSubId {
-			currentSubId = v
-			// We'll never need the previous keys again
-			subCommandGroupMap = make(map[api.CommandSubmissionKey]bool)
-		}
 		subOrder, ok := submissionOrdering[v]
 		if ok {
-			cb := commandBuffers[i]
-			key := api.CommandSubmissionKey{SubmissionOrder: subOrder, CommandBuffer: cb}
-			if _, ok := subCommandGroupMap[key]; !ok {
-				if indices, ok := (*subCommandIndicesMap)[key]; ok {
+			cb := uint64(commandBuffers[i])
+			key := api.CommandSubmissionKey{SubmissionOrder: subOrder,
+				CommandBuffer: cb,
+				RenderPass:    uint64(renderPasses[i]),
+				Framebuffer:   uint64(renderTargets[i])}
+			if indices, ok := (*subCommandIndicesMap)[key]; ok {
+				if names[i] == renderPassSliceName {
+					var idx []uint64
+					if c, ok := subCommandGroupMap[key]; ok {
+						idx = indices[c]
+					} else {
+						idx = indices[0]
+						subCommandGroupMap[key] = 0
+					}
+
 					group := &service.ProfilingData_GpuSlices_Group{
 						Id:   int32(len(groups)),
-						Link: &path.Command{Capture: capture, Indices: indices},
+						Link: &path.Command{Capture: capture, Indices: idx},
 					}
 					groups = append(groups, group)
-					subCommandGroupMap[key] = true
+					subCommandGroupMap[key]++
 				}
 			}
 		} else {
@@ -143,16 +162,6 @@ func processGpuSlices(ctx context.Context, processor *perfetto.Processor, captur
 
 		groupIds[i] = int32(len(groups)) - 1
 	}
-
-	frameIds := slicesColumns[2].GetLongValues()
-	hwQueueIds := slicesColumns[4].GetLongValues()
-	timestamps := slicesColumns[6].GetLongValues()
-	durations := slicesColumns[7].GetLongValues()
-	names := slicesColumns[8].GetStringValues()
-	depths := slicesColumns[9].GetLongValues()
-	argSetIds := slicesColumns[10].GetLongValues()
-	trackIds := slicesColumns[11].GetLongValues()
-	trackNames := slicesColumns[12].GetStringValues()
 
 	for i := uint64(0); i < numSliceRows; i++ {
 		var argsQueryResult *perfetto_service.QueryResult
@@ -189,6 +198,10 @@ func processGpuSlices(ctx context.Context, processor *perfetto.Processor, captur
 			Value: &service.ProfilingData_GpuSlices_Slice_Extra_IntValue{IntValue: uint64(commandBuffers[i])},
 		})
 		extras = append(extras, &service.ProfilingData_GpuSlices_Slice_Extra{
+			Name:  "renderPass",
+			Value: &service.ProfilingData_GpuSlices_Slice_Extra_IntValue{IntValue: uint64(renderPasses[i])},
+		})
+		extras = append(extras, &service.ProfilingData_GpuSlices_Slice_Extra{
 			Name:  "frameId",
 			Value: &service.ProfilingData_GpuSlices_Slice_Extra_IntValue{IntValue: uint64(frameIds[i])},
 		})
@@ -201,7 +214,7 @@ func processGpuSlices(ctx context.Context, processor *perfetto.Processor, captur
 			Value: &service.ProfilingData_GpuSlices_Slice_Extra_IntValue{IntValue: uint64(hwQueueIds[i])},
 		})
 
-		if names[i] == "Surface" && groupIds[i] != -1 {
+		if names[i] == renderPassSliceName && groupIds[i] != -1 {
 			names[i] = fmt.Sprintf("%v", groups[groupIds[i]].Link.Indices)
 		}
 

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -123,7 +123,7 @@ func (t *androidTracer) GetDevice() bind.Device {
 	return t.b
 }
 
-func (t *androidTracer) ProcessProfilingData(ctx context.Context, buffer *bytes.Buffer, capture *path.Capture, handleMappings *map[uint64][]service.VulkanHandleMappingItem, submissionIds *map[api.CommandSubmissionKey][]uint64) (*service.ProfilingData, error) {
+func (t *androidTracer) ProcessProfilingData(ctx context.Context, buffer *bytes.Buffer, capture *path.Capture, handleMappings *map[uint64][]service.VulkanHandleMappingItem, submissionIds *map[api.CommandSubmissionKey][][]uint64) (*service.ProfilingData, error) {
 	// Load Perfetto trace and create trace processor.
 	rawData := make([]byte, buffer.Len())
 	_, err := buffer.Read(rawData)

--- a/gapis/trace/desktop/trace.go
+++ b/gapis/trace/desktop/trace.go
@@ -50,7 +50,7 @@ func (t *DesktopTracer) GetDevice() bind.Device {
 	return t.b
 }
 
-func (t *DesktopTracer) ProcessProfilingData(ctx context.Context, buffer *bytes.Buffer, capture *gapis_path.Capture, handleMapping *map[uint64][]service.VulkanHandleMappingItem, submissionIds *map[api.CommandSubmissionKey][]uint64) (*service.ProfilingData, error) {
+func (t *DesktopTracer) ProcessProfilingData(ctx context.Context, buffer *bytes.Buffer, capture *gapis_path.Capture, handleMapping *map[uint64][]service.VulkanHandleMappingItem, submissionIds *map[api.CommandSubmissionKey][][]uint64) (*service.ProfilingData, error) {
 	return nil, log.Err(ctx, nil, "Desktop replay profiling is unsupported.")
 }
 

--- a/gapis/trace/trace.go
+++ b/gapis/trace/trace.go
@@ -107,7 +107,7 @@ func TraceConfiguration(ctx context.Context, device *path.Device) (*service.Devi
 	return t.TraceConfiguration(ctx)
 }
 
-func ProcessProfilingData(ctx context.Context, device *path.Device, capture *path.Capture, buffer *bytes.Buffer, handleMapping *map[uint64][]service.VulkanHandleMappingItem, submissionIds *map[api.CommandSubmissionKey][]uint64) (*service.ProfilingData, error) {
+func ProcessProfilingData(ctx context.Context, device *path.Device, capture *path.Capture, buffer *bytes.Buffer, handleMapping *map[uint64][]service.VulkanHandleMappingItem, submissionIds *map[api.CommandSubmissionKey][][]uint64) (*service.ProfilingData, error) {
 	t, err := GetTracer(ctx, device)
 	if err != nil {
 		return nil, err

--- a/gapis/trace/tracer/tracer.go
+++ b/gapis/trace/tracer/tracer.go
@@ -74,7 +74,7 @@ type Tracer interface {
 	GetDevice() bind.Device
 	// ProcessProfilingData takes a buffer for a Perfetto trace and translates it into
 	// a ProfilingData
-	ProcessProfilingData(ctx context.Context, buffer *bytes.Buffer, capture *path.Capture, handleMapping *map[uint64][]service.VulkanHandleMappingItem, submissionIds *map[api.CommandSubmissionKey][]uint64) (*service.ProfilingData, error)
+	ProcessProfilingData(ctx context.Context, buffer *bytes.Buffer, capture *path.Capture, handleMapping *map[uint64][]service.VulkanHandleMappingItem, submissionIds *map[api.CommandSubmissionKey][][]uint64) (*service.ProfilingData, error)
 	// Validate validates the GPU profiling capabilities of the given device and returns
 	// an error if validation failed or the GPU profiling data is invalid.
 	Validate(ctx context.Context) error


### PR DESCRIPTION
@AWoloszyn Opening as a PR to solicit discussion.  This does what is probably an unnecessary amount of state tracking inside of a transform.  Since we're already generating links to the command buffers in a queue submit, i'm hoping it might be possible to walk the nodes in the existing command tree to find the render passes rather than what's happening here.