### PR TITLE
Make sure ready signal is fired. (#150)

### DIFF
--- a/gapis/perfetto/android/trace.go
+++ b/gapis/perfetto/android/trace.go
@@ -285,6 +285,7 @@ func (p *Process) captureWithClientApi(ctx context.Context, start task.Signal, s
 		ts.Stop(ctx)
 		return 0, log.Err(ctx, nil, "Cancelled")
 	}
+	ready(ctx)
 	ts.Start(ctx)
 	wait := make(chan error, 1)
 	crash.Go(func() {


### PR DESCRIPTION
Make sure ready signal is fired when trace session is ready to start.

Bug: b/147490759
(cherry picked from commit fa468d50537eb98afaf9c324d5473b2a2ef8bfe9)