### PR TITLE
Update "Goto Command" to support following a .-delimited subcommand 

### DIFF
--- a/gapic/src/main/com/google/gapid/views/GotoCommand.java
+++ b/gapic/src/main/com/google/gapid/views/GotoCommand.java
@@ -17,7 +17,7 @@ package com.google.gapid.views;
 
 import static com.google.gapid.widgets.Widgets.createComposite;
 import static com.google.gapid.widgets.Widgets.createLabel;
-import static com.google.gapid.widgets.Widgets.createSpinner;
+import static com.google.gapid.widgets.Widgets.createTextbox;
 
 import com.google.gapid.models.Analytics.View;
 import com.google.gapid.models.CommandStream;
@@ -36,7 +36,9 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.swt.widgets.Spinner;
+import org.eclipse.swt.widgets.Text;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Dialog for the goto command action.
@@ -50,7 +52,7 @@ public class GotoCommand {
     GotoDialog dialog = new GotoDialog(shell, models.commands);
     if (dialog.open() == Window.OK) {
       models.commands.selectCommands(CommandIndex.forCommand(Path.Command.newBuilder()
-          .addIndices(dialog.value)
+          .addAllIndices(dialog.value)
           .setCapture(models.capture.getData().path)
           .build()), true);
     }
@@ -61,8 +63,8 @@ public class GotoCommand {
    */
   private static class GotoDialog extends MessageDialog {
     private final CommandStream commands;
-    private Spinner spinner;
-    public int value;
+    private Text text;
+    public List<Long> value;
 
     public GotoDialog(Shell shell, CommandStream commands) {
       super(shell, Messages.GOTO, null, Messages.GOTO_COMMAND, MessageDialog.CONFIRM, 0,
@@ -77,26 +79,22 @@ public class GotoCommand {
 
     @Override
     protected Control createCustomArea(Composite parent) {
-      // Although the command ID is a long, we currently only actually support the int range, as
-      // the commands are stored in an array. So, using an int spinner here is fine.
-      //TODO limit to max commands
-      int max = Integer.MAX_VALUE;
-      CommandIndex selection = commands.getSelectedCommands();
-      int current = (selection == null) ? 0 : 0 /*TODO(int)last(selection)*/;
-
       Composite container = createComposite(parent, new GridLayout(2, false));
       container.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
       createLabel(container, Messages.COMMAND_ID + ":");
-      spinner = createSpinner(container, current, 0, max);
-      spinner.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+      text = createTextbox(container, "");
+      text.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 
       return container;
     }
 
     @Override
     protected void buttonPressed(int buttonId) {
-      // The spinner gets disposed after this.
-      value = spinner.getSelection();
+      String[] strings = text.getText().split("\\.");
+      value = new ArrayList<Long>();
+      for (String s : strings) {
+        value.add(Long.parseLong(s));
+      }
       super.buttonPressed(buttonId);
     }
   }

--- a/gapis/api/sync/BUILD.bazel
+++ b/gapis/api/sync/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//core/app/status:go_default_library",
+        "//core/log:go_default_library",
         "//gapis/api:go_default_library",
         "//gapis/api/transform:go_default_library",
         "//gapis/capture:go_default_library",

--- a/gapis/api/sync/sync.go
+++ b/gapis/api/sync/sync.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 
 	"github.com/google/gapid/core/app/status"
+	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/api/transform"
 	"github.com/google/gapid/gapis/capture"
@@ -109,6 +110,8 @@ func MutationCmdsFor(ctx context.Context, c *path.Capture, data *Data, cmds []ap
 	lastCmd := cmds[len(cmds)-1]
 	if api.CmdID(len(cmds)) > id {
 		lastCmd = cmds[id]
+	} else {
+		return nil, log.Errf(ctx, nil, "Requested CmdID %v exceeds range of commands", id)
 	}
 
 	if sync, ok := lastCmd.API().(SynchronizedAPI); ok {

--- a/gapis/api/vulkan/vulkan_terminator.go
+++ b/gapis/api/vulkan/vulkan_terminator.go
@@ -399,7 +399,7 @@ func (t *VulkanTerminator) Transform(ctx context.Context, id api.CmdID, cmd api.
 	// then do that instead of cutting at the derived cutIndex.
 	// It is guaranteed to be safe as long as the requestedSubIndex is
 	// less than the calculated one (i.e. we are cutting more)
-	if len(t.requestSubIndex) > 1 && t.requestSubIndex[0] == uint64(id) {
+	if len(t.requestSubIndex) > 1 && t.requestSubIndex[0] == uint64(id) && t.syncData.SubcommandLookup.Value(t.requestSubIndex) != nil {
 		if len(cutIndex) == 0 || !cutIndex.LessThan(t.requestSubIndex[1:]) {
 			cutIndex = t.requestSubIndex[1:]
 			doCut = true


### PR DESCRIPTION
Update CommandTreeNodeForCommand to generate a full node index for a
full SubCmdIdx.  Also adds sanity checks to the input logic that
disables the "OK" button and presents an error message upon invalid
input.