### PR TITLE
Update frame lifecycle capability based on sdk and preview_sdk versions

### DIFF
--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -331,8 +331,7 @@ func (b *binding) QueryPerfettoServiceState(ctx context.Context) (*device.Perfet
 		result.GpuProfiling = gpu
 	}
 
-	if b.Instance().GetConfiguration().GetOS().GetName() == "R" {
-		// TODO(b/146384733): Change this to API version when it releases
+	if b.Instance().GetConfiguration().GetOS().GetAPIVersion() >= 30 {
 		gpu.HasFrameLifecycle = true
 	}
 

--- a/core/os/android/adb/device.go
+++ b/core/os/android/adb/device.go
@@ -160,6 +160,10 @@ func newDevice(ctx context.Context, serial string, status bind.Status) (*binding
 	// Collect the API version
 	if version, err := d.SystemProperty(ctx, "ro.build.version.sdk"); err == nil {
 		v, _ := strconv.Atoi(version)
+		if preview, err := d.SystemProperty(ctx, "ro.build.version.preview_sdk"); err == nil {
+			p, _ := strconv.Atoi(preview)
+			v += p
+		}
 		d.To.Configuration.OS.APIVersion = int32(v)
 	}
 

--- a/core/os/android/adb/device.go
+++ b/core/os/android/adb/device.go
@@ -160,6 +160,9 @@ func newDevice(ctx context.Context, serial string, status bind.Status) (*binding
 	// Collect the API version
 	if version, err := d.SystemProperty(ctx, "ro.build.version.sdk"); err == nil {
 		v, _ := strconv.Atoi(version)
+		// preview_sdk is used to determine the version for the next OS release
+		// Until the official release, new OS releases will use the same sdk
+		// version as the previous OS while setting the preview_sdk
 		if preview, err := d.SystemProperty(ctx, "ro.build.version.preview_sdk"); err == nil {
 			p, _ := strconv.Atoi(preview)
 			v += p

--- a/core/os/device/deviceinfo/cc/android/query.cpp
+++ b/core/os/device/deviceinfo/cc/android/query.cpp
@@ -328,6 +328,9 @@ bool createContext() {
 
   GET_STRING_PROP("ro.build.version.release", gContext.mOSName);
   GET_INT_PROP("ro.build.version.sdk", gContext.mOSVersion);
+  // preview_sdk is used to determine the version for the next OS release
+  // Until the official release, the new OS releases will use the same sdk
+  // version as the previous OS while setting the preview_sdk
   int previewSdk = 0;
   GET_INT_PROP("ro.build.version.preview_sdk", previewSdk);
   gContext.mOSVersion += previewSdk;

--- a/core/os/device/deviceinfo/cc/android/query.cpp
+++ b/core/os/device/deviceinfo/cc/android/query.cpp
@@ -328,6 +328,9 @@ bool createContext() {
 
   GET_STRING_PROP("ro.build.version.release", gContext.mOSName);
   GET_INT_PROP("ro.build.version.sdk", gContext.mOSVersion);
+  int previewSdk = 0;
+  GET_INT_PROP("ro.build.version.preview_sdk", previewSdk);
+  gContext.mOSVersion += previewSdk;
 
   if (gContext.mSupportedABIs.size() > 0) {
     auto primaryABI = gContext.mSupportedABIs[0];


### PR DESCRIPTION
The name property has been updated to Android 10, for R builds. This is
same as Q and hence cannot be used to distinguish between the two
dessert releases. For now, we depend on sdk and preview_sdk versions to
distinguish them.