### PR TITLE
Add multiple improvements to system profiler selection.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/models/BatterySummaryTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/BatterySummaryTrack.java
@@ -224,7 +224,7 @@ public class BatterySummaryTrack extends Track.WithQueryEngine<BatterySummaryTra
     }
   }
 
-  public static class Values implements Selection<Long>, Selection.Builder<Values> {
+  public static class Values implements Selection, Selection.Builder<Values> {
     public final long[] ts;
     public final long[] dur;
     public final long[] capacity;
@@ -338,7 +338,7 @@ public class BatterySummaryTrack extends Track.WithQueryEngine<BatterySummaryTra
     }
 
     @Override
-    public Selection<Long> build() {
+    public Selection build() {
       return this;
     }
   }

--- a/gapic/src/main/com/google/gapid/perfetto/models/CounterTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/CounterTrack.java
@@ -180,7 +180,7 @@ public class CounterTrack extends Track.WithQueryEngine<CounterTrack.Data> {
     }
   }
 
-  public static class Values implements Selection<Long>, Selection.Builder<Values> {
+  public static class Values implements Selection, Selection.Builder<Values> {
     public final long[] ts;
     public final String[] names;
     public final double[][] values;
@@ -310,7 +310,7 @@ public class CounterTrack extends Track.WithQueryEngine<CounterTrack.Data> {
     }
 
     @Override
-    public Selection<Long> build() {
+    public Selection build() {
       return this;
     }
   }

--- a/gapic/src/main/com/google/gapid/perfetto/models/CpuTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/CpuTrack.java
@@ -225,7 +225,7 @@ public class CpuTrack extends Track.WithQueryEngine<CpuTrack.Data> {
     }
   }
 
-  public static class Slice implements Selection<Long> {
+  public static class Slice implements Selection {
     public final long id;
     public final long time;
     public final long dur;
@@ -286,7 +286,7 @@ public class CpuTrack extends Track.WithQueryEngine<CpuTrack.Data> {
     }
   }
 
-  public static class Slices implements Selection<Long> {
+  public static class Slices implements Selection {
     private final List<Slice> slices;
     public final ImmutableList<ByProcess> processes;
     public final ImmutableSet<Long> sliceKeys;
@@ -350,7 +350,7 @@ public class CpuTrack extends Track.WithQueryEngine<CpuTrack.Data> {
     }
 
     @Override
-    public Selection<Long> build() {
+    public Selection build() {
       return new Slices(slices, processes.values().stream()
           .map(ByProcess.Builder::build)
           .sorted((p1, p2) -> Long.compare(p2.dur, p1.dur))

--- a/gapic/src/main/com/google/gapid/perfetto/models/FrameEventsTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/FrameEventsTrack.java
@@ -228,7 +228,7 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
     }
   }
 
-  public static class Slice implements Selection<Long> {
+  public static class Slice implements Selection {
     public final long id;
     public final long time;
     public final long dur;
@@ -293,7 +293,7 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
 
   }
 
-  public static class Slices implements Selection<Long> {
+  public static class Slices implements Selection {
     private final List<Slice> slices;
     private final String title;
     public final ImmutableList<Node> nodes;
@@ -361,7 +361,7 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
     }
 
     @Override
-    public Selection<Long> build() {
+    public Selection build() {
       return new Slices(slices, title, ImmutableList.copyOf(roots.values()),
           ImmutableSet.copyOf(sliceKeys));
     }

--- a/gapic/src/main/com/google/gapid/perfetto/models/FrameEventsTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/FrameEventsTrack.java
@@ -69,6 +69,8 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
   private static final String RANGE_FOR_IDS_SQL =
       "select " + BASE_COLUMNS + " from %s where id in (%s)";
 
+  private static final long SIGNAL_MARGIN_NS = 10000;
+
   private final long trackId;
 
   public FrameEventsTrack(QueryEngine qe, long trackId) {
@@ -284,6 +286,8 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
     public void getRange(Consumer<TimeSpan> span) {
       if (dur > 0) {
         span.accept(new TimeSpan(time, time + dur));
+      } else { // Expand the zoom/highlight time range for signal selections whose dur is 0.
+        span.accept(new TimeSpan(time, time + dur).expand(SIGNAL_MARGIN_NS));
       }
     }
 

--- a/gapic/src/main/com/google/gapid/perfetto/models/MemorySummaryTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/MemorySummaryTrack.java
@@ -238,7 +238,7 @@ public class MemorySummaryTrack extends Track.WithQueryEngine<MemorySummaryTrack
     }
   }
 
-  public static class Values implements Selection<Long>, Selection.Builder<Values> {
+  public static class Values implements Selection, Selection.Builder<Values> {
     public final long[] ts;
     public final long[] dur;
     public final long[] total;
@@ -352,7 +352,7 @@ public class MemorySummaryTrack extends Track.WithQueryEngine<MemorySummaryTrack
     }
 
     @Override
-    public Selection<Long> build() {
+    public Selection build() {
       return this;
     }
   }

--- a/gapic/src/main/com/google/gapid/perfetto/models/Selection.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Selection.java
@@ -208,7 +208,7 @@ public interface Selection<Key> {
     public static final Kind<Slice.Key> Gpu = new Kind<Slice.Key>(3);
     public static final Kind<Long> VulkanEvent = new Kind<Long>(4);
     public static final Kind<Long> Counter = new Kind<Long>(5);
-    public static final Kind<FrameEventsTrack.Slice.Key> FrameEvents = new Kind<FrameEventsTrack.Slice.Key>(6);
+    public static final Kind<Long> FrameEvents = new Kind<Long>(6);
     public static final Kind<Long> Memory = new Kind<Long>(7);
     public static final Kind<Long> Battery = new Kind<Long>(8);
 

--- a/gapic/src/main/com/google/gapid/perfetto/models/Selection.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Selection.java
@@ -22,9 +22,6 @@ import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gapid.perfetto.TimeSpan;
-import com.google.gapid.perfetto.models.CounterTrack.Values;
-import com.google.gapid.perfetto.models.SliceTrack.Slice;
-import com.google.gapid.perfetto.models.ThreadTrack.StateSlice;
 import com.google.gapid.perfetto.views.MultiSelectionView;
 import com.google.gapid.perfetto.views.State;
 
@@ -40,9 +37,9 @@ import java.util.function.Consumer;
 /**
  * Data about the current selection in the UI.
  */
-public interface Selection<Key> {
+public interface Selection {
   public String getTitle();
-  public boolean contains(Key key);
+  public boolean contains(Long key);
   public Composite buildUi(Composite parent, State state);
   public Selection.Builder<?> getBuilder();
 
@@ -54,21 +51,20 @@ public interface Selection<Key> {
     return false;
   }
 
-  public static final Selection<?> EMPTY_SELECTION = new EmptySelection<Object>();
+  public static final Selection EMPTY_SELECTION = new EmptySelection();
 
-  @SuppressWarnings("unchecked")
-  public static <K> Selection<K> emptySelection() {
-      return (Selection<K>)EMPTY_SELECTION;
+  public static Selection emptySelection() {
+      return EMPTY_SELECTION;
   }
 
-  public static class EmptySelection<K> implements Selection<K>, Builder<EmptySelection<K>> {
+  public static class EmptySelection implements Selection, Builder<EmptySelection> {
     @Override
     public String getTitle() {
       return "";
     }
 
     @Override
-    public boolean contains(K key) {
+    public boolean contains(Long key) {
       return false;
     }
 
@@ -88,12 +84,12 @@ public interface Selection<Key> {
     }
 
     @Override
-    public EmptySelection<K> combine(EmptySelection<K> other) {
+    public EmptySelection combine(EmptySelection other) {
       return this;
     }
 
     @Override
-    public Selection<?> build() {
+    public Selection build() {
       return this;
     }
   }
@@ -102,14 +98,14 @@ public interface Selection<Key> {
    * MultiSelection stores selections across different {@link Kind}s.
    * */
   public static class MultiSelection {
-    private final NavigableMap<Kind<?>, Selection<?>> selections;
+    private final NavigableMap<Kind, Selection> selections;
 
-    public <Key> MultiSelection(Kind<Key> type, Selection<Key> selection) {
+    public MultiSelection(Kind type, Selection selection) {
       this.selections = Maps.newTreeMap();
       this.selections.put(type, selection);
     }
 
-    public MultiSelection(NavigableMap<Kind<?>, Selection<?>> selections) {
+    public MultiSelection(NavigableMap<Kind, Selection> selections) {
       this.selections = selections;
     }
 
@@ -121,13 +117,11 @@ public interface Selection<Key> {
       }
     }
 
-    @SuppressWarnings("unchecked")
-    public <Key> Selection<Key> getSelection(Kind<Key> type) {
-      return selections.containsKey(type) ?
-          (Selection<Key>) selections.get(type) : Selection.emptySelection();
+    public  Selection getSelection(Kind type) {
+      return selections.containsKey(type) ? selections.get(type) : Selection.emptySelection();
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({"rawtypes" })
     public void addSelection(MultiSelection other) {
       for (Selection.Kind k : other.selections.keySet()) {
         this.addSelection(k, other.selections.get(k));
@@ -135,8 +129,8 @@ public interface Selection<Key> {
     }
 
     @SuppressWarnings("unchecked")
-    public <Key, T extends Builder<T>> void addSelection(Kind<Key> kind, Selection<Key> selection) {
-      Selection<Key>  old = getSelection(kind);
+    public <T extends Builder<T>> void addSelection(Kind kind, Selection selection) {
+      Selection old = getSelection(kind);
       if (old == null || old == Selection.EMPTY_SELECTION) {
         selections.put(kind, selection);
       } else {
@@ -154,13 +148,13 @@ public interface Selection<Key> {
 
     private TimeSpan getRange() {
       TimeSpan[] range = new TimeSpan[] { TimeSpan.ZERO };
-      for (Selection<?> sel : selections.values()) {
+      for (Selection sel : selections.values()) {
         sel.getRange(r -> range[0] = range[0].expand(r));
       }
       return range[0];
     }
 
-    private Selection<?> firstSelection() {
+    private Selection firstSelection() {
       return selections.firstEntry().getValue();
     }
   }
@@ -169,21 +163,21 @@ public interface Selection<Key> {
    * Selection builder for combining selections across different {@link Kind}s.
    * */
   public static class CombiningBuilder {
-    private final Map<Kind<?>, ListenableFuture<Selection.Builder<?>>> selections =
+    private final Map<Kind, ListenableFuture<Selection.Builder<?>>> selections =
         Maps.newTreeMap();
 
     @SuppressWarnings("unchecked")
     public <T extends Selection.Builder<T>> void add(
-        Kind<?> type, ListenableFuture<Selection.Builder<?>> selection) {
+        Kind type, ListenableFuture<Selection.Builder<?>> selection) {
       selections.merge(type, selection, (f1, f2) -> transformAsync(f1, r1 ->
         transform(f2, r2 -> (((T)r1).combine((T)r2)))));
     }
 
     public ListenableFuture<MultiSelection> build() {
       return transform(Futures.allAsList(selections.values()), sels -> {
-        Iterator<Kind<?>> keys = selections.keySet().iterator();
+        Iterator<Kind> keys = selections.keySet().iterator();
         Iterator<Selection.Builder<?>> vals = sels.iterator();
-        TreeMap<Kind<?>, Selection<?>> res = Maps.newTreeMap();
+        TreeMap<Kind, Selection> res = Maps.newTreeMap();
         while (keys.hasNext()) {
           res.put(keys.next(), vals.next().build());
         }
@@ -197,20 +191,20 @@ public interface Selection<Key> {
   * */
   public static interface Builder<T extends Builder<T>> {
     public T combine(T other);
-    public Selection<?> build();
+    public Selection build();
   }
 
   @SuppressWarnings("unused")
-  public static class Kind<Key> implements Comparable<Kind<?>>{
-    public static final Kind<Long> Thread = new Kind<Long>(0);
-    public static final Kind<Long> ThreadState = new Kind<Long>(1);
-    public static final Kind<Long> Cpu = new Kind<Long>(2);
-    public static final Kind<Long> Gpu = new Kind<Long>(3);
-    public static final Kind<Long> VulkanEvent = new Kind<Long>(4);
-    public static final Kind<Long> Counter = new Kind<Long>(5);
-    public static final Kind<Long> FrameEvents = new Kind<Long>(6);
-    public static final Kind<Long> Memory = new Kind<Long>(7);
-    public static final Kind<Long> Battery = new Kind<Long>(8);
+  public static class Kind implements Comparable<Kind>{
+    public static final Kind Thread = new Kind(0);
+    public static final Kind ThreadState = new Kind(1);
+    public static final Kind Cpu = new Kind(2);
+    public static final Kind Gpu = new Kind(3);
+    public static final Kind VulkanEvent = new Kind(4);
+    public static final Kind Counter = new Kind(5);
+    public static final Kind FrameEvents = new Kind(6);
+    public static final Kind Memory = new Kind(7);
+    public static final Kind Battery = new Kind(8);
 
     public int priority;
 
@@ -219,7 +213,7 @@ public interface Selection<Key> {
     }
 
     @Override
-    public int compareTo(Kind<?> other) {
+    public int compareTo(Kind other) {
       return this.priority - other.priority;
     }
   }

--- a/gapic/src/main/com/google/gapid/perfetto/models/Selection.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Selection.java
@@ -202,10 +202,10 @@ public interface Selection<Key> {
 
   @SuppressWarnings("unused")
   public static class Kind<Key> implements Comparable<Kind<?>>{
-    public static final Kind<Slice.Key> Thread = new Kind<Slice.Key>(0);
-    public static final Kind<StateSlice.Key> ThreadState = new Kind<StateSlice.Key>(1);
+    public static final Kind<Long> Thread = new Kind<Long>(0);
+    public static final Kind<Long> ThreadState = new Kind<Long>(1);
     public static final Kind<Long> Cpu = new Kind<Long>(2);
-    public static final Kind<Slice.Key> Gpu = new Kind<Slice.Key>(3);
+    public static final Kind<Long> Gpu = new Kind<Long>(3);
     public static final Kind<Long> VulkanEvent = new Kind<Long>(4);
     public static final Kind<Long> Counter = new Kind<Long>(5);
     public static final Kind<Long> FrameEvents = new Kind<Long>(6);

--- a/gapic/src/main/com/google/gapid/perfetto/models/SliceTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/SliceTrack.java
@@ -70,13 +70,13 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
       private final String GPU_COLUMNS = "render_target, render_target_name, render_pass, render_pass_name, command_buffer, command_buffer_name, submission_id";
       private final String GPU_SLICES_QUANT_SQL =
           "select min(start_ts), max(end_ts), depth, label, max(cnt), " +
-          "    first_value(submission_id) over (partition by depth, label, i)  from (" +
+          "    group_concat(id) id, first_value(submission_id) over (partition by depth, label, i) from (" +
           "  select quantum_ts, start_ts, end_ts, depth, label, count(1) cnt, " +
           "      quantum_ts-row_number() over (partition by depth, label order by quantum_ts) i, " +
-          "      submission_id from (" +
+          "      group_concat(id) id, submission_id from (" +
           "    select quantum_ts, min(ts) over win1 start_ts, max(ts + dur) over win1 end_ts, depth, " +
           "        substr(group_concat(name) over win1, 0, 101) label, " +
-          "        first_value(submission_id) over win1 submission_id" +
+          "        id, first_value(submission_id) over win1 submission_id " +
           "    from %s" +
           "    window win1 as (partition by quantum_ts, depth order by dur desc" +
           "    range between unbounded preceding and unbounded following))" +
@@ -95,7 +95,8 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
 
       @Override
       protected void appendForQuant(Data data, QueryEngine.Result res) {
-        data.putExtraLongs("submissionIds", res.stream().mapToLong(r -> r.getLong(5)).toArray());
+        super.appendForQuant(data, res);
+        data.putExtraLongs("submissionIds", res.stream().mapToLong(r -> r.getLong(6)).toArray());
       }
 
       @Override
@@ -143,6 +144,7 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
   }
 
   public abstract ListenableFuture<Slice> getSlice(long id);
+  public abstract ListenableFuture<List<Slice>> getSlices(String concatedId);
   public abstract ListenableFuture<List<Slice>> getSlices(TimeSpan ts, int minDepth, int maxDepth);
 
   public static class Data extends Track.Data {
@@ -154,6 +156,7 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
     public final String[] categories;
     public final ArgSet[] args;
     public Map<String, long[]> extraLongs = Maps.newHashMap();
+    public Map<String, String[]> extraStrings = Maps.newHashMap();
 
     public Data(DataRequest request) {
       super(request);
@@ -185,9 +188,18 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
     public long[] getExtraLongs(String s) {
       return extraLongs.getOrDefault(s, new long[0]);
     }
+
+    public void putExtraStrings(String s, String[] longs) {
+      extraStrings.put(s, longs);
+    }
+
+    public String[] getExtraStrings(String s) {
+      return extraStrings.getOrDefault(s, new String[0]);
+    }
   }
 
-  public static abstract class Slice implements Selection<Slice.Key> {
+  public static abstract class Slice implements Selection<Long> {
+    public final long id;
     public final long time;
     public final long dur;
     public final String category;
@@ -197,8 +209,9 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
     public final long parentId;
     public final ArgSet args;
 
-    public Slice(long time, long dur, String category, String name, int depth, long stackId,
+    public Slice(long id, long time, long dur, String category, String name, int depth, long stackId,
         long parentId, ArgSet args) {
+      this.id = id;
       this.time = time;
       this.dur = dur;
       this.category = category;
@@ -210,7 +223,8 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
     }
 
     public Slice(QueryEngine.Row row, ArgSet args) {
-      this(row.getLong(1), row.getLong(2), row.getString(3), row.getString(4), row.getInt(5),
+      this(row.getLong(0), row.getLong(1), row.getLong(2),
+          row.getString(3), row.getString(4), row.getInt(5),
           row.getLong(6), row.getLong(7), args);
     }
 
@@ -223,8 +237,8 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
     }
 
     @Override
-    public boolean contains(Slice.Key key) {
-      return key.matches(this);
+    public boolean contains(Long key) {
+      return key == id;
     }
 
     @Override
@@ -241,42 +255,6 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
     public void getRange(Consumer<TimeSpan> span) {
       if (dur > 0) {
         span.accept(new TimeSpan(time, time + dur));
-      }
-    }
-
-    public static class Key {
-      public final long time;
-      public final long dur;
-      public final int depth;
-
-      public Key(long time, long dur, int depth) {
-        this.time = time;
-        this.dur = dur;
-        this.depth = depth;
-      }
-
-      public Key(Slice slice) {
-        this(slice.time, slice.dur, slice.depth);
-      }
-
-      public boolean matches(Slice slice) {
-        return slice.time == time && slice.dur == dur && slice.depth == depth;
-      }
-
-      @Override
-      public boolean equals(Object obj) {
-        if (obj == this) {
-          return true;
-        } else if (!(obj instanceof Key)) {
-          return false;
-        }
-        Key o = (Key)obj;
-        return time == o.time && dur == o.dur && depth == o.depth;
-      }
-
-      @Override
-      public int hashCode() {
-        return Long.hashCode(time ^ dur) ^ Integer.hashCode(depth);
       }
     }
 
@@ -341,14 +319,14 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
     }
   }
 
-  public static class Slices implements Selection<Slice.Key> {
+  public static class Slices implements Selection<Long> {
     private final List<Slice> slices;
     private final String title;
     public final ImmutableList<Node> nodes;
-    public final ImmutableSet<Slice.Key> sliceKeys;
+    public final ImmutableSet<Long> sliceKeys;
 
     public Slices(List<Slice> slices, String title, ImmutableList<Node> nodes,
-        ImmutableSet<Slice.Key> sliceKeys) {
+        ImmutableSet<Long> sliceKeys) {
       this.slices = slices;
       this.title = title;
       this.nodes = nodes;
@@ -361,7 +339,7 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
     }
 
     @Override
-    public boolean contains(Slice.Key key) {
+    public boolean contains(Long key) {
       return sliceKeys.contains(key);
     }
 
@@ -389,7 +367,7 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
     private final Map<Long, Node.Builder> byStack = Maps.newHashMap();
     private final Map<Long, List<Node.Builder>> byParent = Maps.newHashMap();
     private final Set<Long> roots = Sets.newHashSet();
-    private final Set<Slice.Key> sliceKeys = Sets.newHashSet();
+    private final Set<Long> sliceKeys = Sets.newHashSet();
 
     public SlicesBuilder(List<Slice> slices) {
       this.slices = slices;
@@ -404,7 +382,7 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
         }
         roots.remove(slice.stackId);
         child.add(slice.dur);
-        sliceKeys.add(new Slice.Key(slice));
+        sliceKeys.add(slice.id);
       }
       this.title = ti;
     }
@@ -427,7 +405,7 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
     }
 
     @Override
-    public Selection<Slice.Key> build() {
+    public Selection<Long> build() {
       return new Slices(slices, title, roots.stream()
           .filter(not(byStack::containsKey))
           .flatMap(root -> byParent.get(root).stream())
@@ -500,7 +478,7 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
     }
   }
 
-  private abstract static class WithQueryEngine extends SliceTrack {
+  public abstract static class WithQueryEngine extends SliceTrack {
     protected static final String BASE_COLUMNS =
         "id, ts, dur, category, name, depth, stack_id, parent_stack_id, arg_set_id";
     protected final String table;
@@ -512,11 +490,12 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
         "select " + baseColumns() + " from %s " +
         "where ts >= %d - dur and ts <= %d order by ts";
     private static final String SLICES_QUANT_SQL =
-        "select min(start_ts), max(end_ts), depth, label, max(cnt) from (" +
+        "select min(start_ts), max(end_ts), depth, label, max(cnt), group_concat(id) id from (" +
         "  select quantum_ts, start_ts, end_ts, depth, label, count(1) cnt, " +
-        "      quantum_ts-row_number() over (partition by depth, label order by quantum_ts) i from (" +
+        "      quantum_ts-row_number() over (partition by depth, label order by quantum_ts) i, " +
+        "      group_concat(id) id from (" +
         "    select quantum_ts, min(ts) over win1 start_ts, max(ts + dur) over win1 end_ts, depth, " +
-        "        substr(group_concat(name) over win1, 0, 101) label" +
+        "        substr(group_concat(name) over win1, 0, 101) label, id" +
         "    from %s" +
         "    window win1 as (partition by quantum_ts, depth order by dur desc" +
         "        range between unbounded preceding and unbounded following))" +
@@ -528,13 +507,17 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
     private final String SLICE_RANGE_SQL =
         "select " + baseColumns() + " from %s " +
         "where ts < %d and ts + dur >= %d and depth >= %d and depth <= %d";
+    private final String SLICES_BY_ID_SQL =
+        "select " + baseColumns() + " from %s where id in (%s)";
     private final QueryEngine qe;
 
     protected String baseColumns() {
       return BASE_COLUMNS;
     }
 
-    protected void appendForQuant(Data data, QueryEngine.Result res) { /* Do nothing by default. */}
+    protected void appendForQuant(Data data, QueryEngine.Result res) {
+      data.putExtraStrings("concatedIds", res.stream().map(r -> r.getString(5)).toArray(String[]::new));
+    }
 
     protected WithQueryEngine(QueryEngine qe, String table, long trackId) {
       super(trackId);
@@ -628,6 +611,16 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
 
     private String sliceSql(long id) {
       return format(SLICE_SQL, tableName("slices"), id);
+    }
+
+    @Override
+    public ListenableFuture<List<Slice>> getSlices(String concatedId) {
+      return transform(qe.query(slicesByIdSql(concatedId)),
+          res -> res.list(($, row) -> buildSlice(row)));
+    }
+
+    private String slicesByIdSql(String concatedId) {
+      return format(SLICES_BY_ID_SQL, tableName("slices"), concatedId);
     }
 
     @Override

--- a/gapic/src/main/com/google/gapid/perfetto/models/SliceTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/SliceTrack.java
@@ -181,20 +181,20 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
       this.args = args;
     }
 
-    public void putExtraLongs(String s, long[] longs) {
-      extraLongs.put(s, longs);
+    public void putExtraLongs(String name, long[] longs) {
+      extraLongs.put(name, longs);
     }
 
-    public long[] getExtraLongs(String s) {
-      return extraLongs.getOrDefault(s, new long[0]);
+    public long[] getExtraLongs(String name) {
+      return extraLongs.getOrDefault(name, new long[0]);
     }
 
-    public void putExtraStrings(String s, String[] longs) {
-      extraStrings.put(s, longs);
+    public void putExtraStrings(String name, String[] strings) {
+      extraStrings.put(name, strings);
     }
 
-    public String[] getExtraStrings(String s) {
-      return extraStrings.getOrDefault(s, new String[0]);
+    public String[] getExtraStrings(String name) {
+      return extraStrings.getOrDefault(name, new String[0]);
     }
   }
 

--- a/gapic/src/main/com/google/gapid/perfetto/models/SliceTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/SliceTrack.java
@@ -198,7 +198,7 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
     }
   }
 
-  public static abstract class Slice implements Selection<Long> {
+  public static abstract class Slice implements Selection {
     public final long id;
     public final long time;
     public final long dur;
@@ -319,7 +319,7 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
     }
   }
 
-  public static class Slices implements Selection<Long> {
+  public static class Slices implements Selection {
     private final List<Slice> slices;
     private final String title;
     public final ImmutableList<Node> nodes;
@@ -405,7 +405,7 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
     }
 
     @Override
-    public Selection<Long> build() {
+    public Selection build() {
       return new Slices(slices, title, roots.stream()
           .filter(not(byStack::containsKey))
           .flatMap(root -> byParent.get(root).stream())

--- a/gapic/src/main/com/google/gapid/perfetto/models/ThreadTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/ThreadTrack.java
@@ -64,17 +64,20 @@ public class ThreadTrack extends Track.WithQueryEngine<ThreadTrack.Data> {
       "select ts, lead(ts, 1, (select end_ts from trace_bounds)) over (order by ts) - ts dur " +
       "from wakeup";
   private static final String STATE_SPAN_VIEW =
-      "select ts, dur, case " +
+      "select ts, dur, case when end_state is null then false else true end is_sched, case " +
       "  when end_state is not null then 'r'" +
       "  when lag(end_state) over ts_win is not null then lag(end_state) over ts_win" +
       "  else 'R'" +
-      "end as state, id " +
+      "end as state, case " +
+      "  when id is not null then id " +                       // Sched id, for slices of 'Running'.
+      "  else rank() over ts_win + (select max(id) from %s)" + // Assigned unique id, for other state slices like 'Waking', 'Runnable', etc.
+      "end as id " +
       "from %s window ts_win as (order by ts)";
 
   private static final String SCHED_SQL =
-      "select ts, dur, state, id from %s where state != 'S' and state != 'x'";
+      "select ts, dur, is_sched, state, id from %s where state != 'S' and state != 'x'";
   private static final String SCHED_RANGE_SQL =
-      "select ts, dur, state from %s where ts < %d and ts + dur >= %d";
+      "select ts, dur, is_sched, state, id from %s where ts < %d and ts + dur >= %d";
 
 
   private final ThreadInfo thread;
@@ -109,7 +112,7 @@ public class ThreadTrack extends Track.WithQueryEngine<ThreadTrack.Data> {
         createView(sched, format(SCHED_VIEW, thread.utid)),
         createView(wakeup, format(INSTANT_VIEW, thread.utid, sched)),
         createSpanLeftJoin(spanJoin, wakeup + ", " + sched),
-        createView(spanView, format(STATE_SPAN_VIEW, spanJoin)),
+        createView(spanView, format(STATE_SPAN_VIEW, spanJoin, spanJoin)),
         createSpan(span, window + ", " + spanView)));
   }
 
@@ -124,14 +127,15 @@ public class ThreadTrack extends Track.WithQueryEngine<ThreadTrack.Data> {
   private ListenableFuture<Data> computeSched(DataRequest req, SliceTrack.Data slices) {
     return transform(qe.query(schedSql()), res -> {
       int rows = res.getNumRows();
-      Data data = new Data(req, new long[rows], new long[rows], new long[rows],
+      Data data = new Data(req, new boolean[rows], new long[rows], new long[rows], new long[rows],
           new ThreadState[rows], slices);
       res.forEachRow((i, row) -> {
         long start = row.getLong(0);
         data.schedStarts[i] = start;
         data.schedEnds[i] = start + row.getLong(1);
-        data.schedStates[i] = ThreadState.of(row.getString(2));
-        data.schedIds[i] = row.getLong(3);
+        data.isSched[i] = row.getInt(2) != 0;
+        data.schedStates[i] = ThreadState.of(row.getString(3));
+        data.ids[i] = row.getLong(4);
       });
       return data;
     });
@@ -147,6 +151,10 @@ public class ThreadTrack extends Track.WithQueryEngine<ThreadTrack.Data> {
 
   public ListenableFuture<CpuTrack.Slice> getCpuSlice(long id) {
     return CpuTrack.getSlice(qe, id);
+  }
+
+  public ListenableFuture<List<Slice>> getSlices(String concatedId) {
+    return sliceTrack.getSlices(concatedId);
   }
 
   public ListenableFuture<List<Slice>> getSlices(TimeSpan ts, int minDepth, int maxDepth) {
@@ -171,17 +179,19 @@ public class ThreadTrack extends Track.WithQueryEngine<ThreadTrack.Data> {
 
   public static class Data extends Track.Data {
     // sched
-    public final long[] schedIds;
+    public final boolean[] isSched;
+    public final long[] ids; // Sched id for sched slice, generated unique id for other state slice.
     public final long[] schedStarts;
     public final long[] schedEnds;
     public final ThreadState[] schedStates;
     // slices
     public final SliceTrack.Data slices;
 
-    public Data(DataRequest request, long[] schedIds, long[] schedStarts, long[] schedEnds,
+    public Data(DataRequest request, boolean[] isSched, long[] ids, long[] schedStarts, long[] schedEnds,
         ThreadState[] schedStates, SliceTrack.Data slices) {
       super(request);
-      this.schedIds = schedIds;
+      this.isSched = isSched;
+      this.ids = ids;
       this.schedStarts = schedStarts;
       this.schedEnds = schedEnds;
       this.schedStates = schedStates;
@@ -189,24 +199,30 @@ public class ThreadTrack extends Track.WithQueryEngine<ThreadTrack.Data> {
     }
   }
 
-  public static class StateSlice implements Selection<StateSlice.Key> {
+  public static class StateSlice implements Selection<Long> {
     public final long time;
     public final long dur;
     public final long utid;
+    public final boolean isSched;
     public final ThreadState state;
+    public final long id;
 
-    public StateSlice(long time, long dur, long utid, ThreadState state) {
+    public StateSlice(long time, long dur, long utid, boolean isSched, ThreadState state, long id) {
       this.time = time;
       this.dur = dur;
       this.utid = utid;
+      this.isSched = isSched;
       this.state = state;
+      this.id = id;
     }
 
     public StateSlice(QueryEngine.Row row, long utid) {
       this.time = row.getLong(0);
       this.dur = row.getLong(1);
       this.utid = utid;
-      this.state = ThreadState.of(row.getString(2));
+      this.isSched = row.getInt(2) != 0;
+      this.state = ThreadState.of(row.getString(3));
+      this.id = row.getLong(4);
     }
 
     @Override
@@ -215,8 +231,8 @@ public class ThreadTrack extends Track.WithQueryEngine<ThreadTrack.Data> {
     }
 
     @Override
-    public boolean contains(StateSlice.Key key) {
-      return key.matches(this);
+    public boolean contains(Long key) {
+      return key == id;
     }
 
     @Override
@@ -235,51 +251,15 @@ public class ThreadTrack extends Track.WithQueryEngine<ThreadTrack.Data> {
         span.accept(new TimeSpan(time, time + dur));
       }
     }
-
-    public static class Key {
-      public final long time;
-      public final long dur;
-      public final long utid;
-
-      public Key(long time, long dur, long utid) {
-        this.time = time;
-        this.dur = dur;
-        this.utid = utid;
-      }
-
-      public Key(StateSlice slice) {
-        this(slice.time, slice.dur, slice.utid);
-      }
-
-      public boolean matches(StateSlice slice) {
-        return slice.time == time && slice.dur == dur && slice.utid == utid;
-      }
-
-      @Override
-      public boolean equals(Object obj) {
-        if (obj == this) {
-          return true;
-        } else if (!(obj instanceof Key)) {
-          return false;
-        }
-        Key o = (Key)obj;
-        return time == o.time && dur == o.dur && utid == o.utid;
-      }
-
-      @Override
-      public int hashCode() {
-        return Long.hashCode(time ^ dur ^ utid);
-      }
-    }
   }
 
-  public static class StateSlices implements Selection<StateSlice.Key> {
+  public static class StateSlices implements Selection<Long> {
     private final List<StateSlice> slices;
     public final ImmutableList<Entry> entries;
-    public final ImmutableSet<StateSlice.Key> sliceKeys;
+    public final ImmutableSet<Long> sliceKeys;
 
     public StateSlices(List<StateSlice> slices, ImmutableList<Entry> entries,
-        ImmutableSet<StateSlice.Key> sliceKeys) {
+        ImmutableSet<Long> sliceKeys) {
       this.slices = slices;
       this.entries = entries;
       this.sliceKeys = sliceKeys;
@@ -291,7 +271,7 @@ public class ThreadTrack extends Track.WithQueryEngine<ThreadTrack.Data> {
     }
 
     @Override
-    public boolean contains(StateSlice.Key key) {
+    public boolean contains(Long key) {
       return sliceKeys.contains(key);
     }
 
@@ -326,13 +306,13 @@ public class ThreadTrack extends Track.WithQueryEngine<ThreadTrack.Data> {
   public static class StateSlicesBuilder implements Selection.Builder<StateSlicesBuilder> {
     private final List<StateSlice> slices;
     private final Map<ThreadState, Long> byState = Maps.newHashMap();
-    private final Set<StateSlice.Key> sliceKeys = Sets.newHashSet();
+    private final Set<Long> sliceKeys = Sets.newHashSet();
 
     public StateSlicesBuilder(List<StateSlice> slices) {
       this.slices = slices;
       for (StateSlice slice : slices) {
         byState.compute(slice.state, (state, old) -> (old == null) ? slice.dur : old + slice.dur);
-        sliceKeys.add(new StateSlice.Key(slice));
+        sliceKeys.add(slice.id);
       }
     }
 
@@ -347,7 +327,7 @@ public class ThreadTrack extends Track.WithQueryEngine<ThreadTrack.Data> {
     }
 
     @Override
-    public Selection<StateSlice.Key> build() {
+    public Selection<Long> build() {
       return new StateSlices(slices, byState.entrySet().stream()
           .map(e -> new StateSlices.Entry(e.getKey(), e.getValue()))
           .sorted((e1, e2) -> Long.compare(e2.totalDur, e1.totalDur))
@@ -371,6 +351,10 @@ public class ThreadTrack extends Track.WithQueryEngine<ThreadTrack.Data> {
     @SuppressWarnings("unused")
     public default ListenableFuture<Slice> getSlice(long id) {
       throw new UnsupportedOperationException();
+    }
+
+    public default ListenableFuture<List<Slice>> getSlices(String concatedId) {
+      return Futures.immediateFuture(Collections.emptyList());
     }
 
     @SuppressWarnings("unused")
@@ -399,6 +383,11 @@ public class ThreadTrack extends Track.WithQueryEngine<ThreadTrack.Data> {
         @Override
         public ListenableFuture<Slice> getSlice(long id) {
           return track.getSlice(id);
+        }
+
+        @Override
+        public ListenableFuture<List<Slice>> getSlices(String concatedId) {
+          return track.getSlices(concatedId);
         }
 
         @Override

--- a/gapic/src/main/com/google/gapid/perfetto/models/ThreadTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/ThreadTrack.java
@@ -199,7 +199,7 @@ public class ThreadTrack extends Track.WithQueryEngine<ThreadTrack.Data> {
     }
   }
 
-  public static class StateSlice implements Selection<Long> {
+  public static class StateSlice implements Selection {
     public final long time;
     public final long dur;
     public final long utid;
@@ -253,7 +253,7 @@ public class ThreadTrack extends Track.WithQueryEngine<ThreadTrack.Data> {
     }
   }
 
-  public static class StateSlices implements Selection<Long> {
+  public static class StateSlices implements Selection {
     private final List<StateSlice> slices;
     public final ImmutableList<Entry> entries;
     public final ImmutableSet<Long> sliceKeys;
@@ -327,7 +327,7 @@ public class ThreadTrack extends Track.WithQueryEngine<ThreadTrack.Data> {
     }
 
     @Override
-    public Selection<Long> build() {
+    public Selection build() {
       return new StateSlices(slices, byState.entrySet().stream()
           .map(e -> new StateSlices.Entry(e.getKey(), e.getValue()))
           .sorted((e1, e2) -> Long.compare(e2.totalDur, e1.totalDur))

--- a/gapic/src/main/com/google/gapid/perfetto/models/VulkanEventTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/VulkanEventTrack.java
@@ -162,7 +162,7 @@ public class VulkanEventTrack extends Track.WithQueryEngine<VulkanEventTrack.Dat
     }
   }
 
-  public static class Slice implements Selection<Long> {
+  public static class Slice implements Selection {
     public final long id;
     public final long time;
     public final long dur;
@@ -217,7 +217,7 @@ public class VulkanEventTrack extends Track.WithQueryEngine<VulkanEventTrack.Dat
     }
   }
 
-  public static class Slices implements Selection<Long> {
+  public static class Slices implements Selection {
     public final List<Slice> slices;
     public final ImmutableSet<Long> sliceKeys;
     private final Set<Long> submissionIds;
@@ -279,7 +279,7 @@ public class VulkanEventTrack extends Track.WithQueryEngine<VulkanEventTrack.Dat
     }
 
     @Override
-    public Selection<Long> build() {
+    public Selection build() {
       return new Slices(slices, ImmutableSet.copyOf(sliceKeys));
     }
   }

--- a/gapic/src/main/com/google/gapid/perfetto/views/BatterySummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/BatterySummaryPanel.java
@@ -35,6 +35,8 @@ import com.google.gapid.perfetto.models.Selection.CombiningBuilder;
 import com.google.gapid.perfetto.models.Selection.Kind;
 import java.util.List;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Cursor;
+import org.eclipse.swt.widgets.Display;
 
 public class BatterySummaryPanel extends TrackPanel<BatterySummaryPanel> implements Selectable {
   private static final double HEIGHT = 50;
@@ -190,6 +192,11 @@ public class BatterySummaryPanel extends TrackPanel<BatterySummaryPanel> impleme
       @Override
       public void stop() {
         hovered = null;
+      }
+
+      @Override
+      public Cursor getCursor(Display display) {
+        return display.getSystemCursor(SWT.CURSOR_HAND);
       }
 
       @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/BatterySummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/BatterySummaryPanel.java
@@ -80,7 +80,7 @@ public class BatterySummaryPanel extends TrackPanel<BatterySummaryPanel> impleme
       }
 
       double maxAbs = track.getMaxAbsCurrent();
-      Selection<Long> selected = state.getSelection(Selection.Kind.Battery);
+      Selection selected = state.getSelection(Selection.Kind.Battery);
       List<Integer> visibleSelected = Lists.newArrayList();
 
       // Draw outgoing battery current above the x axis.

--- a/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
@@ -95,7 +95,7 @@ public class CounterPanel extends TrackPanel<CounterPanel> implements Selectable
       CounterInfo counter = track.getCounter();
       double min = counter.range.min, range = counter.range.range();
 
-      Selection<Long> selected = state.getSelection(Selection.Kind.Counter);
+      Selection selected = state.getSelection(Selection.Kind.Counter);
       List<Integer> visibleSelected = Lists.newArrayList();
       mainGradient().applyBaseAndBorder(ctx);
       ctx.path(path -> {

--- a/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
@@ -35,6 +35,8 @@ import com.google.gapid.perfetto.models.Selection.CombiningBuilder;
 import org.eclipse.swt.SWT;
 
 import java.util.List;
+import org.eclipse.swt.graphics.Cursor;
+import org.eclipse.swt.widgets.Display;
 
 public class CounterPanel extends TrackPanel<CounterPanel> implements Selectable {
   private static final double HOVER_MARGIN = 10;
@@ -196,6 +198,11 @@ public class CounterPanel extends TrackPanel<CounterPanel> implements Selectable
       @Override
       public void stop() {
         hovered = null;
+      }
+
+      @Override
+      public Cursor getCursor(Display display) {
+        return display.getSystemCursor(SWT.CURSOR_HAND);
       }
 
       @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
@@ -97,7 +97,7 @@ public class CpuPanel extends TrackPanel<CpuPanel> implements Selectable {
   private void renderSummary(RenderContext ctx, CpuTrack.Data data, double w, double h) {
     long tStart = data.request.range.start;
     int start = Math.max(0, (int)((state.getVisibleTime().start - tStart) / data.bucketSize));
-    Selection<Long> selected = state.getSelection(Selection.Kind.Cpu);
+    Selection selected = state.getSelection(Selection.Kind.Cpu);
     List<Integer> visibleSelected = Lists.newArrayList();
 
     gradient(track.getCpu().id).applyBase(ctx);
@@ -148,7 +148,7 @@ public class CpuPanel extends TrackPanel<CpuPanel> implements Selectable {
 
   private void renderSlices(RenderContext ctx, CpuTrack.Data data, double h) {
     TimeSpan visible = state.getVisibleTime();
-    Selection<Long> selected = state.getSelection(Selection.Kind.Cpu);
+    Selection selected = state.getSelection(Selection.Kind.Cpu);
     List<Highlight> visibleSelected = Lists.newArrayList();
     for (int i = 0; i < data.starts.length; i++) {
       long tStart = data.starts[i];

--- a/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
@@ -298,6 +298,11 @@ public class CpuPanel extends TrackPanel<CpuPanel> implements Selectable {
       }
 
       @Override
+      public Cursor getCursor(Display display) {
+        return ids.isEmpty() ? null : display.getSystemCursor(SWT.CURSOR_HAND);
+      }
+
+      @Override
       public boolean click() {
         if (ids.isEmpty()) {
           return false;

--- a/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
@@ -34,6 +34,7 @@ import com.google.gapid.perfetto.models.Selection;
 import com.google.gapid.perfetto.models.Selection.CombiningBuilder;
 import com.google.gapid.perfetto.models.ThreadInfo;
 
+import com.google.gapid.util.Arrays;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.RGBA;
@@ -110,8 +111,8 @@ public class CpuPanel extends TrackPanel<CpuPanel> implements Selectable {
         path.lineTo(x, y);
         path.lineTo(x, nextY);
         y = nextY;
-        for (String id : data.concatedIds[i].split(",")) {
-          if (!id.isEmpty() && selected.contains(Long.parseLong(id))) {
+        for (String id : Arrays.getOrDefault(data.concatedIds, i, "").split(",")) {
+          if (!id.isEmpty() && !selected.isEmpty() && selected.contains(Long.parseLong(id))) {
             visibleSelected.add(i);
             break;
           }
@@ -284,7 +285,7 @@ public class CpuPanel extends TrackPanel<CpuPanel> implements Selectable {
         data.request.range.start + hovered.bucket * data.bucketSize + data.bucketSize / 2);
     double dx = HOVER_PADDING + hovered.size.w + HOVER_PADDING;
     double dy = height;
-    String ids = data.concatedIds[bucket];
+    String ids = Arrays.getOrDefault(data.concatedIds, bucket, "");
 
     return new Hover() {
       @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSummaryPanel.java
@@ -19,6 +19,7 @@ import static com.google.gapid.perfetto.views.Loading.drawLoading;
 import static com.google.gapid.perfetto.views.StyleConstants.SELECTION_THRESHOLD;
 import static com.google.gapid.perfetto.views.StyleConstants.TRACK_MARGIN;
 import static com.google.gapid.perfetto.views.StyleConstants.colors;
+import static com.google.gapid.perfetto.views.StyleConstants.gradient;
 import static com.google.gapid.perfetto.views.StyleConstants.mainGradient;
 import static com.google.gapid.util.MoreFutures.transform;
 
@@ -101,6 +102,8 @@ public class FrameEventsSummaryPanel extends TrackPanel<FrameEventsSummaryPanel>
       RenderContext ctx, FrameEventsTrack.Data data, double w, double h) {
     long tStart = data.request.range.start;
     int start = Math.max(0, (int)((state.getVisibleTime().start - tStart) / data.bucketSize));
+    Selection<Long> selected = state.getSelection(Selection.Kind.FrameEvents);
+    List<Integer> visibleSelected = Lists.newArrayList();
 
     mainGradient().applyBaseAndBorder(ctx);
     ctx.path(path -> {
@@ -112,12 +115,26 @@ public class FrameEventsSummaryPanel extends TrackPanel<FrameEventsSummaryPanel>
         path.lineTo(x, y);
         path.lineTo(x, nextY);
         y = nextY;
+        for (String id : data.concatedIds[i].split(",")) {
+          if (!id.isEmpty() && selected.contains(Long.parseLong(id))) {
+            visibleSelected.add(i);
+            break;
+          }
+        }
       }
       path.lineTo(x, h);
       path.close();
       ctx.fillPath(path);
       ctx.drawPath(path);
     });
+
+    // Draw Highlight line after the whole graph is rendered, so that the highlight is on the top.
+    ctx.setBackgroundColor(mainGradient().highlight);
+    for (int index : visibleSelected) {
+      ctx.fillRect(state.timeToPx(tStart + index * data.bucketSize),
+          Math.round(Math.max(0,h - (h * (data.numEvents[index])))) - 1,
+          state.durationToDeltaPx(data.bucketSize), 3);
+    }
 
     if (hovered != null && hovered.bucket >= start) {
       double x = state.timeToPx(tStart + hovered.bucket * data.bucketSize + data.bucketSize / 2);
@@ -138,7 +155,7 @@ public class FrameEventsSummaryPanel extends TrackPanel<FrameEventsSummaryPanel>
 
   public void renderSlices(RenderContext ctx, FrameEventsTrack.Data data) {
     TimeSpan visible = state.getVisibleTime();
-    Selection<Slice.Key> selected = state.getSelection(Selection.Kind.FrameEvents);
+    Selection<Long> selected = state.getSelection(Selection.Kind.FrameEvents);
     List<Highlight> visibleSelected = Lists.newArrayList();
 
     for (int i = 0; i < data.starts.length; i++) {
@@ -159,7 +176,7 @@ public class FrameEventsSummaryPanel extends TrackPanel<FrameEventsSummaryPanel>
         double y = depth * SLICE_HEIGHT;
         ctx.fillRect(rectStart, y, rectWidth, SLICE_HEIGHT);
 
-        if (selected.contains(new Slice.Key(tStart, tEnd - tStart))) {
+        if (selected.contains(data.ids[i])) {
           visibleSelected.add(Highlight.slice(color.border, rectStart, y, rectWidth));
         }
 
@@ -178,7 +195,7 @@ public class FrameEventsSummaryPanel extends TrackPanel<FrameEventsSummaryPanel>
         double[] diamondY = { y + (SLICE_HEIGHT / 2), y, y + (SLICE_HEIGHT / 2), SLICE_HEIGHT };
         ctx.fillPolygon(diamondX, diamondY, 4);
 
-        if (selected.contains(new Slice.Key(tStart, tEnd - tStart))) {
+        if (selected.contains(data.ids[i])) {
           visibleSelected.add(Highlight.diamond(color.border, diamondX, diamondY));
         }
 
@@ -223,12 +240,12 @@ public class FrameEventsSummaryPanel extends TrackPanel<FrameEventsSummaryPanel>
 
     switch (data.kind) {
       case slices: return sliceHover(data, m, x, y, mods);
-      case summary: return summaryHover(data, m, x);
+      case summary: return summaryHover(data, m, x, mods);
       default: return Hover.NONE;
     }
   }
 
-  private Hover summaryHover(FrameEventsTrack.Data data, Fonts.TextMeasurer m, double x) {
+  private Hover summaryHover(FrameEventsTrack.Data data, Fonts.TextMeasurer m, double x, int mods) {
     long time = state.pxToTime(x);
     int bucket = (int)((time - data.request.range.start) / data.bucketSize);
     if (bucket < 0 || bucket >= data.numEvents.length) {
@@ -250,6 +267,8 @@ public class FrameEventsSummaryPanel extends TrackPanel<FrameEventsSummaryPanel>
         data.request.range.start + hovered.bucket * data.bucketSize + data.bucketSize / 2);
     double dx = HOVER_PADDING + hovered.size.w + HOVER_PADDING;
     double dy = height;
+    String ids = data.concatedIds[bucket];
+
     return new Hover() {
       @Override
       public Area getRedraw() {
@@ -259,6 +278,26 @@ public class FrameEventsSummaryPanel extends TrackPanel<FrameEventsSummaryPanel>
       @Override
       public void stop() {
         hovered = null;
+      }
+      
+      @Override
+      public Cursor getCursor(Display display) {
+        return p == 0 ? null : display.getSystemCursor(SWT.CURSOR_HAND);
+      }
+
+      @Override
+      public boolean click() {
+        if (ids.isEmpty()) {
+          return false;
+        }
+        if ((mods & SWT.MOD1) == SWT.MOD1) {
+          state.addSelection(Selection.Kind.FrameEvents,
+              transform(track.getSlices(ids), r -> new FrameEventsTrack.SlicesBuilder(r).build()));
+        } else {
+          state.setSelection(Selection.Kind.FrameEvents,
+              transform(track.getSlices(ids), r -> new FrameEventsTrack.SlicesBuilder(r).build()));
+        }
+        return true;
       }
     };
   }

--- a/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSummaryPanel.java
@@ -76,6 +76,11 @@ public class FrameEventsSummaryPanel extends TrackPanel<FrameEventsSummaryPanel>
   }
 
   @Override
+  public String getTooltip() {
+    return "\\b" + buffer.getDisplay();
+  }
+
+  @Override
   public double getHeight() {
     return buffer.maxDepth * SLICE_HEIGHT;
   }

--- a/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSummaryPanel.java
@@ -36,6 +36,7 @@ import com.google.gapid.perfetto.models.GpuInfo;
 import com.google.gapid.perfetto.models.Selection;
 import com.google.gapid.perfetto.models.Selection.CombiningBuilder;
 
+import com.google.gapid.util.Arrays;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.RGBA;
@@ -120,8 +121,8 @@ public class FrameEventsSummaryPanel extends TrackPanel<FrameEventsSummaryPanel>
         path.lineTo(x, y);
         path.lineTo(x, nextY);
         y = nextY;
-        for (String id : data.concatedIds[i].split(",")) {
-          if (!id.isEmpty() && selected.contains(Long.parseLong(id))) {
+        for (String id : Arrays.getOrDefault(data.concatedIds, i, "").split(",")) {
+          if (!id.isEmpty() && !selected.isEmpty() && selected.contains(Long.parseLong(id))) {
             visibleSelected.add(i);
             break;
           }
@@ -272,7 +273,7 @@ public class FrameEventsSummaryPanel extends TrackPanel<FrameEventsSummaryPanel>
         data.request.range.start + hovered.bucket * data.bucketSize + data.bucketSize / 2);
     double dx = HOVER_PADDING + hovered.size.w + HOVER_PADDING;
     double dy = height;
-    String ids = data.concatedIds[bucket];
+    String ids = Arrays.getOrDefault(data.concatedIds, bucket, "");
 
     return new Hover() {
       @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSummaryPanel.java
@@ -107,7 +107,7 @@ public class FrameEventsSummaryPanel extends TrackPanel<FrameEventsSummaryPanel>
       RenderContext ctx, FrameEventsTrack.Data data, double w, double h) {
     long tStart = data.request.range.start;
     int start = Math.max(0, (int)((state.getVisibleTime().start - tStart) / data.bucketSize));
-    Selection<Long> selected = state.getSelection(Selection.Kind.FrameEvents);
+    Selection selected = state.getSelection(Selection.Kind.FrameEvents);
     List<Integer> visibleSelected = Lists.newArrayList();
 
     mainGradient().applyBaseAndBorder(ctx);
@@ -160,7 +160,7 @@ public class FrameEventsSummaryPanel extends TrackPanel<FrameEventsSummaryPanel>
 
   public void renderSlices(RenderContext ctx, FrameEventsTrack.Data data) {
     TimeSpan visible = state.getVisibleTime();
-    Selection<Long> selected = state.getSelection(Selection.Kind.FrameEvents);
+    Selection selected = state.getSelection(Selection.Kind.FrameEvents);
     List<Highlight> visibleSelected = Lists.newArrayList();
 
     for (int i = 0; i < data.starts.length; i++) {

--- a/gapic/src/main/com/google/gapid/perfetto/views/GpuQueuePanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/GpuQueuePanel.java
@@ -93,7 +93,7 @@ public class GpuQueuePanel extends TrackPanel<GpuQueuePanel> implements Selectab
       }
 
       TimeSpan visible = state.getVisibleTime();
-      Selection<Long> selected = state.getSelection(Selection.Kind.Gpu);
+      Selection selected = state.getSelection(Selection.Kind.Gpu);
       List<Highlight> visibleSelected = Lists.newArrayList();
 
       Set<Long> selectedSIds = getSelectedSubmissionIdsInVulkanEventTrack(state);
@@ -286,7 +286,7 @@ public class GpuQueuePanel extends TrackPanel<GpuQueuePanel> implements Selectab
   }
 
   private static Set<Long> getSelectedSubmissionIdsInVulkanEventTrack(State state) {
-    Selection<Long> selection = state.getSelection(Selection.Kind.VulkanEvent);
+    Selection selection = state.getSelection(Selection.Kind.VulkanEvent);
     Set<Long> res = Sets.newHashSet();    // On Vulkan Event Track.
     if (selection instanceof VulkanEventTrack.Slice) {
       res = Sets.newHashSet(((VulkanEventTrack.Slice)selection).submissionId);

--- a/gapic/src/main/com/google/gapid/perfetto/views/GpuQueuePanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/GpuQueuePanel.java
@@ -93,16 +93,18 @@ public class GpuQueuePanel extends TrackPanel<GpuQueuePanel> implements Selectab
       }
 
       TimeSpan visible = state.getVisibleTime();
-      Selection<Slice.Key> selected = state.getSelection(Selection.Kind.Gpu);
+      Selection<Long> selected = state.getSelection(Selection.Kind.Gpu);
       List<Highlight> visibleSelected = Lists.newArrayList();
 
       Set<Long> selectedSIds = getSelectedSubmissionIdsInVulkanEventTrack(state);
       long[] sIds = data.getExtraLongs("submissionIds");
+      String[] concatedIds = data.getExtraStrings("concatedIds");
 
       for (int i = 0; i < data.starts.length; i++) {
         long tStart = data.starts[i];
         long tEnd = data.ends[i];
         int depth = data.depths[i];
+        long id = data.ids[i];
         String title = buildSliceTitle(data.titles[i], data.args[i]);
 
         if (tEnd <= visible.start || tStart >= visible.end) {
@@ -123,9 +125,16 @@ public class GpuQueuePanel extends TrackPanel<GpuQueuePanel> implements Selectab
         ctx.fillRect(rectStart, y, rectWidth, SLICE_HEIGHT);
 
         // Highlight GPU queue slice if it's selected or linked by a vulkan api event.
-        if (selected.contains(new Slice.Key(tStart, tEnd - tStart, depth)) ||
-            (i < sIds.length && selectedSIds.contains(sIds[i]))) {
+        if (selected.contains(id) || (i < sIds.length && selectedSIds.contains(sIds[i]))) { // Unquantized track.
           visibleSelected.add(new Highlight(color.border, rectStart, y, rectWidth));
+        }
+        if (i < concatedIds.length) {                                                       // Quantized track.
+          for (String cId : concatedIds[i].split(",")) {
+            if (selected.contains(Long.parseLong(cId))) {
+              visibleSelected.add(new Highlight(color.border, rectStart, y, rectWidth));
+              break;
+            }
+          }
         }
 
         // Don't render text when we have less than 7px to play with.
@@ -201,6 +210,8 @@ public class GpuQueuePanel extends TrackPanel<GpuQueuePanel> implements Selectab
         mouseYpos = Math.max(0, Math.min(mouseYpos - (hoveredSize.h - SLICE_HEIGHT) / 2,
             (1 + queue.maxDepth) * SLICE_HEIGHT - hoveredSize.h));
         long id = data.ids[i];
+        String concatedId = i < data.getExtraStrings("concatedIds").length ?
+            data.getExtraStrings("concatedIds")[i] : "";
 
         return new Hover() {
           @Override
@@ -216,20 +227,29 @@ public class GpuQueuePanel extends TrackPanel<GpuQueuePanel> implements Selectab
 
           @Override
           public Cursor getCursor(Display display) {
-            return (id < 0) ? null : display.getSystemCursor(SWT.CURSOR_HAND);
+            return (id < 0 && concatedId.isEmpty()) ? null : display.getSystemCursor(SWT.CURSOR_HAND);
           }
 
           @Override
           public boolean click() {
-            if (id < 0) {
-              return false;
+            if (id > 0) { // Track data with no quantization.
+              if ((mods & SWT.MOD1) == SWT.MOD1) {
+                state.addSelection(Selection.Kind.Gpu, track.getSlice(id));
+              } else {
+                state.setSelection(Selection.Kind.Gpu, track.getSlice(id));
+              }
+              return true;
+            } else if (!concatedId.isEmpty()) { // Track data with quantization.
+              if ((mods & SWT.MOD1) == SWT.MOD1) {
+                state.addSelection(Selection.Kind.Gpu, transform(track.getSlices(concatedId),
+                    s -> new SliceTrack.SlicesBuilder(s).build()));
+              } else {
+                state.setSelection(Selection.Kind.Gpu, transform(track.getSlices(concatedId),
+                    s -> new SliceTrack.SlicesBuilder(s).build()));
+              }
+              return true;
             }
-            if ((mods & SWT.MOD1) == SWT.MOD1) {
-              state.addSelection(Selection.Kind.Gpu, track.getSlice(id));
-            } else {
-              state.setSelection(Selection.Kind.Gpu, track.getSlice(id));
-            }
-            return true;
+            return false;
           }
         };
       }

--- a/gapic/src/main/com/google/gapid/perfetto/views/MemorySummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/MemorySummaryPanel.java
@@ -82,7 +82,7 @@ public class MemorySummaryPanel extends TrackPanel<MemorySummaryPanel> implement
         return;
       }
 
-      Selection<Long> selected = state.getSelection(Selection.Kind.Memory);
+      Selection selected = state.getSelection(Selection.Kind.Memory);
       List<Integer> visibleSelected = Lists.newArrayList();
 
       memoryBuffersGradient().applyBase(ctx);

--- a/gapic/src/main/com/google/gapid/perfetto/views/MemorySummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/MemorySummaryPanel.java
@@ -34,6 +34,8 @@ import com.google.gapid.perfetto.models.Selection.CombiningBuilder;
 import com.google.gapid.perfetto.models.Selection.Kind;
 import java.util.List;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Cursor;
+import org.eclipse.swt.widgets.Display;
 
 /**
  * Displays information about the system memory usage.
@@ -203,6 +205,11 @@ public class MemorySummaryPanel extends TrackPanel<MemorySummaryPanel> implement
       @Override
       public void stop() {
         hovered = null;
+      }
+
+      @Override
+      public Cursor getCursor(Display display) {
+        return display.getSystemCursor(SWT.CURSOR_HAND);
       }
 
       @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/MultiSelectionView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/MultiSelectionView.java
@@ -32,12 +32,12 @@ import java.util.Map;
  */
 public class MultiSelectionView extends Composite {
   public MultiSelectionView(
-      Composite parent, Map<Selection.Kind<?>, Selection<?>> selections, State state) {
+      Composite parent, Map<Selection.Kind, Selection> selections, State state) {
     super(parent, SWT.NONE);
     setLayout(new FillLayout());
 
     TabFolder folder = createStandardTabFolder(this);
-    for (Selection<?> s : selections.values()) {
+    for (Selection s : selections.values()) {
       createStandardTabItem(folder, s.getTitle(), s.buildUi(folder, state));
     }
   }

--- a/gapic/src/main/com/google/gapid/perfetto/views/ProcessSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/ProcessSummaryPanel.java
@@ -113,7 +113,7 @@ public class ProcessSummaryPanel extends TrackPanel<ProcessSummaryPanel> impleme
     // TODO: dedupe with CpuRenderer
     long tStart = data.request.range.start;
     int start = Math.max(0, (int)((state.getVisibleTime().start - tStart) / data.bucketSize));
-    Selection<Long> selected = state.getSelection(Selection.Kind.Cpu);
+    Selection selected = state.getSelection(Selection.Kind.Cpu);
     List<Integer> visibleSelected = Lists.newArrayList();
 
     mainGradient().applyBaseAndBorder(ctx);
@@ -166,7 +166,7 @@ public class ProcessSummaryPanel extends TrackPanel<ProcessSummaryPanel> impleme
   private void renderSlices(RenderContext ctx, ProcessSummaryTrack.Data data, double h) {
     // TODO: dedupe with CpuRenderer
     TimeSpan visible = state.getVisibleTime();
-    Selection<Long> selected = state.getSelection(Selection.Kind.Cpu);
+    Selection selected = state.getSelection(Selection.Kind.Cpu);
     List<Highlight> visibleSelected = Lists.newArrayList();
     int cpuCount = state.getCpuInfo().count();
     double cpuH = (h - cpuCount + 1) / cpuCount;

--- a/gapic/src/main/com/google/gapid/perfetto/views/ProcessSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/ProcessSummaryPanel.java
@@ -36,6 +36,7 @@ import com.google.gapid.perfetto.models.Selection;
 import com.google.gapid.perfetto.models.Selection.CombiningBuilder;
 import com.google.gapid.perfetto.models.ThreadInfo;
 
+import com.google.gapid.util.Arrays;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.RGBA;
@@ -126,8 +127,8 @@ public class ProcessSummaryPanel extends TrackPanel<ProcessSummaryPanel> impleme
         path.lineTo(x, y);
         path.lineTo(x, nextY);
         y = nextY;
-        for (String id : data.concatedIds[i].split(",")) {
-          if (!id.isEmpty() && selected.contains(Long.parseLong(id))) {
+        for (String id : Arrays.getOrDefault(data.concatedIds, i, "").split(",")) {
+          if (!id.isEmpty() && !selected.isEmpty() && selected.contains(Long.parseLong(id))) {
             visibleSelected.add(i);
             break;
           }
@@ -298,7 +299,7 @@ public class ProcessSummaryPanel extends TrackPanel<ProcessSummaryPanel> impleme
         data.request.range.start + hovered.bucket * data.bucketSize + data.bucketSize / 2);
     double dx = HOVER_PADDING + hovered.size.w + HOVER_PADDING;
     double dy = height;
-    String ids = data.concatedIds[bucket];
+    String ids = Arrays.getOrDefault(data.concatedIds, bucket, "");
 
     return new Hover() {
       @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/ProcessSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/ProcessSummaryPanel.java
@@ -312,6 +312,11 @@ public class ProcessSummaryPanel extends TrackPanel<ProcessSummaryPanel> impleme
       }
 
       @Override
+      public Cursor getCursor(Display display) {
+        return ids.isEmpty() ? null : display.getSystemCursor(SWT.CURSOR_HAND);
+      }
+
+      @Override
       public boolean click() {
         if (ids.isEmpty()) {
           return false;

--- a/gapic/src/main/com/google/gapid/perfetto/views/State.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/State.java
@@ -130,7 +130,7 @@ public abstract class State {
     return selection;
   }
 
-  public <T> Selection<T> getSelection(Selection.Kind<T> type) {
+  public Selection getSelection(Selection.Kind type) {
     if (selection == null) {
       return Selection.emptySelection();
     } else {
@@ -213,7 +213,7 @@ public abstract class State {
     return hasDeselection;
   }
 
-  public <Key> void addSelection(Selection.Kind<Key> type, ListenableFuture<? extends Selection<Key>> futureSel) {
+  public <Key> void addSelection(Selection.Kind type, ListenableFuture<? extends Selection> futureSel) {
     int myId = lastSelectionUpdateId.incrementAndGet();
     thenOnUiThread(futureSel, newSelection -> {
       if (lastSelectionUpdateId.get() == myId) {
@@ -222,7 +222,7 @@ public abstract class State {
     });
   }
 
-  public <Key> void addSelection(Selection.Kind<Key> type, Selection<Key> newSel) {
+  public <Key> void addSelection(Selection.Kind type, Selection newSel) {
     if (selection == null) {
       setSelection(type, newSel);
     } else {
@@ -245,7 +245,7 @@ public abstract class State {
     });
   }
 
-  public <Key> void setSelection(Selection.Kind<Key> type, ListenableFuture<? extends Selection<Key>> futureSel) {
+  public <Key> void setSelection(Selection.Kind type, ListenableFuture<? extends Selection> futureSel) {
     int myId = lastSelectionUpdateId.incrementAndGet();
     thenOnUiThread(futureSel, newSelection -> {
       if (lastSelectionUpdateId.get() == myId) {
@@ -254,7 +254,7 @@ public abstract class State {
     });
   }
 
-  public <Key> void setSelection(Selection.Kind<Key> type, Selection<Key> selection) {
+  public <Key> void setSelection(Selection.Kind type, Selection selection) {
     setSelection(new Selection.MultiSelection(type, selection));
   }
 

--- a/gapic/src/main/com/google/gapid/perfetto/views/ThreadPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/ThreadPanel.java
@@ -110,8 +110,8 @@ public class ThreadPanel extends TrackPanel<ThreadPanel> implements Selectable {
 
       TimeSpan visible = state.getVisibleTime();
       Selection<Long> selectedCpu = state.getSelection(Selection.Kind.Cpu);
-      Selection<StateSlice.Key> selectedThreadState = state.getSelection(Selection.Kind.ThreadState);
-      Selection<Slice.Key> selectedThread = state.getSelection(Selection.Kind.Thread);
+      Selection<Long> selectedThreadState = state.getSelection(Selection.Kind.ThreadState);
+      Selection<Long> selectedThread = state.getSelection(Selection.Kind.Thread);
       List<Highlight> visibleSelected = Lists.newArrayList();
 
       boolean merging = false;
@@ -178,9 +178,8 @@ public class ThreadPanel extends TrackPanel<ThreadPanel> implements Selectable {
           }
         }
 
-        if (selectedCpu.contains(data.schedIds[i])
-            || selectedThreadState.contains(new StateSlice.Key(data.schedStarts[i],
-                data.schedEnds[i] - data.schedStarts[i], track.getThread().utid))) {
+        if (data.isSched[i] && selectedCpu.contains(data.ids[i])
+            || !data.isSched[i] && selectedThreadState.contains(data.ids[i])) {
           visibleSelected.add(
               new Highlight(data.schedStates[i].color.get().border, rectStart, 0, rectWidth));
         }
@@ -192,10 +191,12 @@ public class ThreadPanel extends TrackPanel<ThreadPanel> implements Selectable {
 
       if (expanded) {
         SliceTrack.Data slices = data.slices;
+        String[] concatedIds = slices.getExtraStrings("concatedIds");
         for (int i = 0; i < slices.starts.length; i++) {
           long tStart = slices.starts[i];
           long tEnd = slices.ends[i];
           int depth = slices.depths[i];
+          long id = slices.ids[i];
           //String cat = data.categories[i];
           String title = slices.titles[i];
           if (tEnd <= visible.start || tStart >= visible.end) {
@@ -209,8 +210,16 @@ public class ThreadPanel extends TrackPanel<ThreadPanel> implements Selectable {
           color.applyBase(ctx);
           ctx.fillRect(rectStart, y, rectWidth, SLICE_HEIGHT);
 
-          if (selectedThread.contains(new Slice.Key(tStart, tEnd - tStart, depth))) {
+          if (selectedThread.contains(id)) { // Unquantized track.
             visibleSelected.add(new Highlight(color.border, rectStart, y, rectWidth));
+          }
+          if (i < concatedIds.length) {      // Quantized track.
+            for (String cId : concatedIds[i].split(",")) {
+              if (selectedThread.contains(Long.parseLong(cId))) {
+                visibleSelected.add(new Highlight(color.border, rectStart, y, rectWidth));
+                break;
+              }
+            }
           }
 
           // Don't render text when we have less than 7px to play with.
@@ -290,12 +299,12 @@ public class ThreadPanel extends TrackPanel<ThreadPanel> implements Selectable {
 
             @Override
             public boolean click() {
-              if (data.schedIds[index] != 0) {
+              if (data.isSched[index]) {
                 if ((mods & SWT.MOD1) == SWT.MOD1) {
-                  state.addSelection(Selection.Kind.Cpu, track.getCpuSlice(data.schedIds[index]));
+                  state.addSelection(Selection.Kind.Cpu, track.getCpuSlice(data.ids[index]));
                   state.addSelectedThread(state.getThreadInfo(track.getThread().utid));
                 } else {
-                  state.setSelection(Selection.Kind.Cpu, track.getCpuSlice(data.schedIds[index]));
+                  state.setSelection(Selection.Kind.Cpu, track.getCpuSlice(data.ids[index]));
                   state.setSelectedThread(state.getThreadInfo(track.getThread().utid));
                 }
               } else {
@@ -303,12 +312,12 @@ public class ThreadPanel extends TrackPanel<ThreadPanel> implements Selectable {
                   state.addSelection(Selection.Kind.ThreadState,
                       new ThreadTrack.StateSlice(data.schedStarts[index],
                           data.schedEnds[index] - data.schedStarts[index], track.getThread().utid,
-                          data.schedStates[index]));
+                          data.isSched[index], data.schedStates[index], data.ids[index]));
                 } else {
                   state.setSelection(Selection.Kind.ThreadState,
                       new ThreadTrack.StateSlice(data.schedStarts[index],
                           data.schedEnds[index] - data.schedStarts[index], track.getThread().utid,
-                          data.schedStates[index]));
+                          data.isSched[index], data.schedStates[index], data.ids[index]));
                 }
               }
               return true;
@@ -337,6 +346,8 @@ public class ThreadPanel extends TrackPanel<ThreadPanel> implements Selectable {
           mouseYpos = Math.max(0, Math.min(mouseYpos - (hoveredSize.h - SLICE_HEIGHT) / 2,
               (1 + track.getThread().maxDepth) * SLICE_HEIGHT - hoveredSize.h));
           long id = slices.ids[i];
+          String concatedId = i < slices.getExtraStrings("concatedIds").length ?
+              slices.getExtraStrings("concatedIds")[i] : "";
 
           return new Hover() {
             @Override
@@ -352,20 +363,29 @@ public class ThreadPanel extends TrackPanel<ThreadPanel> implements Selectable {
 
             @Override
             public Cursor getCursor(Display display) {
-              return (id < 0) ? null : display.getSystemCursor(SWT.CURSOR_HAND);
+              return (id < 0 && concatedId.isEmpty()) ? null : display.getSystemCursor(SWT.CURSOR_HAND);
             }
 
             @Override
             public boolean click() {
-              if (id < 0) {
-                return false;
+              if (id > 0) { // Track data with no quantization.
+                if ((mods & SWT.MOD1) == SWT.MOD1) {
+                  state.addSelection(Selection.Kind.Thread, track.getSlice(id));
+                } else {
+                  state.setSelection(Selection.Kind.Thread, track.getSlice(id));
+                }
+                return true;
+              } else if (!concatedId.isEmpty()) { // Track data with quantization.
+                if ((mods & SWT.MOD1) == SWT.MOD1) {
+                  state.addSelection(Selection.Kind.Thread, transform(track.getSlices(concatedId),
+                      s -> new SliceTrack.SlicesBuilder(s).build()));
+                } else {
+                  state.setSelection(Selection.Kind.Thread, transform(track.getSlices(concatedId),
+                      s -> new SliceTrack.SlicesBuilder(s).build()));
+                }
+                return true;
               }
-              if ((mods & SWT.MOD1) == SWT.MOD1) {
-                state.addSelection(Selection.Kind.Thread, track.getSlice(id));
-              } else {
-                state.setSelection(Selection.Kind.Thread, track.getSlice(id));
-              }
-              return true;
+              return false;
             }
           };
         }

--- a/gapic/src/main/com/google/gapid/perfetto/views/ThreadPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/ThreadPanel.java
@@ -109,9 +109,9 @@ public class ThreadPanel extends TrackPanel<ThreadPanel> implements Selectable {
       }
 
       TimeSpan visible = state.getVisibleTime();
-      Selection<Long> selectedCpu = state.getSelection(Selection.Kind.Cpu);
-      Selection<Long> selectedThreadState = state.getSelection(Selection.Kind.ThreadState);
-      Selection<Long> selectedThread = state.getSelection(Selection.Kind.Thread);
+      Selection selectedCpu = state.getSelection(Selection.Kind.Cpu);
+      Selection selectedThreadState = state.getSelection(Selection.Kind.ThreadState);
+      Selection selectedThread = state.getSelection(Selection.Kind.Thread);
       List<Highlight> visibleSelected = Lists.newArrayList();
 
       boolean merging = false;

--- a/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventPanel.java
@@ -88,7 +88,7 @@ public class VulkanEventPanel extends TrackPanel<VulkanEventPanel> implements Se
       }
 
       TimeSpan visible = state.getVisibleTime();
-      Selection<Long> selected = state.getSelection(Selection.Kind.VulkanEvent);
+      Selection selected = state.getSelection(Selection.Kind.VulkanEvent);
       List<Integer> visibleSelected = Lists.newArrayList();
 
       for (int i = 0; i < data.starts.length; i++) {

--- a/gapic/src/main/com/google/gapid/util/Arrays.java
+++ b/gapic/src/main/com/google/gapid/util/Arrays.java
@@ -25,4 +25,8 @@ public class Arrays {
   public static <T> T last(T[] array) {
     return (array == null || array.length == 0) ? null : array[array.length - 1];
   }
+
+  public static <T> T getOrDefault(T[] array, int idx, T dflt) {
+    return array == null || idx >= array.length ? dflt : array[idx];
+  }
 }

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -1305,12 +1305,13 @@ message ProfilingData {
 
       uint64 ts = 1;
       uint64 dur = 2;
-      string label = 3;
-      int32 depth = 4;
-      repeated Extra extras = 5;
+      uint64 id = 3;
+      string label = 4;
+      int32 depth = 5;
+      repeated Extra extras = 6;
 
-      int32 trackId = 6;  // references Track.id
-      int32 groupId = 7;  // references Group.id
+      int32 trackId = 7;  // references Track.id
+      int32 groupId = 8;  // references Group.id
     }
 
     message Track {

--- a/gapis/trace/android/adreno/profiling_data.go
+++ b/gapis/trace/android/adreno/profiling_data.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	slicesQuery = "" +
-		"SELECT s.context_id, s.render_target, s.frame_id, s.submission_id, s.hw_queue_id, s.command_buffer, s.render_pass, s.ts, s.dur, s.name, depth, arg_set_id, track_id, t.name " +
+		"SELECT s.context_id, s.render_target, s.frame_id, s.submission_id, s.hw_queue_id, s.command_buffer, s.render_pass, s.ts, s.dur, s.id, s.name, depth, arg_set_id, track_id, t.name " +
 		"FROM gpu_track t LEFT JOIN gpu_slice s " +
 		"ON s.track_id = t.id WHERE t.scope = 'gpu_render_stage' ORDER BY s.ts"
 	argsQueryFmt = "" +
@@ -124,11 +124,12 @@ func processGpuSlices(ctx context.Context, processor *perfetto.Processor, captur
 	hwQueueIds := slicesColumns[4].GetLongValues()
 	timestamps := slicesColumns[7].GetLongValues()
 	durations := slicesColumns[8].GetLongValues()
-	names := slicesColumns[9].GetStringValues()
-	depths := slicesColumns[10].GetLongValues()
-	argSetIds := slicesColumns[11].GetLongValues()
-	trackIds := slicesColumns[12].GetLongValues()
-	trackNames := slicesColumns[13].GetStringValues()
+	ids := slicesColumns[9].GetLongValues()
+	names := slicesColumns[10].GetStringValues()
+	depths := slicesColumns[11].GetLongValues()
+	argSetIds := slicesColumns[12].GetLongValues()
+	trackIds := slicesColumns[13].GetLongValues()
+	trackNames := slicesColumns[14].GetStringValues()
 
 	subCommandGroupMap := make(map[api.CmdSubmissionKey]int)
 	for i, v := range submissionIds {
@@ -219,6 +220,7 @@ func processGpuSlices(ctx context.Context, processor *perfetto.Processor, captur
 		slices[i] = &service.ProfilingData_GpuSlices_Slice{
 			Ts:      uint64(timestamps[i]),
 			Dur:     uint64(durations[i]),
+			Id:      uint64(ids[i]),
 			Label:   names[i],
 			Depth:   int32(depths[i]),
 			Extras:  extras,


### PR DESCRIPTION
 - When time quantization happens, still support selection behavior for Frame Event Panel, GPU Queue Panel and Thread Panel.
- Query and use id as the selection key, rather than combine ts, dur and other entries together to act as a key.
- Remove key type generics in selection framework.
- Change mouse cursor to hand whenever it's a clickable area.
- Show the full frame event tile at hovering.
- Fix the zero duration frame event signal's zooming/highlighting problem.
- Bug: http://b/147922469. #1.