### PR TITLE
Implement linking to Vulkan objects in the struct UI

### DIFF
--- a/gapis/resolve/memory.go
+++ b/gapis/resolve/memory.go
@@ -292,7 +292,7 @@ func MemoryAsType(ctx context.Context, p *path.MemoryAsType, rc *path.ResolveCon
 	}
 	vals := []*memory_box.Value{}
 	for i := 0; i < nElems; i++ {
-		v, err := memory_box.Box(ctx, dec, ty)
+		v, err := memory_box.Box(ctx, dec, ty, p, rc)
 		if err != nil {
 			return nil, err
 		}

--- a/gapis/service/memory_box/BUILD.bazel
+++ b/gapis/service/memory_box/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//core/data/pod:go_default_library",
         "//core/log:go_default_library",
         "//gapis/memory:go_default_library",
+        "//gapis/service/path:go_default_library",
         "//gapis/service/types:go_default_library",
     ],
 )
@@ -36,7 +37,10 @@ proto_library(
     name = "memory_box_proto",
     srcs = ["box.proto"],
     visibility = ["//visibility:public"],
-    deps = ["//core/data/pod:pod_proto"],
+    deps = [
+        "//core/data/pod:pod_proto",
+        "//gapis/service/path:path_proto",
+    ],
 )
 
 go_proto_library(
@@ -44,7 +48,10 @@ go_proto_library(
     importpath = "github.com/google/gapid/gapis/service/memory_box",
     proto = ":memory_box_proto",
     visibility = ["//visibility:public"],
-    deps = ["//core/data/pod:go_default_library"],
+    deps = [
+        "//core/data/pod:go_default_library",
+        "//gapis/service/path:go_default_library",
+    ],
 )
 
 java_proto_library(

--- a/gapis/service/memory_box/box.proto
+++ b/gapis/service/memory_box/box.proto
@@ -15,6 +15,7 @@
 syntax = "proto3";
 
 import "core/data/pod/pod.proto";
+import "gapis/service/path/path.proto";
 
 package memory_box;
 option java_package = "com.google.gapid.proto.service.memory_box";
@@ -30,6 +31,7 @@ message Value {
     Array array = 6;
     Null null = 7;
   }
+  path.Any link = 8;
 }
 
 message Pointer {


### PR DESCRIPTION
- Have the server produce paths when boxing linkable handle types.
  This requires a bit of ugliness to recover the actual type of the
  handle and call through its Link() implementation if present.

- In the client, convert the value column of the struct UI to use
  custom drawing. Move the existing ad-hoc linking for "large arrays" to
  be linked from the value column, and add link following for
  server-provided links as well.

Bug: b/143594054