### PR TITLE
Explicetly check Select.Default for nil in the template.

### DIFF
--- a/gapis/api/templates/go_common.tmpl
+++ b/gapis/api/templates/go_common.tmpl
@@ -784,7 +784,7 @@
             return {{Template "Go.Read" $c.Expression}}
       {{end}}
     default:
-      {{if $.Default}}
+      {{if not (IsNil $.Default)}}
         return {{Template "Go.Read" $.Default}}
       {{else}}
         // TODO: better unmatched handling


### PR DESCRIPTION
Newer versions of the templating engine appear to treat this differently. We have "{{if $.Default}}" meaning "if there is a default", but apparently, "default: as!uint32(0)" creates an expression that makes the condition false. Changing it to "default: as!uint32(5)" would cause it to be true, but "0" somehow makes it false. Most likely the implementation does "if {arg} is not a zero object", and the struct created by our parsers happens to look like a zero object.