### PR TITLE
Create only one staging buffer per device

### DIFF
--- a/core/cc/make_unique.h
+++ b/core/cc/make_unique.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// std::make_unique is only available from C++14. As we stick to C++11 for now,
+// we define our own make_unique here.
+
+#ifndef CORE_MAKE_UNIQUE_H
+#define CORE_MAKE_UNIQUE_H
+
+#include <memory>
+
+template <typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args) {
+  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+#endif  // CORE_MAKE_UNIQUE_H

--- a/core/vulkan/vk_memory_tracker_layer/cc/memory_tracker_layer_impl.cpp
+++ b/core/vulkan/vk_memory_tracker_layer/cc/memory_tracker_layer_impl.cpp
@@ -24,6 +24,7 @@
 #include <malloc.h>
 #endif
 
+#include "core/cc/make_unique.h"
 #include "core/vulkan/vk_memory_tracker_layer/cc/tracing_helpers.h"
 #include "perfetto/base/time.h"
 
@@ -39,11 +40,6 @@ using scoped_write_lock = layer_helpers::threading::scoped_write_lock;
 MemoryTracker memory_tracker_instance;
 rwlock rwl_global_unique_handles;
 std::unordered_map<uint64_t, uint64_t> global_unique_handles;
-
-template <typename T, typename... Args>
-std::unique_ptr<T> make_unique(Args&&... args) {
-  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
 
 // --------------------------- UniqueHandleGenerator ---------------------------
 


### PR DESCRIPTION
When retrieving the Vulkan state at the start of a mid-execution
capture, we create a new staging buffer for each of the buffers in the
state.

This change creates only one staging buffer per device, and reuses it
to retrieve all buffers of that device.

Bug: none
Test: capture a few Vulkan apps