### PR TITLE
Disable Frame lifecycle by default

### DIFF
--- a/gapic/src/main/com/google/gapid/models/Settings.java
+++ b/gapic/src/main/com/google/gapid/models/Settings.java
@@ -96,7 +96,7 @@ public class Settings {
               .setSlices(true)
               .setCounters(true)
               .setCounterRate(1)
-              .setSurfaceFlinger(true))
+              .setSurfaceFlinger(false))
           .setMemory(SettingsProto.Perfetto.Memory.newBuilder()
               .setEnabled(true)
               .setRate(10))

--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
@@ -512,7 +512,7 @@ public class TraceConfigDialog extends DialogBase {
 
         if (gpuCaps.getHasFrameLifecycle()) {
           gpuFrame = createCheckbox(
-              gpuGroup, "Frame Lifecycle", sGpu.getSurfaceFlinger(), e -> updateGpu());
+              gpuGroup, "Frame Lifecycle", false, e -> updateGpu());
         } else {
           gpuFrame = null;
         }

--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
@@ -512,7 +512,7 @@ public class TraceConfigDialog extends DialogBase {
 
         if (gpuCaps.getHasFrameLifecycle()) {
           gpuFrame = createCheckbox(
-              gpuGroup, "Frame Lifecycle", false, e -> updateGpu());
+              gpuGroup, "Frame Lifecycle", sGpu.getSurfaceFlinger(), e -> updateGpu());
         } else {
           gpuFrame = null;
         }


### PR DESCRIPTION
During the feedback from Blizzard, they were using android R and were confused due to the amount of tracks with Frame Lifecycle. Disabling it by default would be a better solution in the current state of frame lifecycle.
We can enable it if we want, to test it here.

Bug : 150403599