### PR TITLE
Temporarily disable vulkan memory layer for android

### DIFF
--- a/core/os/device/deviceinfo/cc/android/query.cpp
+++ b/core/os/device/deviceinfo/cc/android/query.cpp
@@ -519,7 +519,7 @@ void glDriverPlatform(device::OpenGLDriver* driver) {
 device::VulkanProfilingLayers* get_vulkan_profiling_layers() {
   auto layers = new device::VulkanProfilingLayers();
   layers->set_cpu_timing(true);
-  layers->set_memory_tracker(true);
+  layers->set_memory_tracker(false);
   return layers;
 }
 


### PR DESCRIPTION
The layer is causing issues and not well tested.
Temporily disabling it until the issues are resolved.

Bug: 150371900