### PR TITLE
Make validation more robust on Adreno.

### DIFF
--- a/gapis/trace/android/adreno/validate.go
+++ b/gapis/trace/android/adreno/validate.go
@@ -24,14 +24,14 @@ import (
 var (
 	// All counters must be inside this array.
 	counters = []validate.GpuCounter{
-		{1, "Clocks / Second", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
-		{3, "GPU % Utilization", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
-		{21, "% Shaders Busy", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
-		{26, "Fragment ALU Instructions / Sec (Full)", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
+		{1, "Clocks / Second", validate.And(validate.IsNumber, validate.CheckLargerThanZero())},
+		{3, "GPU % Utilization", validate.And(validate.IsNumber, validate.CheckLargerThanZero())},
+		{21, "% Shaders Busy", validate.And(validate.IsNumber, validate.CheckLargerThanZero())},
+		{26, "Fragment ALU Instructions / Sec (Full)", validate.And(validate.IsNumber, validate.CheckLargerThanZero())},
 		{30, "Textures / Vertex", validate.And(validate.IsNumber, validate.CheckEqualTo(0.0))},
-		{31, "Textures / Fragment", validate.And(validate.IsNumber, validate.CheckApproximateTo(1.0, 0.1))},
-		{37, "% Time Shading Fragments", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
-		{38, "% Time Shading Vertices", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
+		{31, "Textures / Fragment", validate.And(validate.IsNumber, validate.CheckAverageApproximateTo(1.0, 0.1))},
+		{37, "% Time Shading Fragments", validate.And(validate.IsNumber, validate.CheckLargerThanZero())},
+		{38, "% Time Shading Vertices", validate.And(validate.IsNumber, validate.CheckLargerThanZero())},
 		{39, "% Time Compute", validate.And(validate.IsNumber, validate.CheckEqualTo(0.0))},
 	}
 )

--- a/gapis/trace/android/mali/validate.go
+++ b/gapis/trace/android/mali/validate.go
@@ -24,13 +24,13 @@ import (
 var (
 	// All counters must be inside this array.
 	counters = []validate.GpuCounter{
-		{6, "GPU active cycles", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
-		{8, "Fragment jobs", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
-		{196, "Fragment active cycles", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
+		{6, "GPU active cycles", validate.And(validate.IsNumber, validate.CheckLargerThanZero())},
+		{8, "Fragment jobs", validate.And(validate.IsNumber, validate.CheckLargerThanZero())},
+		{196, "Fragment active cycles", validate.And(validate.IsNumber, validate.CheckLargerThanZero())},
 		{233, "Compressed texture line fetch requests", validate.And(validate.IsNumber, validate.CheckEqualTo(0.0))},
-		{65536, "GPU utilization", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
-		{65538, "Fragment queue utilization", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
-		{65579, "Execution core utilization", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
+		{65536, "GPU utilization", validate.And(validate.IsNumber, validate.CheckLargerThanZero())},
+		{65538, "Fragment queue utilization", validate.And(validate.IsNumber, validate.CheckLargerThanZero())},
+		{65579, "Execution core utilization", validate.And(validate.IsNumber, validate.CheckLargerThanZero())},
 		{65585, "Texture data fetches form compressed lines", validate.And(validate.IsNumber, validate.CheckEqualTo(0.0))},
 	}
 )


### PR DESCRIPTION
The average of 'Textures / Fragment' should be 1 for the vulkan sample while
each 50 ms sample might vary a bit larger than 0.1 from 1.

Minor: Move some code around to avoid duplication.

Bug: b/151801290
Test: bazel run gapit -- validate_gpu_profiling --os android