### PR TITLE
Disable alpha channel by default in ImagePanel

### DIFF
--- a/gapic/src/main/com/google/gapid/widgets/ImagePanel.java
+++ b/gapic/src/main/com/google/gapid/widgets/ImagePanel.java
@@ -597,7 +597,7 @@ public class ImagePanel extends Composite implements Loadable {
   private static final class SceneData {
     public Image[] images = {};
     public MatD[] transforms = {};
-    public final boolean channels[] = { true, true, true, true };
+    public final boolean channels[] = { true, true, true, false };
     public Histogram histogram;
     public Range displayRange = Range.IDENTITY;
     public boolean histogramVisible;


### PR DESCRIPTION
In real Vulkan workloads, particularly with swapchain images, there is
often an alpha channel present but ignored, and the app is not careful
about what it writes into the alpha channel as a result. AGI already had
some logic to try and detect when the alpha channel was "unused" based
on contents, but junk rendered into it defeats that heuristic.

Disabling the alpha is a better default.

Bug: b/150420088