### PR TITLE
Fix device instance name on Android

### DIFF
--- a/core/os/device/deviceinfo/cc/android/query.cpp
+++ b/core/os/device/deviceinfo/cc/android/query.cpp
@@ -136,7 +136,6 @@ struct Context {
   EGLContext mContext;
   int mNumCores;
   std::string mHost;
-  std::string mSerial;
   std::string mHardware;
   std::string mOSName;
   std::string mOSBuild;
@@ -501,7 +500,7 @@ const char* gpuName() { return ""; }
 
 const char* gpuVendor() { return ""; }
 
-const char* instanceName() { return gContext.mSerial.c_str(); }
+const char* instanceName() { return gContext.mHardware.c_str(); }
 
 const char* hardwareName() { return gContext.mHardware.c_str(); }
 


### PR DESCRIPTION
Return the hardware name for the instance name. This mirrors:
https://github.com/google/agi/blob/77648d1557836fcf549c4238e65fb1e35c1d296f/core/os/android/adb/device.go#L245

This also removes the "serial" field, as reading serial number via
ro.serialno property is prevented by SELinux, see:
https://cs.android.com/android/platform/superproject/+/master:system/sepolicy/public/domain.te;l=541;drc=19a5cc2bab59a4eea424ab38a6f1aa67b65860f1

Bug: b/153327038