### PR TITLE
Fixes a "Widgets is disposed" error when switching trace types.

### DIFF
--- a/gapic/src/main/com/google/gapid/MainWindow.java
+++ b/gapic/src/main/com/google/gapid/MainWindow.java
@@ -126,11 +126,15 @@ public class MainWindow extends ApplicationWindow {
         if (error != null) {
           mainUi.showMessage(error);
         } else {
-          MainView view = mainUi.getContents().updateAndGet(
-              models.capture.getData().capture.getType());
-          view.updateViewMenu(findMenu(MenuItems.VIEW_ID));
-          getMenuBarManager().updateAll(true);
-          mainUi.stopLoading();
+          // Let all other handlers of this event get a chance to process before we start disposing
+          // UI components underneath everybody.
+          scheduleIfNotDisposed(mainUi, () -> {
+            MainView view = mainUi.getContents().updateAndGet(
+                models.capture.getData().capture.getType());
+            view.updateViewMenu(findMenu(MenuItems.VIEW_ID));
+            getMenuBarManager().updateAll(true);
+            mainUi.stopLoading();
+          });
         }
       }
     });


### PR DESCRIPTION
When opening, say, a graphics trace and then a system profile, a lot of the UI components are disposed in order to replace the graphics trace UI with the system profile UI. Any of these UI components that listen to capture load events will unregister themselves when being disposed. However, since we are in the middle of handling such an event, it is possible for such components to then still receive the current event.
Instead of checking in each component whether they have since been disposed when handling the event, let's just schedule the disposing to happen after the event has been fully processed.