### PR TITLE
Separate vk debug marker layer from cpu timing layer

### DIFF
--- a/core/app/layout/layout.go
+++ b/core/app/layout/layout.go
@@ -40,6 +40,7 @@ const (
 	LibGraphicsSpy LibraryType = iota
 	LibVirtualSwapChain
 	LibCPUTiming
+	LibDebugMarker
 	LibMemoryTracker
 )
 
@@ -78,12 +79,14 @@ var libTypeToName = map[LibraryType]string{
 	LibGraphicsSpy:      "libgapii",
 	LibVirtualSwapChain: "libVkLayer_VirtualSwapchain",
 	LibCPUTiming:        "libVkLayer_CPUTiming",
+	LibDebugMarker:      "libVkLayer_DebugMarker",
 	LibMemoryTracker:    "libVkLayer_MemoryTracker",
 }
 
 var layerNameToLibType = map[string]LibraryType{
 	"VirtualSwapchain": LibVirtualSwapChain,
 	"CPUTiming":        LibCPUTiming,
+	"DebugMarker":      LibDebugMarker,
 	"MemoryTracker":    LibMemoryTracker,
 }
 
@@ -91,7 +94,7 @@ var dataSourceNameToLayerName = map[string]string{
 	"VirtualSwapchain":    "VirtualSwapchain",
 	"VulkanCPUTiming":     "CPUTiming",
 	"VulkanMemoryTracker": "MemoryTracker",
-	"VulkanAPI":           "CPUTiming",
+	"VulkanAPI":           "DebugMarker",
 }
 
 var libTypeToJson = map[LibraryType]string{
@@ -99,6 +102,7 @@ var libTypeToJson = map[LibraryType]string{
 	LibVirtualSwapChain: "VirtualSwapchainLayer.json",
 	LibCPUTiming:        "CPUTimingLayer.json",
 	LibMemoryTracker:    "MemoryTrackerLayer.json",
+	LibDebugMarker:      "DebugMarker.json",
 }
 
 func withLibraryPlatformSuffix(lib string, os device.OSKind) string {
@@ -266,6 +270,7 @@ var libTypeToLibPath = map[LibraryType]string{
 	LibGraphicsSpy:      "gapid/gapii/cc/libgapii",
 	LibVirtualSwapChain: "gapid/core/vulkan/vk_virtual_swapchain/cc/libVkLayer_VirtualSwapchain",
 	LibCPUTiming:        "gapid/core/vulkan/vk_api_timing_layer/cc/libVkLayer_CPUTiming",
+	LibDebugMarker:      "gapid/core/vulkan/vk_api_timing_layer/cc/libVkLayer_DebugMarker",
 	LibMemoryTracker:    "gapid/core/vulkan/vk_memory_tracker_layer/cc/libVkLayer_MemoryTracker",
 }
 
@@ -273,6 +278,7 @@ var libTypeToJsonPath = map[LibraryType]string{
 	LibGraphicsSpy:      "gapid/gapii/vulkan/vk_graphics_spy/cc/GraphicsSpyLayer.json",
 	LibVirtualSwapChain: "gapid/core/vulkan/vk_virtual_swapchain/cc/VirtualSwapchainLayer.json",
 	LibCPUTiming:        "gapid/core/vulkan/vk_api_timing_layer/cc/CPUTimingLayer.json",
+	LibDebugMarker:      "gapid/core/vulkan/vk_api_timing_layer/cc/DebugMarkerLayer.json",
 	LibMemoryTracker:    "gapid/core/vulkan/vk_memory_tracker_layer/cc/MemoryTrackerLayer.json",
 }
 

--- a/core/vulkan/vk_api_timing_layer/cc/timing_layer.tmpl
+++ b/core/vulkan/vk_api_timing_layer/cc/timing_layer.tmpl
@@ -18,49 +18,6 @@
 {{Global "Vulkan.LayerName" "CPUTiming"}}
 {{Global "Vulkan.LayerDescription" "Vulkan API CPU Call Timing"}}
 
-{{define "DEBUG_UTILS_FUNCTIONS"}}
-vkSetDebugUtilsObjectNameEXT
-vkSetDebugUtilsObjectTagEXT
-vkQueueBeginDebugUtilsLabelEXT
-vkQueueEndDebugUtilsLabelEXT
-vkQueueInsertDebugUtilsLabelEXT
-vkCmdBeginDebugUtilsLabelEXT
-vkCmdEndDebugUtilsLabelEXT
-vkCmdInsertDebugUtilsLabelEXT
-vkCreateDebugUtilsMessengerEXT
-vkDestroyDebugUtilsMessengerEXT
-vkSubmitDebugUtilsMessageEXT
-{{end}}
-
-{{define "IS_DEBUG_UTILS_FUNCTIONS"}}
-  {{$filters := Strings (Macro "DEBUG_UTILS_FUNCTIONS") | SplitEOL}}
-  {{range $f := $filters}}
-    {{if eq $.Name $f}}true{{end}}
-  {{end}}
-{{end}}
-
-{{define "DEBUG_MARKER_FUNCTIONS"}}
-vkDebugMarkerSetObjectTagEXT
-vkDebugMarkerSetObjectNameEXT
-vkCmdDebugMarkerBeginEXT
-vkCmdDebugMarkerEndEXT
-vkCmdDebugMarkerInsertEXT
-{{end}}
-
-{{define "ALL_DEBUG_FUNCTIONS"}}
- {{Macro "DEBUG_MARKER_FUNCTIONS"}}
- {{Macro "DEBUG_UTILS_FUNCTIONS"}}
-{{end}}
-
-{{define "IS_DEBUG_MARKER_FUNCTIONS"}}
-  {{$filters := Strings (Macro "DEBUG_MARKER_FUNCTIONS") | SplitEOL}}
-  {{range $f := $filters}}
-    {{if eq $.Name $f}}true{{end}}
-  {{end}}
-{{end}}
-
-{{Global "Vulkan.ImplementedFunctions" (Strings (Macro "ALL_DEBUG_FUNCTIONS") | SplitEOL)}}
-
 {{Include "../../../../gapis/api/vulkan/templates/vulkan_layer.tmpl"}}
 
 {{$ | Macro "layer_impl.cpp" | Reflow 4 | Write "layer_impl.cpp"}}
@@ -70,11 +27,10 @@ vkCmdDebugMarkerInsertEXT
 {{Template "C++.Copyright"}}
 #include "core/vulkan/vk_api_timing_layer/cc/layer.h"
 #include "core/vulkan/vk_api_timing_layer/cc/tracing_helpers.h"
-#include "core/vulkan/vk_api_timing_layer/cc/vk_api_emitter.h"
 #include "core/cc/timer.h"
 #include <cinttypes>
 
-namespace api_timing {
+namespace {{(Global "Vulkan.LayerNamespace")}} {
 
 struct timer {
     timer(const char* category, const char* name):
@@ -87,13 +43,9 @@ struct timer {
     const char* cat;
 };
 
-static bool debug_utils_ext_supported = false;
-static bool debug_marker_ext_supported = false;
-
 {{range $c := AllCommands $}}
 {{$ind := Title (Macro "InitialIndirection" $c)}}
 {{if and (not (GetAnnotation $c "pfn")) (not (GetAnnotation $c "synthetic"))}}
-{{if and (not (Macro "IS_DEBUG_UTILS_FUNCTIONS" $c)) (not (Macro "IS_DEBUG_MARKER_FUNCTIONS" $c)) (not (eq $c.Name "vkEnumerateInstanceExtensionProperties")) (not (eq $c.Name "vkEnumerateDeviceExtensionProperties"))}}
 {{Template "BeginPlatformIfDef" $c}}
 {{Template "C++.BaseType" $c.Return.Type}} {{$c.Name}}(PFN_{{$c.Name}} next, {{Macro "C++.BaseCallParameters" $c | JoinWith ", "}}) {
     timer t("{{$ind}}", "{{$c.Name}}");
@@ -101,232 +53,8 @@ static bool debug_marker_ext_supported = false;
 }
 {{Template "EndPlatformIfDef" $c}}
 
-{{else}}
-
-// Since this layer is declaring the debug extensions are implemented, we need to also implement
-// all functions in the extension, but we need to be careful not to forward the function call if
-// the extension was not implemented.
-{{if and (Macro "IS_DEBUG_UTILS_FUNCTIONS" $c)  (not (eq $c.Name "vkSetDebugUtilsObjectNameEXT"))}}
-{{Template "BeginPlatformIfDef" $c}}
-{{Template "C++.BaseType" $c.Return.Type}} {{$c.Name}}(PFN_{{$c.Name}} next, {{Macro "C++.BaseCallParameters" $c | JoinWith ", "}}) {
-    timer t("{{$ind}}", "{{$c.Name}}");
-
-{{if not (IsVoid $c.Return.Type)}}
-    return debug_utils_ext_supported ? next({{Template "C++.CallArguments" $c}}) : VK_SUCCESS;
-{{else}}
-    if (debug_utils_ext_supported) {
-        next({{Template "C++.CallArguments" $c}});
-    }
-{{end}}
-}
-{{Template "EndPlatformIfDef" $c}}
-{{end}}
-{{if and (Macro "IS_DEBUG_MARKER_FUNCTIONS" $c) (not (eq $c.Name "vkDebugMarkerSetObjectNameEXT"))}}
-{{Template "BeginPlatformIfDef" $c}}
-{{Template "C++.BaseType" $c.Return.Type}} {{$c.Name}}(PFN_{{$c.Name}} next, {{Macro "C++.BaseCallParameters" $c | JoinWith ", "}}) {
-    timer t("{{$ind}}", "{{$c.Name}}");
-
-{{if not (IsVoid $c.Return.Type)}}
-    return debug_marker_ext_supported ? next({{Template "C++.CallArguments" $c}}) : VK_SUCCESS;
-{{else}}
-    if (debug_marker_ext_supported) {
-        next({{Template "C++.CallArguments" $c}});
-    }
-{{end}}
-}
-{{Template "EndPlatformIfDef" $c}}
-{{end}}
-
-{{end}}
 {{end}}
 {{end}}
 
-
-// Maps VkDebugReportObjectTypeEXT to VkObjectType.
-VkObjectType getVkObjectType(VkDebugReportObjectTypeEXT vk_debug_report_object_type) {
-#define CASE(OBJ)                               \
-  case VK_DEBUG_REPORT_OBJECT_TYPE_##OBJ##_EXT: \
-    return VK_OBJECT_TYPE_##OBJ
-
-  switch (vk_debug_report_object_type) {
-    CASE(UNKNOWN);
-    CASE(INSTANCE);
-    CASE(PHYSICAL_DEVICE);
-    CASE(DEVICE);
-    CASE(QUEUE);
-    CASE(SEMAPHORE);
-    CASE(COMMAND_BUFFER);
-    CASE(FENCE);
-    CASE(DEVICE_MEMORY);
-    CASE(BUFFER);
-    CASE(IMAGE);
-    CASE(EVENT);
-    CASE(QUERY_POOL);
-    CASE(BUFFER_VIEW);
-    CASE(IMAGE_VIEW);
-    CASE(SHADER_MODULE);
-    CASE(PIPELINE_CACHE);
-    CASE(PIPELINE_LAYOUT);
-    CASE(RENDER_PASS);
-    CASE(PIPELINE);
-    CASE(DESCRIPTOR_SET_LAYOUT);
-    CASE(SAMPLER);
-    CASE(DESCRIPTOR_POOL);
-    CASE(DESCRIPTOR_SET);
-    CASE(FRAMEBUFFER);
-    CASE(COMMAND_POOL);
-    CASE(SURFACE_KHR);
-    CASE(SWAPCHAIN_KHR);
-    CASE(DEBUG_REPORT_CALLBACK_EXT);
-    CASE(DISPLAY_KHR);
-    CASE(DISPLAY_MODE_KHR);
-    CASE(OBJECT_TABLE_NVX);
-    CASE(INDIRECT_COMMANDS_LAYOUT_NVX);
-    CASE(VALIDATION_CACHE_EXT);
-    CASE(SAMPLER_YCBCR_CONVERSION);
-    CASE(DESCRIPTOR_UPDATE_TEMPLATE);
-    CASE(ACCELERATION_STRUCTURE_NV);
-    default:
-      return VK_OBJECT_TYPE_UNKNOWN;
-  }
-#undef CASE
-}
-
-VkResult vkSetDebugUtilsObjectNameEXT(
-        PFN_vkSetDebugUtilsObjectNameEXT     next,
-        VkDevice                             device,
-        const VkDebugUtilsObjectNameInfoEXT* pNameInfo) {
-    timer t("VkDevice", "vkSetDebugUtilsObjectNameEXT");
-
-    api_timing::VkApiEmit().EmitDebugUtilsObjectName(
-            reinterpret_cast<uint64_t>(device), pNameInfo->objectType, pNameInfo->objectHandle, pNameInfo->pObjectName);
-
-    // Must not forward function call if the extension was not supported.
-    return debug_utils_ext_supported ? next(device, pNameInfo) : VK_SUCCESS;
-}
-
-VkResult vkDebugMarkerSetObjectNameEXT(
-        PFN_vkDebugMarkerSetObjectNameEXT     next,
-        VkDevice                              device,
-        VkDebugMarkerObjectNameInfoEXT const* pNameInfo) {
-    timer t("VkDevice", "vkDebugMarkerSetObjectNameEXT");
-
-    // Convert object type to VkObjectType and emit the trace.
-    api_timing::VkApiEmit().EmitDebugUtilsObjectName(
-            reinterpret_cast<uint64_t>(device), getVkObjectType(pNameInfo->objectType), pNameInfo->object, pNameInfo->pObjectName);
-
-    // Must not forward function call if the extension was not supported.
-    return debug_marker_ext_supported ? next(device, pNameInfo) : VK_SUCCESS;
-}
-
-
-namespace {
-
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
-
-const char* LAYER_NAME = "CPUTiming";
-const VkExtensionProperties INSTANCE_EXTENSIONS[] = {
-    {VK_EXT_DEBUG_UTILS_EXTENSION_NAME, VK_EXT_DEBUG_UTILS_SPEC_VERSION},
-};
-const uint32_t NUM_INSTANCE_EXTENSIONS = ARRAY_SIZE(INSTANCE_EXTENSIONS);
-const VkExtensionProperties DEVICE_EXTENSIONS[] = {
-    {VK_EXT_DEBUG_MARKER_EXTENSION_NAME, VK_EXT_DEBUG_MARKER_SPEC_VERSION},
-};
-const uint32_t NUM_DEVICE_EXTENSIONS = ARRAY_SIZE(DEVICE_EXTENSIONS);
-
-#undef ARRAY_SIZE
-
-/**
- * Enumerate extension properties for a specific layer.
- *
- * This should expose only the new extensions added by the layer.
- */
-VkResult enumerateExtensionPropertiesForLayer(
-        uint32_t* pPropertyCount,
-        VkExtensionProperties* pProperties,
-        uint32_t numExtensions,
-        const VkExtensionProperties extensions[]) {
-    if (pProperties == nullptr) {
-        *pPropertyCount = numExtensions;
-        return VK_SUCCESS;
-    }
-    uint32_t capacity = std::min(*pPropertyCount, numExtensions);
-    memcpy(pProperties, extensions, capacity * sizeof(VkExtensionProperties));
-    if (*pPropertyCount < numExtensions) {
-        return VK_INCOMPLETE;
-    } else {
-        *pPropertyCount = numExtensions;
-        return VK_SUCCESS;
-    }
-}
-} // end of anonymous namespace
-
-// This layer needs to add VK_EXT_debug_utils and VK_EXT_debug_marker as a supported extension.
-
-VkResult vkEnumerateInstanceExtensionProperties(
-        PFN_vkEnumerateInstanceExtensionProperties next,
-        char const* pLayerName,
-        uint32_t* pPropertyCount,
-        VkExtensionProperties* pProperties) {
-    timer t("", "vkEnumerateInstanceExtensionProperties");
-    if (pLayerName != nullptr && strcmp(pLayerName, LAYER_NAME) == 0) {
-        return enumerateExtensionPropertiesForLayer(
-                pPropertyCount,
-                pProperties,
-                NUM_INSTANCE_EXTENSIONS,
-                INSTANCE_EXTENSIONS);
-    }
-    return next(pLayerName, pPropertyCount, pProperties);
-}
-
-VkResult vkEnumerateDeviceExtensionProperties(
-        PFN_vkEnumerateDeviceExtensionProperties next,
-        VkPhysicalDevice physicalDevice,
-        char const* pLayerName,
-        uint32_t* pPropertyCount,
-        VkExtensionProperties* pProperties) {
-    timer t("VkPhysicalDevice", "vkEnumerateDeviceExtensionProperties");
-
-    if (pLayerName != nullptr && strcmp(pLayerName, LAYER_NAME) == 0) {
-        return enumerateExtensionPropertiesForLayer(
-                pPropertyCount,
-                pProperties,
-                NUM_DEVICE_EXTENSIONS,
-                DEVICE_EXTENSIONS);
-    }
-    // Manually append device extension.  This should not be necessary, but the Android vulkan
-    // loader does not expose extensions from implicit layer (b/143293104).
-    if (pProperties == nullptr) {
-        VkResult res = next(physicalDevice, pLayerName, pPropertyCount, pProperties);
-        if (res == VK_SUCCESS) {
-            (*pPropertyCount) += NUM_DEVICE_EXTENSIONS;
-        }
-        return res;
-    }
-    if (*pPropertyCount > 0) {
-        uint32_t requestedCount = *pPropertyCount;
-        VkResult res = next(physicalDevice, pLayerName, pPropertyCount, pProperties);
-        if (res == VK_SUCCESS) {
-            for (uint32_t i = 0; i < *pPropertyCount; ++i) {
-                if (!strcmp(VK_EXT_DEBUG_UTILS_EXTENSION_NAME, pProperties[i].extensionName)) {
-                    debug_utils_ext_supported = true;
-                }
-                if (!strcmp(VK_EXT_DEBUG_MARKER_EXTENSION_NAME, pProperties[i].extensionName)) {
-                    debug_marker_ext_supported = true;
-                }
-            }
-            // *pPropertyCount is expected to be requestedCount - NUM_DEVICE_EXTENSIONS.
-            *pPropertyCount = std::min(*pPropertyCount + NUM_DEVICE_EXTENSIONS, requestedCount);
-            uint32_t count = std::min(NUM_DEVICE_EXTENSIONS, *pPropertyCount);
-            memcpy(
-                    &pProperties[*pPropertyCount - count],
-                    DEVICE_EXTENSIONS,
-                    count * sizeof(VkExtensionProperties));
-        }
-        return res;
-    }
-    return VK_SUCCESS;
-}
-
-}
+} // end of {{(Global "Vulkan.LayerNamespace")}}
 {{end}}

--- a/core/vulkan/vk_debug_marker_layer/apk/BUILD.bazel
+++ b/core/vulkan/vk_debug_marker_layer/apk/BUILD.bazel
@@ -1,0 +1,21 @@
+# Copyright (C) 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless requ`ired by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//tools/build:rules.bzl", "android_native")
+
+android_native(
+    name = "VkLayer_DebugMarker",
+    visibility = ["//visibility:public"],
+    deps = ["//core/vulkan/vk_debug_marker_layer/cc:libVkLayer_DebugMarker_android"],
+)

--- a/core/vulkan/vk_debug_marker_layer/cc/BUILD.bazel
+++ b/core/vulkan/vk_debug_marker_layer/cc/BUILD.bazel
@@ -1,0 +1,122 @@
+# Copyright (C) 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//tools/build:rules.bzl", "android_dynamic_library", "api_template", "apic_template", "cc_copts", "cc_dynamic_library")
+
+api_template(
+    name = "debug_marker",
+    includes = [
+        "//gapis/api/vulkan/templates:vulkan_layer",
+    ],
+    outputs = [
+        "layer.h",
+        "layer.cpp",
+        "layer_impl.cpp",
+    ],
+    template = "debug_marker_layer.tmpl",
+)
+
+apic_template(
+    name = "debug_marker_templated",
+    api = "//gapis/api/vulkan:api",
+    templates = [
+        ":debug_marker",
+    ],
+)
+
+cc_library(
+    name = "cc",
+    srcs = glob([
+        "*.cpp",
+        "*.inc",
+        "*.h",
+    ]) + [
+        ":debug_marker_templated",
+    ],
+    copts = cc_copts() + select({
+        "//tools/build:linux": [
+            "-DVK_USE_PLATFORM_XCB_KHR",
+            "-DVK_USE_PLATFORM_GGP",
+        ],
+        "//tools/build:darwin": [],
+        "//tools/build:windows": ["-DVK_USE_PLATFORM_WIN32_KHR"],
+        # Android
+        "//conditions:default": ["-DVK_USE_PLATFORM_ANDROID_KHR"],
+    }) + [
+        "-fno-rtti",
+        "-fno-exceptions",
+        "-DNDEBUG",  # always ndebug for perfetto
+    ],
+    linkopts = select({
+        "//tools/build:linux": ["-lpthread"],
+        "//tools/build:darwin": [],
+        "//tools/build:windows": ["-lpthread"],
+        # Android
+        "//conditions:default": [
+            "-ldl",
+            "-lm",
+            "-llog",
+        ],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//core/cc",
+        "//core/vulkan/cc/include/ggp_c:vulkan_ggp_dummy",
+        "//core/vulkan/layer_helpers",
+        "//core/vulkan/perfetto_producer",
+        "@vulkan-headers//:vulkan",
+    ],
+)
+
+cc_library(
+    name = "headers",
+    srcs = glob([
+        "*.h",
+    ]),
+    copts = cc_copts() + select({
+        "//tools/build:linux": [
+            "-DVK_USE_PLATFORM_XCB_KHR",
+        ],
+        "//tools/build:darwin": [],
+        "//tools/build:windows": ["-DVK_USE_PLATFORM_WIN32_KHR"],
+        # Android
+        "//conditions:default": ["-DVK_USE_PLATFORM_ANDROID_KHR"],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        "@vulkan-headers//:vulkan",
+    ],
+)
+
+cc_dynamic_library(
+    name = "libVkLayer_DebugMarker",
+    visibility = ["//visibility:public"],
+    exports = "debug_marker_desktop.exports",
+    deps = [":cc"],
+)
+
+android_dynamic_library(
+    name = "libVkLayer_DebugMarker_android",
+    visibility = ["//visibility:public"],
+    exports = "debug_marker_android.exports",
+    deps = [":cc"],
+)
+
+filegroup(
+    name = "json",
+    srcs = [
+        "DebugMarkerLayer.json",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/core/vulkan/vk_debug_marker_layer/cc/DebugMarkerLayer.json
+++ b/core/vulkan/vk_debug_marker_layer/cc/DebugMarkerLayer.json
@@ -1,0 +1,15 @@
+{
+  "file_format_version": "1.0.0",
+  "layer": {
+    "name": "DebugMarker",
+    "type": "GLOBAL",
+    "library_path": "<library>",
+    "api_version": "1.0.5",
+    "implementation_version": "1",
+    "description": "Vulkan Debug Marker Producer",
+    "functions": {
+      "vkGetDeviceProcAddr": "VkApiGetDeviceProcAddr",
+      "vkGetInstanceProcAddr": "VkApiGetInstanceProcAddr"
+    }
+  }
+}

--- a/core/vulkan/vk_debug_marker_layer/cc/debug_marker_android.exports
+++ b/core/vulkan/vk_debug_marker_layer/cc/debug_marker_android.exports
@@ -1,0 +1,7 @@
+DebugMarkerGetDeviceProcAddr
+DebugMarkerGetInstanceProcAddr
+vkEnumerateInstanceLayerProperties
+vkEnumerateInstanceExtensionProperties
+vkEnumerateDeviceLayerProperties
+vkEnumerateDeviceExtensionProperties
+_layer_dummy_func__

--- a/core/vulkan/vk_debug_marker_layer/cc/debug_marker_desktop.exports
+++ b/core/vulkan/vk_debug_marker_layer/cc/debug_marker_desktop.exports
@@ -1,0 +1,3 @@
+DebugMarkerGetDeviceProcAddr
+DebugMarkerGetInstanceProcAddr
+_layer_dummy_func__

--- a/core/vulkan/vk_debug_marker_layer/cc/debug_marker_layer.tmpl
+++ b/core/vulkan/vk_debug_marker_layer/cc/debug_marker_layer.tmpl
@@ -1,0 +1,305 @@
+{{/*
+ * Copyright (C) 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */}}
+
+{{Global "Vulkan.LayerNamespace" "vk_api"}}
+{{Global "Vulkan.LayerName" "DebugMarker"}}
+{{Global "Vulkan.LayerDescription" "Record Vulkan debug marker"}}
+
+{{define "DEBUG_UTILS_FUNCTIONS"}}
+vkSetDebugUtilsObjectNameEXT
+vkSetDebugUtilsObjectTagEXT
+vkQueueBeginDebugUtilsLabelEXT
+vkQueueEndDebugUtilsLabelEXT
+vkQueueInsertDebugUtilsLabelEXT
+vkCmdBeginDebugUtilsLabelEXT
+vkCmdEndDebugUtilsLabelEXT
+vkCmdInsertDebugUtilsLabelEXT
+vkCreateDebugUtilsMessengerEXT
+vkDestroyDebugUtilsMessengerEXT
+vkSubmitDebugUtilsMessageEXT
+{{end}}
+
+{{define "IS_DEBUG_UTILS_FUNCTIONS"}}
+  {{$filters := Strings (Macro "DEBUG_UTILS_FUNCTIONS") | SplitEOL}}
+  {{range $f := $filters}}
+    {{if eq $.Name $f}}true{{end}}
+  {{end}}
+{{end}}
+
+{{define "DEBUG_MARKER_FUNCTIONS"}}
+vkDebugMarkerSetObjectTagEXT
+vkDebugMarkerSetObjectNameEXT
+vkCmdDebugMarkerBeginEXT
+vkCmdDebugMarkerEndEXT
+vkCmdDebugMarkerInsertEXT
+{{end}}
+
+{{define "OTHER_OVERRIDES"}}
+vkEnumerateInstanceExtensionProperties
+vkEnumerateDeviceExtensionProperties
+{{end}}
+
+
+{{define "ALL_DEBUG_FUNCTIONS"}}
+ {{Macro "DEBUG_MARKER_FUNCTIONS"}}
+ {{Macro "DEBUG_UTILS_FUNCTIONS"}}
+ {{Macro "OTHER_OVERRIDES"}}
+{{end}}
+
+{{define "IS_DEBUG_MARKER_FUNCTIONS"}}
+  {{$filters := Strings (Macro "DEBUG_MARKER_FUNCTIONS") | SplitEOL}}
+  {{range $f := $filters}}
+    {{if eq $.Name $f}}true{{end}}
+  {{end}}
+{{end}}
+
+{{Global "Vulkan.OverrideFunctions" (Strings (Macro "ALL_DEBUG_FUNCTIONS") | SplitEOL)}}
+{{Global "Vulkan.ImplementedFunctions" (Strings (Macro "ALL_DEBUG_FUNCTIONS") | SplitEOL)}}
+
+{{Include "../../../../gapis/api/vulkan/templates/vulkan_layer.tmpl"}}
+
+{{$ | Macro "layer_impl.cpp" | Reflow 4 | Write "layer_impl.cpp"}}
+
+{{define "layer_impl.cpp"}}
+
+{{Template "C++.Copyright"}}
+#include "core/vulkan/vk_debug_marker_layer/cc/layer.h"
+#include "core/vulkan/vk_debug_marker_layer/cc/vk_api_emitter.h"
+#include <cinttypes>
+
+namespace {{(Global "Vulkan.LayerNamespace")}} {
+
+static bool debug_utils_ext_supported = false;
+static bool debug_marker_ext_supported = false;
+
+// Since this layer is declaring the debug extensions are implemented, we need to also implement
+// all functions in the extension, but we need to be careful not to forward the function call if
+// the extension was not implemented.
+{{range $c := AllCommands $}}
+
+{{if and (Macro "IS_DEBUG_UTILS_FUNCTIONS" $c)  (not (eq $c.Name "vkSetDebugUtilsObjectNameEXT"))}}
+{{Template "BeginPlatformIfDef" $c}}
+{{Template "C++.BaseType" $c.Return.Type}} {{$c.Name}}(PFN_{{$c.Name}} next, {{Macro "C++.BaseCallParameters" $c | JoinWith ", "}}) {
+
+{{if not (IsVoid $c.Return.Type)}}
+    return (debug_utils_ext_supported && next != nullptr) ? next({{Template "C++.CallArguments" $c}}) : VK_SUCCESS;
+{{else}}
+    if (next != nullptr) {
+        next({{Template "C++.CallArguments" $c}});
+    }
+{{end}}
+}
+{{Template "EndPlatformIfDef" $c}}
+{{end}}
+
+{{if and (Macro "IS_DEBUG_MARKER_FUNCTIONS" $c) (not (eq $c.Name "vkDebugMarkerSetObjectNameEXT"))}}
+{{Template "BeginPlatformIfDef" $c}}
+{{Template "C++.BaseType" $c.Return.Type}} {{$c.Name}}(PFN_{{$c.Name}} next, {{Macro "C++.BaseCallParameters" $c | JoinWith ", "}}) {
+
+{{if not (IsVoid $c.Return.Type)}}
+    return (debug_marker_ext_supported && next != nullptr) ? next({{Template "C++.CallArguments" $c}}) : VK_SUCCESS;
+{{else}}
+    if (next != nullptr) {
+        next({{Template "C++.CallArguments" $c}});
+    }
+{{end}}
+}
+{{Template "EndPlatformIfDef" $c}}
+{{end}}
+
+{{end}}
+
+
+// Maps VkDebugReportObjectTypeEXT to VkObjectType.
+VkObjectType getVkObjectType(VkDebugReportObjectTypeEXT vk_debug_report_object_type) {
+#define CASE(OBJ)                               \
+  case VK_DEBUG_REPORT_OBJECT_TYPE_##OBJ##_EXT: \
+    return VK_OBJECT_TYPE_##OBJ
+
+  switch (vk_debug_report_object_type) {
+    CASE(UNKNOWN);
+    CASE(INSTANCE);
+    CASE(PHYSICAL_DEVICE);
+    CASE(DEVICE);
+    CASE(QUEUE);
+    CASE(SEMAPHORE);
+    CASE(COMMAND_BUFFER);
+    CASE(FENCE);
+    CASE(DEVICE_MEMORY);
+    CASE(BUFFER);
+    CASE(IMAGE);
+    CASE(EVENT);
+    CASE(QUERY_POOL);
+    CASE(BUFFER_VIEW);
+    CASE(IMAGE_VIEW);
+    CASE(SHADER_MODULE);
+    CASE(PIPELINE_CACHE);
+    CASE(PIPELINE_LAYOUT);
+    CASE(RENDER_PASS);
+    CASE(PIPELINE);
+    CASE(DESCRIPTOR_SET_LAYOUT);
+    CASE(SAMPLER);
+    CASE(DESCRIPTOR_POOL);
+    CASE(DESCRIPTOR_SET);
+    CASE(FRAMEBUFFER);
+    CASE(COMMAND_POOL);
+    CASE(SURFACE_KHR);
+    CASE(SWAPCHAIN_KHR);
+    CASE(DEBUG_REPORT_CALLBACK_EXT);
+    CASE(DISPLAY_KHR);
+    CASE(DISPLAY_MODE_KHR);
+    CASE(OBJECT_TABLE_NVX);
+    CASE(INDIRECT_COMMANDS_LAYOUT_NVX);
+    CASE(VALIDATION_CACHE_EXT);
+    CASE(SAMPLER_YCBCR_CONVERSION);
+    CASE(DESCRIPTOR_UPDATE_TEMPLATE);
+    CASE(ACCELERATION_STRUCTURE_NV);
+    default:
+      return VK_OBJECT_TYPE_UNKNOWN;
+  }
+#undef CASE
+}
+
+VkResult vkSetDebugUtilsObjectNameEXT(
+        PFN_vkSetDebugUtilsObjectNameEXT     next,
+        VkDevice                             device,
+        const VkDebugUtilsObjectNameInfoEXT* pNameInfo) {
+    vk_api::VkApiEmit().EmitDebugUtilsObjectName(
+            reinterpret_cast<uint64_t>(device), pNameInfo->objectType, pNameInfo->objectHandle, pNameInfo->pObjectName);
+
+    // Must not forward function call if the extension was not supported.
+    return debug_utils_ext_supported ? next(device, pNameInfo) : VK_SUCCESS;
+}
+
+VkResult vkDebugMarkerSetObjectNameEXT(
+        PFN_vkDebugMarkerSetObjectNameEXT     next,
+        VkDevice                              device,
+        VkDebugMarkerObjectNameInfoEXT const* pNameInfo) {
+    // Convert object type to VkObjectType and emit the trace.
+    vk_api::VkApiEmit().EmitDebugUtilsObjectName(
+            reinterpret_cast<uint64_t>(device), getVkObjectType(pNameInfo->objectType), pNameInfo->object, pNameInfo->pObjectName);
+
+    // Must not forward function call if the extension was not supported.
+    return debug_marker_ext_supported ? next(device, pNameInfo) : VK_SUCCESS;
+}
+
+namespace {
+
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+
+const char* LAYER_NAME = "{{Global "Vulkan.LayerName"}}";
+const VkExtensionProperties INSTANCE_EXTENSIONS[] = {
+    {VK_EXT_DEBUG_UTILS_EXTENSION_NAME, VK_EXT_DEBUG_UTILS_SPEC_VERSION},
+};
+const uint32_t NUM_INSTANCE_EXTENSIONS = ARRAY_SIZE(INSTANCE_EXTENSIONS);
+const VkExtensionProperties DEVICE_EXTENSIONS[] = {
+    {VK_EXT_DEBUG_MARKER_EXTENSION_NAME, VK_EXT_DEBUG_MARKER_SPEC_VERSION},
+};
+const uint32_t NUM_DEVICE_EXTENSIONS = ARRAY_SIZE(DEVICE_EXTENSIONS);
+
+#undef ARRAY_SIZE
+
+/**
+ * Enumerate extension properties for a specific layer.
+ *
+ * This should expose only the new extensions added by the layer.
+ */
+VkResult enumerateExtensionPropertiesForLayer(
+        uint32_t* pPropertyCount,
+        VkExtensionProperties* pProperties,
+        uint32_t numExtensions,
+        const VkExtensionProperties extensions[]) {
+    if (pProperties == nullptr) {
+        *pPropertyCount = numExtensions;
+        return VK_SUCCESS;
+    }
+    uint32_t capacity = std::min(*pPropertyCount, numExtensions);
+    memcpy(pProperties, extensions, capacity * sizeof(VkExtensionProperties));
+    if (*pPropertyCount < numExtensions) {
+        return VK_INCOMPLETE;
+    } else {
+        *pPropertyCount = numExtensions;
+        return VK_SUCCESS;
+    }
+}
+} // end of anonymous namespace
+
+// This layer needs to add VK_EXT_debug_utils and VK_EXT_debug_marker as a supported extension.
+
+VkResult vkEnumerateInstanceExtensionProperties(
+        PFN_vkEnumerateInstanceExtensionProperties next,
+        char const* pLayerName,
+        uint32_t* pPropertyCount,
+        VkExtensionProperties* pProperties) {
+    if (pLayerName != nullptr && strcmp(pLayerName, LAYER_NAME) == 0) {
+        return enumerateExtensionPropertiesForLayer(
+                pPropertyCount,
+                pProperties,
+                NUM_INSTANCE_EXTENSIONS,
+                INSTANCE_EXTENSIONS);
+    }
+    return next(pLayerName, pPropertyCount, pProperties);
+}
+
+VkResult vkEnumerateDeviceExtensionProperties(
+        PFN_vkEnumerateDeviceExtensionProperties next,
+        VkPhysicalDevice physicalDevice,
+        char const* pLayerName,
+        uint32_t* pPropertyCount,
+        VkExtensionProperties* pProperties) {
+    if (pLayerName != nullptr && strcmp(pLayerName, LAYER_NAME) == 0) {
+        return enumerateExtensionPropertiesForLayer(
+                pPropertyCount,
+                pProperties,
+                NUM_DEVICE_EXTENSIONS,
+                DEVICE_EXTENSIONS);
+    }
+    // Manually append device extension.  This should not be necessary, but the Android vulkan
+    // loader does not expose extensions from implicit layer (b/143293104).
+    if (pProperties == nullptr) {
+        VkResult res = next(physicalDevice, pLayerName, pPropertyCount, pProperties);
+        if (res == VK_SUCCESS) {
+            (*pPropertyCount) += NUM_DEVICE_EXTENSIONS;
+        }
+        return res;
+    }
+    if (*pPropertyCount > 0) {
+        uint32_t requestedCount = *pPropertyCount;
+        VkResult res = next(physicalDevice, pLayerName, pPropertyCount, pProperties);
+        if (res == VK_SUCCESS) {
+            for (uint32_t i = 0; i < *pPropertyCount; ++i) {
+                if (!strcmp(VK_EXT_DEBUG_UTILS_EXTENSION_NAME, pProperties[i].extensionName)) {
+                    debug_utils_ext_supported = true;
+                }
+                if (!strcmp(VK_EXT_DEBUG_MARKER_EXTENSION_NAME, pProperties[i].extensionName)) {
+                    debug_marker_ext_supported = true;
+                }
+            }
+            // *pPropertyCount is expected to be requestedCount - NUM_DEVICE_EXTENSIONS.
+            *pPropertyCount = std::min(*pPropertyCount + NUM_DEVICE_EXTENSIONS, requestedCount);
+            uint32_t count = std::min(NUM_DEVICE_EXTENSIONS, *pPropertyCount);
+            memcpy(
+                    &pProperties[*pPropertyCount - count],
+                    DEVICE_EXTENSIONS,
+                    count * sizeof(VkExtensionProperties));
+        }
+        return res;
+    }
+    return VK_SUCCESS;
+}
+
+} // end of {{(Global "Vulkan.LayerNamespace")}}
+{{end}}

--- a/core/vulkan/vk_debug_marker_layer/cc/layer_helpers.cpp
+++ b/core/vulkan/vk_debug_marker_layer/cc/layer_helpers.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "core/cc/log.h"
+#include "core/cc/target.h"
+extern "C" {
+__attribute__((constructor)) void _layer_dummy_func__();
+}
+#if (TARGET_OS == GAPID_OS_WINDOWS) || (TARGET_OS == GAPID_OS_OSX)
+class dummy_struct {};
+#else
+#include <dlfcn.h>
+#include <cstdint>
+#include <cstdio>
+class dummy_struct {
+ public:
+  dummy_struct();
+};
+
+dummy_struct::dummy_struct() {
+  GAPID_ERROR("Loading dummy struct");
+  Dl_info info;
+  if (dladdr((void*)&_layer_dummy_func__, &info)) {
+    dlopen(info.dli_fname, RTLD_NODELETE);
+  }
+}
+#endif
+
+extern "C" {
+// _layer_dummy_func__ is marked __attribute__((constructor))
+// this means on .so open, it will be called. Once that happens,
+// we create a dummy struct, which on Android and Linux,
+// Forces the layer to never be unloaded. There is some global
+// state in perfetto producers that does not like being unloaded.
+void _layer_dummy_func__() {
+  dummy_struct d;
+  (void)d;
+}
+}

--- a/core/vulkan/vk_debug_marker_layer/cc/vk_api_emitter.cpp
+++ b/core/vulkan/vk_debug_marker_layer/cc/vk_api_emitter.cpp
@@ -15,5 +15,5 @@
  *
  */
 
-#include "core/vulkan/vk_api_timing_layer/cc/vk_api_emitter.h"
-PERFETTO_DEFINE_DATA_SOURCE_STATIC_MEMBERS(api_timing::VkApiProducer);
+#include "core/vulkan/vk_debug_marker_layer/cc/vk_api_emitter.h"
+PERFETTO_DEFINE_DATA_SOURCE_STATIC_MEMBERS(vk_api::VkApiProducer);

--- a/core/vulkan/vk_debug_marker_layer/cc/vk_api_emitter.h
+++ b/core/vulkan/vk_debug_marker_layer/cc/vk_api_emitter.h
@@ -22,7 +22,7 @@
 #include "core/vulkan/perfetto_producer/perfetto_data_source.h"
 #include "core/vulkan/perfetto_producer/perfetto_threadlocal_emitter.h"
 
-namespace api_timing {
+namespace vk_api {
 
 template <typename T>
 class VkApiEmitter : ThreadlocalEmitterBase {
@@ -81,12 +81,12 @@ struct VkApiTypeTraits {
 };
 
 using VkApiProducer = VkApiEmitter<VkApiTypeTraits>;
-auto const VkApiEmit = &api_timing::tracing::Emit<VkApiTypeTraits>;
-}  // namespace api_timing
+auto const VkApiEmit = &vk_api::tracing::Emit<VkApiTypeTraits>;
+}  // namespace vk_api
 
 #define __INCLUDING_VK_API_EMITTER_INC__
-#include "core/vulkan/vk_api_timing_layer/cc/vk_api_emitter.inc"
+#include "core/vulkan/vk_debug_marker_layer/cc/vk_api_emitter.inc"
 #undef __INCLUDING_VK_API_EMITTER_INC__
 
-PERFETTO_DECLARE_DATA_SOURCE_STATIC_MEMBERS(api_timing::VkApiProducer);
+PERFETTO_DECLARE_DATA_SOURCE_STATIC_MEMBERS(vk_api::VkApiProducer);
 #endif

--- a/core/vulkan/vk_debug_marker_layer/cc/vk_api_emitter.inc
+++ b/core/vulkan/vk_debug_marker_layer/cc/vk_api_emitter.inc
@@ -19,7 +19,7 @@
 #include "perfetto/tracing/core/data_source_config.h"
 #include "perfetto/base/time.h"
 
-namespace api_timing {
+namespace vk_api {
 
 template <typename T>
 VkApiEmitter<T>::VkApiEmitter() {

--- a/gapidapk/android/apk/BUILD.bazel
+++ b/gapidapk/android/apk/BUILD.bazel
@@ -18,6 +18,7 @@ _NATIVE_LIBRARIES = {
     "deviceinfo": "//core/os/device/deviceinfo/apk",
     "VkLayer_VirtualSwapchain": "//core/vulkan/vk_virtual_swapchain/apk",
     "VkLayer_CPUTiming": "//core/vulkan/vk_api_timing_layer/apk",
+    "VkLayer_DebugMarker": "//core/vulkan/vk_debug_marker_layer/apk",
     "VkLayer_MemoryTracker": "//core/vulkan/vk_memory_tracker_layer/apk",
     "gapii": "//gapii/apk",
     "interceptor": "//gapii/apk",


### PR DESCRIPTION
CPUTiming is often not need together with debug marker.
Separate the two layers make the code much easier to maintain.

Bug: b/148465074