### PR TITLE
Add selection behavior for CPU Panel under time quantization.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/models/CpuTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/CpuTrack.java
@@ -36,6 +36,7 @@ import com.google.gapid.perfetto.views.CpuSliceSelectionView;
 import com.google.gapid.perfetto.views.CpuSlicesSelectionView;
 import com.google.gapid.perfetto.views.State;
 
+import java.util.Arrays;
 import org.eclipse.swt.widgets.Composite;
 
 import java.util.Collections;
@@ -99,7 +100,10 @@ public class CpuTrack extends Track.WithQueryEngine<CpuTrack.Data> {
   private ListenableFuture<Data> computeSummary(DataRequest req, Window w) {
     return transform(qe.query(summarySql(w.bucketSize)), result -> {
       int len = w.getNumberOfBuckets();
-      Data data = new Data(req, w.bucketSize, new long[len], new long[len], new double[len]);
+      long[] ids = new long[len], utids = new long[len];
+      Arrays.fill(ids, -1);
+      Arrays.fill(utids, -1);
+      Data data = new Data(req, w.bucketSize, ids, utids, new double[len]);
       result.forEachRow(($, r) -> {
         data.ids[r.getInt(0)] = r.getLong(1);
         data.utids[r.getInt(0)] = r.getLong(2);

--- a/gapic/src/main/com/google/gapid/perfetto/models/ProcessSummaryTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/ProcessSummaryTrack.java
@@ -35,8 +35,11 @@ public class ProcessSummaryTrack extends Track.WithQueryEngine<ProcessSummaryTra
   // "where cpu < %numCpus%" is for performance reasons of the window table.
   private static final String PROCESS_VIEW_SQL = "select * from sched where utid in (%s)";
   private static final String SUMMARY_SQL =
-      "select quantum_ts, sum(dur)/cast(%d * %d as float) " +
-      "from %s group by quantum_ts";
+      "select quantum_ts, id, utid, sum(dur)/cast(%d * %d as float) util from(" +
+          "select *, first_value(row_id) over win id, first_value(utid) over win utid " +
+          "from %s " +
+          "window win as (partition by quantum_ts order by dur desc)) " +
+      "group by quantum_ts";
   private static final String SLICES_SQL = "select ts, dur, cpu, utid, row_id from %s";
 
   private final int numCpus;
@@ -76,8 +79,13 @@ public class ProcessSummaryTrack extends Track.WithQueryEngine<ProcessSummaryTra
 
   private ListenableFuture<Data> computeSummary(DataRequest req, Window w) {
     return transform(qe.query(summarySql(w.bucketSize)), result -> {
-      Data data = new Data(req, w.bucketSize, new double[w.getNumberOfBuckets()]);
-      result.forEachRow(($, r) -> data.utilizations[r.getInt(0)] = r.getDouble(1));
+      int len = w.getNumberOfBuckets();
+      Data data = new Data(req, w.bucketSize, new long[len], new long[len], new double[len]);
+      result.forEachRow(($, r) -> {
+        data.ids[r.getInt(0)] = r.getLong(1);
+        data.utids[r.getInt(0)] = r.getLong(2);
+        data.utilizations[r.getInt(0)] = r.getDouble(3);
+      });
       return data;
     });
   }
@@ -113,26 +121,26 @@ public class ProcessSummaryTrack extends Track.WithQueryEngine<ProcessSummaryTra
 
   public static class Data extends Track.Data {
     public final Kind kind;
+    public final long[] ids;
+    public final long[] utids;
     // Summary.
     public final long bucketSize;
     public final double[] utilizations;
     // Slice.
-    public final long[] ids;
     public final long[] starts;
     public final long[] ends;
     public final int[] cpus;
-    public final long[] utids;
 
-    public Data(DataRequest request, long bucketSize, double[] utilizations) {
+    public Data(DataRequest request, long bucketSize, long[] ids, long[] utids, double[] utilizations) {
       super(request);
       this.kind = Kind.summary;
+      this.ids = ids;
+      this.utids = utids;
       this.bucketSize = bucketSize;
       this.utilizations = utilizations;
-      this.ids = null;
       this.starts = null;
       this.ends = null;
       this.cpus = null;
-      this.utids = null;
     }
 
     public Data(
@@ -140,10 +148,10 @@ public class ProcessSummaryTrack extends Track.WithQueryEngine<ProcessSummaryTra
       super(request);
       this.kind = Kind.slice;
       this.ids = ids;
+      this.utids = utids;
       this.starts = starts;
       this.ends = ends;
       this.cpus = cpus;
-      this.utids = utids;
       this.bucketSize = 0;
       this.utilizations = null;
     }

--- a/gapic/src/main/com/google/gapid/perfetto/models/ProcessSummaryTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/ProcessSummaryTrack.java
@@ -27,6 +27,7 @@ import static java.util.stream.Collectors.joining;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gapid.perfetto.models.CpuTrack.Slice;
+import java.util.Arrays;
 
 /**
  * {@link Track} containing CPU usage data of all threads in a process.
@@ -80,7 +81,10 @@ public class ProcessSummaryTrack extends Track.WithQueryEngine<ProcessSummaryTra
   private ListenableFuture<Data> computeSummary(DataRequest req, Window w) {
     return transform(qe.query(summarySql(w.bucketSize)), result -> {
       int len = w.getNumberOfBuckets();
-      Data data = new Data(req, w.bucketSize, new long[len], new long[len], new double[len]);
+      long[] ids = new long[len], utids = new long[len];
+      Arrays.fill(ids, -1);
+      Arrays.fill(utids, -1);
+      Data data = new Data(req, w.bucketSize, ids, utids, new double[len]);
       result.forEachRow(($, r) -> {
         data.ids[r.getInt(0)] = r.getLong(1);
         data.utids[r.getInt(0)] = r.getLong(2);

--- a/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
@@ -297,6 +297,9 @@ public class CpuPanel extends TrackPanel<CpuPanel> implements Selectable {
 
       @Override
       public boolean click() {
+        if (utid < 0) {
+          return false;
+        }
         if ((mods & SWT.MOD1) == SWT.MOD1) {
           state.addSelection(Selection.Kind.Cpu, track.getSlice(id));
           state.addSelectedThread(state.getThreadInfo(utid));

--- a/gapic/src/main/com/google/gapid/perfetto/views/ProcessSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/ProcessSummaryPanel.java
@@ -308,6 +308,9 @@ public class ProcessSummaryPanel extends TrackPanel<ProcessSummaryPanel> {
 
       @Override
       public boolean click() {
+        if (utid < 0) {
+          return false;
+        }
         if ((mods & SWT.MOD1) == SWT.MOD1) {
           state.addSelection(Selection.Kind.Cpu, track.getSlice(id));
           state.addSelectedThread(state.getThreadInfo(utid));


### PR DESCRIPTION
 - In CPU Panel, when zoom in, the selection behavior for "CPU slices"
 already exists; but when zoom out, selection behavior for "CPU graph" is
 missing, this PR address this issue.
 - A very useful use case enabled by this PR would be 1.zooming out and
 have an overview, 2.select a peak point denoting high CPU utilization
 in graph, 3.click 'f'or 'm' to quickly zoom/mark.
 - Bug: http://b/147922469. #1.