### PR TITLE
Use device capabilities to decide whether to add profiling layer

### DIFF
--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -1050,7 +1050,7 @@ func (a API) Replay(
 			makeReadable.imagesOnly = true
 			optimize = false
 			transforms.Add(NewWaitForPerfetto(req.traceOptions, req.handler, req.buffer))
-			if strings.Contains(device.GetConfiguration().GetHardware().GetGPU().GetName(), "Adreno") {
+			if device.GetConfiguration().GetPerfettoCapability().GetGpuProfiling().GetHasRenderStageProducerLayer() {
 				transforms.Add(&profilingLayers{})
 			}
 			transforms.Add(replay.NewMappingExporter(ctx, req.handleMappings))


### PR DESCRIPTION
Previously we had hardcoded this in a weird way based on the device
name. We already know from the perfetto capabilities whether the device
needs a layer to be loaded -- use that.