### PR TITLE
Open perfetto traces as soon as they are terminated

### DIFF
--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -1235,7 +1235,11 @@ public class TracerDialog {
             button.setText("Stop");
             break;
           case Done:
-            button.setText("Open Trace");
+            if (request.options.getType() == Service.TraceType.Perfetto) {
+              okPressed();
+            } else {
+              button.setText("Open Trace");
+            }
             break;
           default:
             button.setText("Cancel");


### PR DESCRIPTION
This avoids the user to have to press the "Open Trace" button.
We still want to keep an "Open Trace" button for Graphics traces, for
future plans of multiple graphics traces within the same app run.

Bug: b/143711475