### PR TITLE
Fix wrong combination when selecting across multiple gpu counters.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/views/CountersSelectionView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CountersSelectionView.java
@@ -40,9 +40,13 @@ public class CountersSelectionView extends Composite {
 
     createTableColumn(
         viewer, "Time", r -> timeToString(sel.ts[(Integer)r] - state.getTraceTime().start));
-    for (int i = 0; i < sel.names.length; i++) {
-      final int idx = i;
-      createTableColumn(viewer, sel.names[i], r -> String.valueOf(sel.values[idx][(Integer)r]));
+    for (String name : sel.values.keySet()) {
+      createTableColumn(viewer, name, r -> {
+        if (sel.ids.get(name)[(Integer)r] == -1) {
+          return "/";
+        }
+        return String.valueOf(sel.values.get(name)[(Integer)r]);
+      });
     }
 
     // Skip the last row (it represents the end of the selection range).

--- a/gapic/src/main/com/google/gapid/util/Arrays.java
+++ b/gapic/src/main/com/google/gapid/util/Arrays.java
@@ -29,4 +29,10 @@ public class Arrays {
   public static <T> T getOrDefault(T[] array, int idx, T dflt) {
     return array == null || idx >= array.length ? dflt : array[idx];
   }
+
+  public static long[] filled(long[] array, long val) {
+    // No generic pattern here because want a long[] array rather than Long[] array.
+    java.util.Arrays.fill(array, val);
+    return array;
+  }
 }


### PR DESCRIPTION
 - Can test out by 1. Select some gpu counters. 2. Ctrl + select some
 other gpu counters. 3. Look at the info box. 4. Notice the wrong
 columns and messy counter values.
 - Bug: N/A.