### PR TITLE
Change the key type of the ResourceMap type.

### DIFF
--- a/gapis/api/gles/resources.go
+++ b/gapis/api/gles/resources.go
@@ -329,7 +329,7 @@ func (s Shaderʳ) SetResourceData(
 	if err != nil {
 		return err
 	}
-	resourceID := resourceIDs[s]
+	resourceID := resourceIDs[s.ResourceHandle()]
 
 	resource, err := resources.Find(s.ResourceType(ctx), resourceID)
 	if err != nil {

--- a/gapis/api/resource.go
+++ b/gapis/api/resource.go
@@ -24,8 +24,10 @@ import (
 	"github.com/google/gapid/gapis/service/path"
 )
 
-// ResourceMap is a map from Resource to its id in a database.
-type ResourceMap map[Resource]id.ID
+// ResourceMap is a map from Resource handles to Resource IDs in the database.
+// Note this map is not time-globally valid. It is only valid at a specific
+// point in a trace, since handles may be re-used.
+type ResourceMap map[string]id.ID
 
 // Resource represents an asset in a capture.
 type Resource interface {

--- a/gapis/api/vulkan/resources.go
+++ b/gapis/api/vulkan/resources.go
@@ -853,7 +853,7 @@ func (shader ShaderModuleObjectʳ) SetResourceData(
 	if err != nil {
 		return err
 	}
-	resourceID := resourceIDs[shader]
+	resourceID := resourceIDs[shader.ResourceHandle()]
 
 	resource, err := resources.Find(shader.ResourceType(ctx), resourceID)
 	if err != nil {

--- a/gapis/resolve/resource_data.go
+++ b/gapis/resolve/resource_data.go
@@ -88,7 +88,7 @@ func buildResources(ctx context.Context, p *path.Command, t api.ResourceType) (*
 	state.OnResourceCreated = func(r api.Resource) {
 		currentCmdResourceCount++
 		i := genResourceID(currentCmdIndex, currentCmdResourceCount)
-		idMap[r] = i
+		idMap[r.ResourceHandle()] = i
 		resources[i] = r
 	}
 


### PR DESCRIPTION
Currently the key is the Resource interface (i.e. a pointer). This key is only useful if the exact same state object is used for map lookups. Since the map is put into the DB, this is not usually the case.

With this change, the key is the resource handle. However, since the APIs are allowed to re-use handles, they are no longer "time-globally" unique, and so the mapping is only valid at a specific point in the trace. It is currently only used at specific points in the trace, so this is OK.