### PR TITLE
Change API function tables from maps to flat arrays

### DIFF
--- a/gapir/cc/interpreter.cpp
+++ b/gapir/cc/interpreter.cpp
@@ -94,11 +94,7 @@ void Interpreter::registerBuiltin(uint8_t api, FunctionTable::Id id,
 
 void Interpreter::setRendererFunctions(uint8_t api,
                                        FunctionTable* functionTable) {
-  if (functionTable != nullptr) {
-    mRendererFunctions[api] = functionTable;
-  } else {
-    mRendererFunctions.erase(api);
-  }
+  mRendererFunctions[api] = functionTable;
 }
 
 void Interpreter::resetInstructions() {
@@ -207,7 +203,7 @@ Interpreter::Result Interpreter::call(uint32_t opcode) {
     checkReplayStatusCallback(label, mInstructionCount, mCurrentInstruction);
   }
   if (func == nullptr) {
-    if (mRendererFunctions.count(api) > 0) {
+    if (mRendererFunctions[api] != nullptr) {
       func = mRendererFunctions[api]->lookup(id);
     } else {
       if (apiRequestCallback && apiRequestCallback(this, api)) {

--- a/gapir/cc/interpreter.h
+++ b/gapir/cc/interpreter.h
@@ -180,11 +180,15 @@ class Interpreter {
   // Memory manager which managing the memory used during the interpretation
   const MemoryManager* mMemoryManager;
 
-  // The builtin functions.
-  std::unordered_map<uint8_t, FunctionTable> mBuiltins;
+  // The builtin functions. The size of this array is specified by the number of
+  // supported APIs which in-turn is defined by the packing of the vm bytecode
+  // (4 bits = 16 values)
+  FunctionTable mBuiltins[16];
 
-  // The current renderer functions.
-  std::unordered_map<uint8_t, FunctionTable*> mRendererFunctions;
+  // The current renderer functions. The size of this array is specified by the
+  // number of supported APIs which in-turn is defined by the packing of the vm
+  // bytecode (4 bits = 16 values)
+  FunctionTable* mRendererFunctions[16] = {};
 
   // Callback function for requesting renderer functions for an unknown api.
   ApiRequestCallback apiRequestCallback;


### PR DESCRIPTION
Many look-ups are performed on these tables and they are only 64k of void* entries max.

