### PR TITLE
Make sure ready signal is fired.

### DIFF
--- a/gapis/perfetto/android/trace.go
+++ b/gapis/perfetto/android/trace.go
@@ -285,6 +285,7 @@ func (p *Process) captureWithClientApi(ctx context.Context, start task.Signal, s
 		ts.Stop(ctx)
 		return 0, log.Err(ctx, nil, "Cancelled")
 	}
+	ready(ctx)
 	ts.Start(ctx)
 	wait := make(chan error, 1)
 	crash.Go(func() {


### PR DESCRIPTION
Make sure ready signal is fired when trace session is ready to start.

Bug: b/147490759