### PR TITLE
Reserve mapped memory at state initialization

### DIFF
--- a/gapis/api/state.go
+++ b/gapis/api/state.go
@@ -87,7 +87,7 @@ type State interface {
 	// SetupInitialState sanitizes deserialized state to make it valid.
 	// It can fill in any derived data which we choose not to serialize,
 	// or it can apply backward-compatibility fixes for older traces.
-	SetupInitialState(ctx context.Context)
+	SetupInitialState(ctx context.Context, state *GlobalState)
 }
 
 // NewStateWithEmptyAllocator returns a new, default-initialized State object,

--- a/gapis/api/test/test.go
+++ b/gapis/api/test/test.go
@@ -50,7 +50,7 @@ func (s *State) Root(ctx context.Context, p *path.State, r *path.ResolveConfig) 
 // SetupInitialState sanitizes deserialized state to make it valid.
 // It can fill in any derived data which we choose not to serialize,
 // or it can apply backward-compatibility fixes for older traces.
-func (*State) SetupInitialState(ctx context.Context) {}
+func (*State) SetupInitialState(ctx context.Context, state *api.GlobalState) {}
 
 func (i Remapped) remap(cmd api.Cmd, s *api.GlobalState) (interface{}, bool) {
 	return i, true

--- a/gapis/api/transform/transforms.go
+++ b/gapis/api/transform/transforms.go
@@ -35,7 +35,7 @@ func (l Transforms) TransformAll(ctx context.Context, cmds []api.Cmd, numberOfIn
 			newState.Memory = s.Memory.Clone()
 			for k, v := range s.APIs {
 				clonedState := v.Clone(newState.Arena)
-				clonedState.SetupInitialState(ctx)
+				clonedState.SetupInitialState(ctx, newState)
 				newState.APIs[k] = clonedState
 			}
 			s = newState

--- a/gapis/api/vulkan/frame_loop.go
+++ b/gapis/api/vulkan/frame_loop.go
@@ -533,7 +533,7 @@ func (f *frameLoop) cloneState(ctx context.Context, startState *api.GlobalState)
 	for apiState, graphicsApi := range startState.APIs {
 
 		clonedState := graphicsApi.Clone(clone.Arena)
-		clonedState.SetupInitialState(ctx)
+		clonedState.SetupInitialState(ctx, clone)
 
 		clone.APIs[apiState] = clonedState
 	}

--- a/gapis/capture/graphics.go
+++ b/gapis/capture/graphics.go
@@ -150,7 +150,7 @@ func (c *GraphicsCapture) NewState(ctx context.Context) *api.GlobalState {
 		// Clone serialized state, and initialize it for use.
 		for k, v := range c.InitialState.APIs {
 			s := v.Clone(out.Arena)
-			s.SetupInitialState(ctx)
+			s.SetupInitialState(ctx, out)
 			out.APIs[k.ID()] = s
 		}
 	}

--- a/gapis/replay/batch.go
+++ b/gapis/replay/batch.go
@@ -178,7 +178,7 @@ func (r *InitialPayloadResolvable) Resolve(
 	// Clone serialized state, and initialize it for use.
 	for k, v := range out.state.APIs {
 		s := v.Clone(generatedState.Arena)
-		s.SetupInitialState(ctx)
+		s.SetupInitialState(ctx, out.state)
 		generatedState.APIs[k] = s
 	}
 
@@ -313,7 +313,7 @@ func (m *manager) execute(
 		// Clone serialized state, and initialize it for use.
 		for k, v := range depState.APIs {
 			s := v.Clone(initState.Arena)
-			s.SetupInitialState(ctx)
+			s.SetupInitialState(ctx, initState)
 			initState.APIs[k] = s
 		}
 	}

--- a/gapis/resolve/dependencygraph2/dependency_graph_test.go
+++ b/gapis/resolve/dependencygraph2/dependency_graph_test.go
@@ -78,7 +78,7 @@ func (TestRef) Root(ctx context.Context, p *path.State, r *path.ResolveConfig) (
 	return nil, nil
 }
 
-func (TestRef) SetupInitialState(ctx context.Context) {}
+func (TestRef) SetupInitialState(ctx context.Context, state *api.GlobalState) {}
 
 func newTestRef() TestRef {
 	return TestRef{api.NewRefID()}


### PR DESCRIPTION
Previously, if device memory was mapped prior to MEC start, the
allocator was not informed that the memory range was in use. This
led to other memory allocations and/or mappings being placed over
the top.

This would lead to quiet memory corruption in the common case,
or if we got unlucky and placed another memory mapping over the same
range, bizarre explosions when eventually trying to unmap & delete
pre-MEC-start device memory object.

Fixes Swiftshader 'UnmapMemory' crash on Swarming.

Bug: b/151297033