### PR TITLE
vkUnmap memory of gapii staging buffer

### DIFF
--- a/gapii/cc/vulkan_mid_execution.cpp
+++ b/gapii/cc/vulkan_mid_execution.cpp
@@ -193,6 +193,9 @@ class StagingBuffer {
       device_functions_.vkDestroyBuffer(device_, staging_buffer_, nullptr);
     }
     if (staging_memory_) {
+      if (bound_memory_) {
+        device_functions_.vkUnmapMemory(device_, staging_memory_);
+      }
       device_functions_.vkFreeMemory(device_, staging_memory_, nullptr);
     }
   }

--- a/gapii/cc/vulkan_mid_execution.cpp
+++ b/gapii/cc/vulkan_mid_execution.cpp
@@ -197,9 +197,9 @@ class StagingBuffer {
       // Driver bug workaround: explicitely unmap memory before vkFreeMemory().
       // https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkFreeMemory.html
       // The vkFreeMemory spec says "If a memory object is mapped at the time
-      // it is freed, it is implicitly unmapped". Yet some driver seem to
-      // leak the memory, unless it is explicitely unmaped. Hence our call to
-      // vkUnmapMemory() here.
+      // it is freed, it is implicitly unmapped". Yet some drivers seem to
+      // leak the memory, unless it is explicitely unmapped. Hence our call
+      // to vkUnmapMemory() here.
       if (bound_memory_) {
         device_functions_.vkUnmapMemory(device_, staging_memory_);
       }

--- a/gapii/cc/vulkan_mid_execution.cpp
+++ b/gapii/cc/vulkan_mid_execution.cpp
@@ -193,6 +193,13 @@ class StagingBuffer {
       device_functions_.vkDestroyBuffer(device_, staging_buffer_, nullptr);
     }
     if (staging_memory_) {
+      // TODO(b/151157266): Remove this workaround once b/151157266 is fixed.
+      // Driver bug workaround: explicitely unmap memory before vkFreeMemory().
+      // https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkFreeMemory.html
+      // The vkFreeMemory spec says "If a memory object is mapped at the time
+      // it is freed, it is implicitly unmapped". Yet some driver seem to
+      // leak the memory, unless it is explicitely unmaped. Hence our call to
+      // vkUnmapMemory() here.
       if (bound_memory_) {
         device_functions_.vkUnmapMemory(device_, staging_memory_);
       }


### PR DESCRIPTION
Adding this vkUnmap removes what look like a memory leak during capture.

The spec for vkFreeMemory says:

> If a memory object is mapped at the time it is freed, it is implicitly unmapped.

So this unmap may not be strictly necessary. Yet it does fix a memory explosion
issue for a particular title, on two GPU vendors.
