### PR TITLE
Remove racy and thus flaky test WithoutSpinLockGuard

### DIFF
--- a/core/memory_tracker/cc/memory_tracker_test.cpp
+++ b/core/memory_tracker/cc/memory_tracker_test.cpp
@@ -225,28 +225,6 @@ void* VoidPointerAdd(void* addr, ssize_t offset) {
 
 using SpinLockTest = TestFixture;
 
-// Thread A sleeps first, then increases the counter, while Thread B will
-// increase the counter before Thread A wakes up.
-TEST_F(SpinLockTest, WithoutSpinLockGuard) {
-  Init();
-  uint32_t counter = 0u;
-  RunInTwoThreads(
-      // Thread A is initiated first and runs first.
-      [this, &counter]() {
-        m_.unlock();
-        usleep(5000);
-        counter++;
-        EXPECT_EQ(2u, counter);
-      },
-      // Thread B is initiated secondly and runs after thread A runs.
-      [this, &counter]() {
-        m_.lock();
-        counter++;
-        EXPECT_EQ(1u, counter);
-      });
-  EXPECT_EQ(2u, counter);
-}
-
 // Thread A sleeps first, then increases the counter, but Thread B waits for
 // the spin lock. So Thread A increases the counter before Thread B.
 TEST_F(SpinLockTest, WithSpinLockGuard) {


### PR DESCRIPTION
This test has a race, and as such it randomly fails on the CI.

Bug: b/149401797
