### PR TITLE
Add Mali counters for validation.

### DIFF
--- a/gapis/trace/android/mali/validate.go
+++ b/gapis/trace/android/mali/validate.go
@@ -23,7 +23,16 @@ import (
 
 var (
 	// All counters must be inside this array.
-	counters = []validate.GpuCounter{}
+	counters = []validate.GpuCounter{
+		{6, "GPU active cycles", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
+		{8, "Fragment jobs", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
+		{196, "Fragment active cycles", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
+		{233, "Compressed texture line fetch requests", validate.And(validate.IsNumber, validate.CheckEqualTo(0.0))},
+		{65536, "GPU utilization", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
+		{65538, "Fragment queue utilization", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
+		{65579, "Execution core utilization", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
+		{65585, "Texture data fetches form compressed lines", validate.And(validate.IsNumber, validate.CheckEqualTo(0.0))},
+	}
 )
 
 type MaliValidator struct {

--- a/gapis/trace/android/validate/validate.go
+++ b/gapis/trace/android/validate/validate.go
@@ -156,7 +156,7 @@ func ValidateGpuCounters(ctx context.Context, processor *perfetto.Processor, cou
 			longValues := column.GetLongValues()
 			if len(longValues) != 1 {
 				// This should never happen, but sill have a check.
-				return log.Err(ctx, nil, "Query result is not 1.")
+				return log.Errf(ctx, nil, "Query result is not 1: %v", counter)
 			}
 			counterID = longValues[0]
 			break


### PR DESCRIPTION
Add several Mali counters into validation. Provide counter information when
validation fails.

Bug: b/149346641
Test: bazel run gapit -- validate_gpu_profiling --os android