### PR TITLE
(gapid cherry-pick) Make SXS video work with PNG output.

### DIFF
--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -26,6 +26,7 @@ const (
 	SxsVideo
 	RegularVideo
 	IndividualFrames
+	SxsFrames
 )
 
 const (
@@ -62,6 +63,7 @@ var videoTypeNames = map[VideoType]string{
 	SxsVideo:         "sxs",
 	RegularVideo:     "regular",
 	IndividualFrames: "frames",
+	SxsFrames:        "sxs-frames",
 }
 
 func (v *VideoType) Choose(c interface{}) {

--- a/cmd/gapit/sxs_video.go
+++ b/cmd/gapit/sxs_video.go
@@ -224,7 +224,7 @@ func (verb *videoVerb) sxsVideoSource(
 		//    ┃                ┃   Histogram   ┃
 		//    ┃                ┣━━━━━━━━━━━━━━━┫ p7
 		//    ┗━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┛
-		//                     p6
+		//                     p6                p8
 		var histogramHeight int
 		if histogram != nil {
 			histogramHeight = histogram.Bounds().Dy()
@@ -234,8 +234,10 @@ func (verb *videoVerb) sxsVideoSource(
 		p5 := image.Pt(w+2, h+200)
 		p6 := image.Pt(w, h*2)
 		p7 := image.Pt(w*2, p5.Y+histogramHeight)
+		p8 := image.Pt(w*2, h*2)
 
 		white := &image.Uniform{C: color.White}
+		black := &image.Uniform{C: color.Black}
 		rect := func(min, max image.Point) image.Rectangle {
 			return image.Rectangle{Min: min, Max: max}
 		}
@@ -262,6 +264,7 @@ func (verb *videoVerb) sxsVideoSource(
 				draw.Draw(sxs, rect(p2, p6), d, image.ZP, draw.Src)
 			}
 
+			draw.Draw(sxs, rect(p3, p8), black, image.ZP, draw.Src)
 			// Histogram
 			if h := histogram; h != nil {
 				draw.Draw(sxs, rect(p5, p7), histogram, image.ZP, draw.Src)
@@ -347,6 +350,11 @@ func getHistogram(videoFrames []*videoFrame) *image.NRGBA {
 
 	pixels := make([]byte, w*h*4)
 	out := &image.NRGBA{Pix: pixels, Stride: w * 4, Rect: image.Rect(0, 0, w, h)}
+	for i := range pixels {
+		if i%4 == 3 {
+			pixels[i] = 255
+		}
+	}
 
 	// Layout into RGBA32 bitmap.
 	f32s := make([]float32, bins*w)

--- a/cmd/gapit/video.go
+++ b/cmd/gapit/video.go
@@ -228,12 +228,18 @@ func (verb *videoVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	case RegularVideo:
 		vidSrc = verb.regularVideoSource
 		vidOut = verb.encodeVideo
+	case SxsFrames:
+		fallthrough
 	case SxsVideo:
 		if len(fboEvents) == 0 {
 			return fmt.Errorf("Capture does not contain framebuffer observations")
 		}
 		vidSrc = verb.sxsVideoSource
-		vidOut = verb.encodeVideo
+		if verb.Type == SxsFrames {
+			vidOut = verb.writeFrames
+		} else {
+			vidOut = verb.encodeVideo
+		}
 	case AutoVideo:
 		if len(fboEvents) > 0 {
 			vidSrc = verb.sxsVideoSource


### PR DESCRIPTION
This adds sxs-frames which will output to PNG.
It also blackens out the historgram background,
since unlike video, PNG respects alpha.