### PR TITLE
Make sure we don't drop the DocumentOpen events.

### DIFF
--- a/gapic/src/main/com/google/gapid/Main.java
+++ b/gapic/src/main/com/google/gapid/Main.java
@@ -35,7 +35,9 @@ import com.google.gapid.util.ExceptionHandler;
 import com.google.gapid.util.Flags;
 import com.google.gapid.util.Flags.Flag;
 import com.google.gapid.util.Logging;
+import com.google.gapid.util.MacApplication;
 import com.google.gapid.util.Messages;
+import com.google.gapid.util.OS;
 import com.google.gapid.util.Scheduler;
 import com.google.gapid.views.TracerDialog;
 import com.google.gapid.widgets.Theme;
@@ -65,6 +67,10 @@ public class Main {
     Settings settings = Settings.load();
     Theme theme = Theme.load(Display.getDefault());
     ExceptionHandler handler = Crash2ExceptionHandler.register(settings);
+
+    if (OS.isMac) {
+      MacApplication.listenForOpenDocument(Display.getDefault());
+    }
 
     try {
       new UI(settings, theme, handler, args).show();

--- a/gapic/src/main/com/google/gapid/util/MacApplication.java
+++ b/gapic/src/main/com/google/gapid/util/MacApplication.java
@@ -15,25 +15,44 @@
  */
 package com.google.gapid.util;
 
+import static java.util.logging.Level.INFO;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 
 import java.util.function.Consumer;
+import java.util.logging.Logger;
 
 /**
  * Special handling for OSX application menus.
  */
 public class MacApplication {
+  private static final Logger LOG = Logger.getLogger(MacApplication.class.getName());
+
+  private static Consumer<String> onOpen = null;
+  private static String documentToOpen;
+
   private MacApplication() {
+  }
+
+  public static void listenForOpenDocument(Display display) {
+    display.addListener(SWT.OpenDocument, e -> {
+      LOG.log(INFO, "OpenDocument Event: " + e);
+      if (onOpen != null) {
+        onOpen.accept(e.text);
+      } else {
+        documentToOpen = e.text;
+      }
+    });
   }
 
   /**
    * Initializes the OSX application menus.
    */
   public static void init(
-      Display display, Runnable onAbout, Runnable onSettings, Consumer<String> onOpen) {
+      Display display, Runnable onAbout, Runnable onSettings, Consumer<String> newOnOpen) {
     Menu menu = display.getSystemMenu();
     if (menu == null) {
       return;
@@ -50,6 +69,9 @@ public class MacApplication {
       }
     }
 
-    display.addListener(SWT.OpenDocument, e -> onOpen.accept(e.text));
+    onOpen = newOnOpen;
+    if (documentToOpen != null) {
+      onOpen.accept(documentToOpen);
+    }
   }
 }


### PR DESCRIPTION
Listen for the DocumentOpen event as soon as possible, so we don't miss any. If one is received, while we are still starting up, simply remember the file to open and open it as soon as we are ready.