### PR TITLE
Stop overriding GPU queue track names

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/models/GpuInfo.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/GpuInfo.java
@@ -88,7 +88,7 @@ public class GpuInfo {
       res.forEachRow(($, r) -> {
         switch (r.getString(2)) {
           case "gpu_render_stage":
-            queues.add(new Queue(queues.size(), r));
+            queues.add(new Queue(r));
             break;
           case "vulkan_events":
             vkApiEvents.add(new VkApiEvent(r));
@@ -106,22 +106,22 @@ public class GpuInfo {
   }
 
   public static class Queue {
-    public final int id;
+    public final String name;
     public final long trackId;
     public final int maxDepth;
 
-    public Queue(int id, long trackId, int maxDepth) {
-      this.id = id;
+    public Queue(long trackId, String name, int maxDepth) {
       this.trackId = trackId;
+      this.name = name;
       this.maxDepth = maxDepth;
     }
 
-    public Queue(int id, QueryEngine.Row row) {
-      this(id, row.getLong(0), row.getInt(3));
+    public Queue(QueryEngine.Row row) {
+      this(row.getLong(0), row.getString(1), row.getInt(3));
     }
 
     public String getDisplay() {
-      return "GPU Queue " + id;
+      return name;
     }
   }
 

--- a/gapic/src/main/com/google/gapid/views/ProfileView.java
+++ b/gapic/src/main/com/google/gapid/views/ProfileView.java
@@ -162,7 +162,7 @@ public class ProfileView extends Composite implements Tab, Capture.Listener, Pro
           }
         }
         panels.add(new Container(new GpuQueuePanel(state,
-            new GpuInfo.Queue(track.getId(), track.getId(), maxDepth + 1),
+            new GpuInfo.Queue(track.getId(), track.getName(), maxDepth + 1),
             new GpuSliceTrack(track.getId(), matched))));
       }
 


### PR DESCRIPTION
Early versions of the profiling support provided 'ugly' track names, but
that has since been fixed. Just present the GPU queue names as provided
by the driver.

This fixes the 'GPU Queue 48' quirk in the replay profiler,
and prepares us for more descriptive track names from other drivers.

Bug: b/150692802