### PR TITLE
Save trace of swiftshader test, for debug purposes

### DIFF
--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -125,6 +125,6 @@ test "${APP_EXIT_STATUS}" -eq 130
 
 # TODO(https://github.com/google/gapid/issues/3163): The coherent memory
 #  tracker must be disabled with SwiftShader for now.
-xvfb-run -e xvfb.log -a bazel-bin/pkg/gapit trace -device host -disable-coherentmemorytracker -disable-pcs -disable-unknown-extensions -record-errors -no-buffer -api vulkan -start-at-frame 5 -capture-frames 10 -observe-frames 1 -out vulkan_sample.gfxtrace bazel-bin/cmd/vulkan_sample/vulkan_sample
+xvfb-run -e xvfb.log -a bazel-bin/pkg/gapit trace -device host -disable-coherentmemorytracker -disable-pcs -disable-unknown-extensions -record-errors -no-buffer -api vulkan -start-at-frame 5 -capture-frames 10 -observe-frames 1 -out out/dist/vulkan_sample.gfxtrace bazel-bin/cmd/vulkan_sample/vulkan_sample
 
-xvfb-run -e xvfb.log -a bazel-bin/pkg/gapit video -gapir-nofallback -type sxs -frames-minimum 10 -out vulkan_sample.mp4 vulkan_sample.gfxtrace
+xvfb-run -e xvfb.log -a bazel-bin/pkg/gapit video -gapir-nofallback -type sxs -frames-minimum 10 -out vulkan_sample.mp4  out/dist/vulkan_sample.gfxtrace

--- a/kokoro/linux/common.cfg
+++ b/kokoro/linux/common.cfg
@@ -18,6 +18,8 @@ action {
     regex: "out/dist/agi*.deb"
     regex: "out/dist/agi*.zip"
     regex: "out/dist/*gapir*.sym"
+    # b/151297033: save trace of sample on swiftshader, for debug purposes
+    regex: "out/dist/*.gfxtrace"
     strip_prefix: "out/dist"
   }
 }


### PR DESCRIPTION
We have a flaky failure on our swiftshader capture-replay test, so
let's temporarily save the trace such that we can properly debug next
time the failure occurs.

Bug: b/151297033