### PR TITLE
Framelifecycle polishes (Updated Perfetto)

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/models/FrameEventsTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/FrameEventsTrack.java
@@ -400,14 +400,14 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
   public static class FrameSelection {
     public static FrameSelection EMPTY = new FrameSelection();
     // key = concat(layerName, '_', frameNumber)
-    private List<String> keys;
+    private Set<String> keys;
 
     public FrameSelection() {
-      keys = Lists.newArrayList();
+      keys = Sets.newHashSet();
     }
 
     public FrameSelection(long[] f, String[] l) {
-      keys = Lists.newArrayList();
+      keys = Sets.newHashSet();
       for (int i = 0; i < l.length; i++) {
         keys.add(l[i] + "_" + f[i]);
       }

--- a/gapic/src/main/com/google/gapid/perfetto/models/FrameEventsTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/FrameEventsTrack.java
@@ -25,22 +25,26 @@ import static com.google.gapid.perfetto.models.QueryEngine.expectOneRow;
 import static com.google.gapid.util.MoreFutures.transform;
 import static com.google.gapid.util.MoreFutures.transformAsync;
 import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.primitives.Longs;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gapid.perfetto.TimeSpan;
 import com.google.gapid.perfetto.views.FrameEventsMultiSelectionView;
 import com.google.gapid.perfetto.views.FrameEventsSelectionView;
 import com.google.gapid.perfetto.views.State;
 
-import java.util.Arrays;
 import org.eclipse.swt.widgets.Composite;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Consumer;
@@ -51,11 +55,12 @@ import java.util.function.Consumer;
 // TODO: dedupe code with SliceTrack.
 public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Data>{
   private static final String BASE_COLUMNS =
-      "id, ts, dur, category, name, depth, stack_id, parent_stack_id, arg_set_id";
+      "id, ts, dur, name, depth, stack_id, parent_stack_id, arg_set_id, " +
+      "frame_numbers, layer_names";
   private static final String SLICES_VIEW =
-      "select " + BASE_COLUMNS + " from gpu_slice where track_id = %d";
+      "select " + BASE_COLUMNS + " from frame_slice where track_id = %d";
   private static final String SLICE_SQL =
-      "select " + BASE_COLUMNS + " from gpu_slice where id = %d";
+      "select " + BASE_COLUMNS + " from frame_slice where id = %d";
   private static final String SLICES_SQL =
        "select " + BASE_COLUMNS + " from %s " +
        "where ts >= %d - dur and ts <= %d order by ts";
@@ -68,8 +73,15 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
       "where ts < %d and ts + dur >= %d and depth >= %d and depth <= %d";
   private static final String RANGE_FOR_IDS_SQL =
       "select " + BASE_COLUMNS + " from %s where id in (%s)";
+  private static final String STAT_TABLE_SQL =
+      "select frame_numbers, layer_names, queue_to_acquire_time, " +
+      "acquire_to_latch_time, latch_to_present_time " +
+      "from frame_slice left join frame_stats " +
+      "on frame_slice.id = frame_stats.slice_id " +
+      "where frame_stats.slice_id = %d";
 
   private static final long SIGNAL_MARGIN_NS = 10000;
+  private static final long FRAMELIFECYCLE_QUANTIZE_CUTOFF = MICROSECONDS.toNanos(500);
 
   private final long trackId;
 
@@ -98,26 +110,30 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
 
   @Override
   public ListenableFuture<Data> computeData(DataRequest req) {
-    Window window = Window.compute(req, 5);
+    Window window = Window.compute(req, 5, FRAMELIFECYCLE_QUANTIZE_CUTOFF);
     return transformAsync(window.update(qe, tableName("window")),
         $ -> window.quantized ? computeSummary(req, window) : computeSlices(req));
   }
 
   private ListenableFuture<Data> computeSlices(DataRequest req) {
     return transformAsync(qe.query(slicesSql(req)), res ->
-    transform(qe.getAllArgs(res.stream().mapToLong(r -> r.getLong(8))), args -> {
+    transform(qe.getAllArgs(res.stream().mapToLong(r -> r.getLong(7))), args -> {
       int rows = res.getNumRows();
-      Data data = new Data(req, new long[rows], new long[rows], new long[rows], new int[rows],
-          new String[rows], new String[rows], new ArgSet[rows]);
+      Data data = new Data(req, new long[rows], new long[rows], new long[rows],
+          new String[rows], new long[rows][], new String[rows][], new ArgSet[rows]);
       res.forEachRow((i, row) -> {
         long start = row.getLong(1);
         data.ids[i] = row.getLong(0);
         data.starts[i] = start;
         data.ends[i] = start + row.getLong(2);
-        data.categories[i] = row.getString(3);
-        data.titles[i] = row.getString(4);
-        data.depths[i] = row.getInt(5);
-        data.args[i] = args.getOrDefault(row.getLong(8), ArgSet.EMPTY);
+        data.titles[i] = row.getString(3);
+        data.args[i] = args.getOrDefault(row.getLong(7), ArgSet.EMPTY);
+        long[] frameNumbers = Arrays.stream(row.getString(8).split(", "))
+            .mapToLong(Long::parseLong)
+            .toArray();
+        String[] layerNames = row.getString(9).split(", ");
+        data.frameNumbers[i] = frameNumbers;
+        data.layerNames[i] = layerNames;
       });
       return data;
     }));
@@ -147,11 +163,31 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
 
   public ListenableFuture<Slice> getSlice(long id) {
     return transformAsync(expectOneRow(qe.query(sliceSql(id))), r ->
-        transform(qe.getArgs(r.getLong(8)), args -> buildSlice(r, args)));
+        transformAsync(qe.getArgs(r.getLong(7)), args ->
+        transform(getStats(id, r.getLong(2)), stats -> buildSlice(r, args, stats))));
   }
 
-  protected Slice buildSlice(QueryEngine.Row row, ArgSet args) {
-    return new Slice(row, args, trackId);
+  private ListenableFuture<Map<String, FrameStats>> getStats(long id, long dur) {
+    if (dur == 0) { // No stats for instant events
+      return Futures.immediateFuture(null);
+    }
+    return transform(qe.query(statSql(id)), result -> {
+      Map<String, FrameStats> stats = Maps.newHashMap();
+      result.forEachRow((i, row) -> {
+        stats.put(row.getString(1).split(", ")[i],
+            new FrameStats(Long.parseLong(row.getString(0).split(", ")[i]),
+                row.getLong(2), row.getLong(3), row.getLong(4)));
+      });
+      return stats;
+    });
+  }
+
+  private static String statSql(long sliceId) {
+    return format(STAT_TABLE_SQL, sliceId);
+  }
+
+  protected Slice buildSlice(QueryEngine.Row row, ArgSet args, Map<String, FrameStats> frameStats) {
+    return new Slice(row, args, frameStats);
   }
 
   private static String sliceSql(long id) {
@@ -160,7 +196,7 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
 
   public ListenableFuture<List<Slice>> getSlices(TimeSpan ts, int minDepth, int maxDepth) {
     return transform(qe.query(sliceRangeSql(ts, minDepth, maxDepth)),
-        res -> res.list(($, row) -> buildSlice(row, ArgSet.EMPTY)));
+        res -> res.list(($, row) -> buildSlice(row, ArgSet.EMPTY, null)));
   }
 
   private String sliceRangeSql(TimeSpan ts, int minDepth, int maxDepth) {
@@ -169,7 +205,7 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
 
   public ListenableFuture<List<Slice>> getSlices(String ids) {
     return transform(qe.query(sliceRangeForIdsSql(ids)),
-        res -> res.list(($, row) -> buildSlice(row, ArgSet.EMPTY)));
+        res -> res.list(($, row) -> buildSlice(row, ArgSet.EMPTY, null)));
   }
 
   private String sliceRangeForIdsSql(String ids) {
@@ -186,9 +222,9 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
     public final long[] ids;
     public final long[] starts;
     public final long[] ends;
-    public final int[] depths;
     public final String[] titles;
-    public final String[] categories;
+    public final long[][] frameNumbers;
+    public final String[][] layerNames;
     public final ArgSet[] args;
 
     public static enum Kind {
@@ -205,14 +241,14 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
       this.ids = null;
       this.starts = null;
       this.ends = null;
-      this.depths = null;
       this.titles = null;
-      this.categories = null;
+      this.frameNumbers = null;
+      this.layerNames = null;
       this.args = null;
     }
 
-    public Data(DataRequest request, long[] ids, long[] starts, long[] ends, int[] depths,
-        String[] titles, String[] categories, ArgSet[] args) {
+    public Data(DataRequest request, long[] ids, long[] starts, long[] ends,
+        String[] titles, long[][] frameNumbers, String[][] layerNames, ArgSet[] args) {
       super(request);
       this.kind = Kind.slices;
       this.bucketSize = 0;
@@ -221,9 +257,9 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
       this.ids = ids;
       this.starts = starts;
       this.ends = ends;
-      this.depths = depths;
       this.titles = titles;
-      this.categories = categories;
+      this.frameNumbers = frameNumbers;
+      this.layerNames = layerNames;
       this.args = args;
     }
   }
@@ -234,32 +270,48 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
     public final long dur;
     public final String name;
     public final ArgSet args;
-    public final long trackId;
+    public final long[] frameNumbers;
+    public final String[] layerNames;
+    // Map of each buffer(layerName) that contributed to the displayed frame, to
+    // its corresponding FrameStats
+    public final Map<String, FrameStats> frameStats;
 
-    public Slice(long id, long time, long dur, String name, long trackId) {
+    public Slice(long id, long time, long dur, String name, String frameNumbers,
+        String layerNames, Map<String, FrameStats> frameStats) {
       this.id = id;
       this.time = time;
       this.dur = dur;
       this.name = name;
       this.args = ArgSet.EMPTY;
-      this.trackId = trackId;
+      this.frameNumbers = Arrays.stream(frameNumbers.split(", "))
+          .mapToLong(Long::parseLong)
+          .toArray();
+      this.layerNames = layerNames.split(", ");
+      this.frameStats = frameStats;
     }
 
-    public Slice(long id, long time, long dur, String name, ArgSet args, long trackId) {
+    public Slice(long id, long time, long dur, String name, ArgSet args, String frameNumbers,
+        String layerNames, Map<String, FrameStats> frameStats) {
       this.id = id;
       this.time = time;
       this.dur = dur;
       this.name = name;
       this.args = args;
-      this.trackId = trackId;
+      this.frameNumbers = Arrays.stream(frameNumbers.split(", "))
+          .mapToLong(Long::parseLong)
+          .toArray();
+      this.layerNames = layerNames.split(", ");
+      this.frameStats = frameStats;
     }
 
-    public Slice(QueryEngine.Row row, ArgSet args, long trackId) {
-      this(row.getLong(0), row.getLong(1), row.getLong(2), row.getString(4), args, trackId);
+    public Slice(QueryEngine.Row row, ArgSet args, Map<String, FrameStats> frameStats) {
+      this(row.getLong(0), row.getLong(1), row.getLong(2), row.getString(3), args,
+          row.getString(8), row.getString(9), frameStats);
     }
 
-    public Slice(QueryEngine.Row row, long trackId) {
-      this(row.getLong(0), row.getLong(1), row.getLong(2), row.getString(4), trackId);
+    public Slice(QueryEngine.Row row, Map<String, FrameStats> frameStats) {
+      this(row.getLong(0), row.getLong(1), row.getLong(2), row.getString(3),
+          row.getString(8), row.getString(9), frameStats);
     }
 
     @Override
@@ -291,6 +343,9 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
       }
     }
 
+    public FrameSelection getSelection() {
+      return new FrameSelection(frameNumbers, layerNames);
+    }
   }
 
   public static class Slices implements Selection {
@@ -333,6 +388,62 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
         slice.getRange(span);
       }
     }
+
+    public FrameSelection getSelection() {
+      FrameSelection selection = new FrameSelection();
+      slices.forEach(s -> selection.combine(s.getSelection()));
+      return selection;
+    }
+  }
+
+  public static class FrameSelection {
+    public final List<Long> frameNumbers;
+    public final List<String> layerNames;
+    public static FrameSelection EMPTY = new FrameSelection();
+
+    public FrameSelection() {
+      frameNumbers = Lists.newArrayList();
+      layerNames = Lists.newArrayList();
+    }
+
+    public FrameSelection(long[] frameNumbers, String[] layerNames) {
+      this.frameNumbers = Lists.newArrayList(Longs.asList(frameNumbers));
+      this.layerNames = Lists.newArrayList(layerNames);
+    }
+
+    public boolean contains(long[] f, String[] l) {
+      for (int i = 0; i < f.length; i++) {
+        int idx = frameNumbers.indexOf(f[i]);
+        if (idx != -1 && layerNames.get(idx).equals(l[i])) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    public void combine(FrameSelection other) {
+      frameNumbers.addAll(other.frameNumbers);
+      layerNames.addAll(other.layerNames);
+    }
+
+    public boolean isEmpty() {
+      return frameNumbers.size() == 0 ? true : false;
+    }
+  }
+
+  public static class FrameStats {
+    public final long frameNumber;
+    public final long queueToAcquireTime;
+    public final long acquireToLatchTime;
+    public final long latchToPresentTime;
+
+    public FrameStats(long frameNumber, long queueToAcquireTime, long acquireToLatchTime,
+        long latchToPresentTime) {
+      this.frameNumber = frameNumber;
+      this.queueToAcquireTime = queueToAcquireTime;
+      this.acquireToLatchTime = acquireToLatchTime;
+      this.latchToPresentTime = latchToPresentTime;
+    }
   }
 
   public static class SlicesBuilder implements Selection.Builder<SlicesBuilder> {
@@ -346,7 +457,7 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
       String ti = "";
       for (Slice slice : slices) {
         ti = slice.getTitle();
-        roots.put(slice.id, new Node(slice.name, slice.dur, slice.dur, slice.trackId));
+        roots.put(slice.id, new Node(slice.name, slice.dur, slice.dur, slice.layerNames));
         sliceKeys.add(slice.id);
       }
       this.title = ti;
@@ -375,13 +486,13 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
     public final String name;
     public final long dur;
     public final long self;
-    public final long trackId;
+    public final String[] layers;
 
-    public Node(String name, long dur, long self, long id) {
+    public Node(String name, long dur, long self, String[] layers) {
       this.name = name;
       this.dur = dur;
       this.self = self;
-      this.trackId = id;
+      this.layers = layers;
     }
   }
 }

--- a/gapic/src/main/com/google/gapid/perfetto/models/FrameInfo.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/FrameInfo.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.perfetto.models;
+
+import static com.google.gapid.util.MoreFutures.transform;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.gapid.models.Perfetto;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Data about a GPU in the trace.
+ */
+public class FrameInfo {
+  public static final FrameInfo NONE = new FrameInfo(Collections.emptyList());
+
+  private static final String FRAME_SLICE_QUERY =
+      "select t.id, t.name, t.scope, max(depth) + 1 " +
+      "from gpu_track t join frame_slice s on (t.id = s.track_id) " +
+      "group by t.id " +
+      "order by t.id";
+
+  private final List<Buffer> buffers;
+
+  private FrameInfo(List<Buffer> buffers) {
+    this.buffers = buffers;
+  }
+
+  public boolean isEmpty() {
+    return buffers.isEmpty();
+  }
+
+  public int bufferCount() {
+    return buffers.size();
+  }
+
+  public Iterable<Buffer> buffers() {
+    return Iterables.unmodifiableIterable(buffers);
+  }
+
+  public static ListenableFuture<Perfetto.Data.Builder> listFrames(Perfetto.Data.Builder data) {
+    return transform(info(data.qe), frame -> data.setFrame(frame));
+  }
+
+  private static ListenableFuture<FrameInfo> info(QueryEngine qe) {
+    return
+        transform(qe.queries(FRAME_SLICE_QUERY), frame -> {
+            List<Buffer> buffers = Lists.newArrayList();
+            frame.forEachRow(($, r) -> {
+              buffers.add(new Buffer(r));
+            });
+
+            // Sort buffers by name, the query is sorted by track id for the queues.
+            buffers.sort((b1, b2) -> {
+              // Displayed Frame track should always be at top
+              if (b1.name.equals("Displayed Frame")) {
+                return -1;
+              } else if(b2.name.equals("Displayed Frame")) {
+                return 1;
+              }
+              return b1.name.compareTo(b2.name);
+            });
+            return new FrameInfo(buffers);
+        });
+  }
+
+  public static class Buffer {
+    public final long trackId;
+    public final String name;
+    public final int maxDepth;
+
+    public Buffer(long trackId, String name, int maxDepth) {
+      this.trackId = trackId;
+      this.name = name;
+      this.maxDepth = maxDepth;
+    }
+
+    public Buffer(QueryEngine.Row row) {
+      this(row.getLong(0), row.getString(1), row.getInt(3));
+    }
+
+    public String getDisplay() {
+      return name;
+    }
+  }
+}

--- a/gapic/src/main/com/google/gapid/perfetto/models/FrameInfo.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/FrameInfo.java
@@ -36,6 +36,7 @@ public class FrameInfo {
       "from gpu_track t join frame_slice s on (t.id = s.track_id) " +
       "group by t.id " +
       "order by t.id";
+  private static final String DISPLAYED_FRAME_TRACK_NAME = "Displayed Frame";
 
   private final List<Buffer> buffers;
 
@@ -67,12 +68,12 @@ public class FrameInfo {
               buffers.add(new Buffer(r));
             });
 
-            // Sort buffers by name, the query is sorted by track id for the queues.
+            // Sort buffers by name, the query is sorted by track id.
             buffers.sort((b1, b2) -> {
               // Displayed Frame track should always be at top
-              if (b1.name.equals("Displayed Frame")) {
+              if (b1.name.equals(DISPLAYED_FRAME_TRACK_NAME)) {
                 return -1;
-              } else if(b2.name.equals("Displayed Frame")) {
+              } else if(b2.name.equals(DISPLAYED_FRAME_TRACK_NAME)) {
                 return 1;
               }
               return b1.name.compareTo(b2.name);

--- a/gapic/src/main/com/google/gapid/perfetto/models/GpuInfo.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/GpuInfo.java
@@ -16,7 +16,6 @@
 package com.google.gapid.perfetto.models;
 
 import static com.google.gapid.util.MoreFutures.transform;
-import static com.google.gapid.util.MoreFutures.transformAsync;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -30,32 +29,24 @@ import java.util.List;
  * Data about a GPU in the trace.
  */
 public class GpuInfo {
-  public static final GpuInfo NONE = new GpuInfo(Collections.emptyList(), Collections.emptyList(),
-      Collections.emptyList());
+  public static final GpuInfo NONE = new GpuInfo(Collections.emptyList(), Collections.emptyList());
 
   private static final String MAX_DEPTH_QUERY =
       "select t.id, t.name, t.scope, max(depth) + 1 " +
       "from gpu_track t left join gpu_slice s on (t.id = s.track_id) " +
       "group by t.id " +
       "order by t.id";
-  private static final String FRAME_SLICE_QUERY =
-      "select t.id, t.name, t.scope, max(depth) + 1 " +
-      "from gpu_track t join frame_slice s on (t.id = s.track_id) " +
-      "group by t.id " +
-      "order by t.id";
 
   private final List<Queue> queues;
   private final List<VkApiEvent> vkApiEvents;
-  private final List<Buffer> buffers;
 
-  private GpuInfo(List<Queue> queues, List<VkApiEvent> vkApiEvents, List<Buffer> buffers) {
+  private GpuInfo(List<Queue> queues, List<VkApiEvent> vkApiEvents) {
     this.queues = queues;
     this.vkApiEvents = vkApiEvents;
-    this.buffers = buffers;
   }
 
   public boolean isEmpty() {
-    return queues.isEmpty() && buffers.isEmpty();
+    return queues.isEmpty();
   }
 
   public int queueCount() {
@@ -74,25 +65,15 @@ public class GpuInfo {
     return Iterables.unmodifiableIterable(vkApiEvents);
   }
 
-  public int bufferCount() {
-    return buffers.size();
-  }
-
-  public Iterable<Buffer> buffers() {
-    return Iterables.unmodifiableIterable(buffers);
-  }
-
   public static ListenableFuture<Perfetto.Data.Builder> listGpus(Perfetto.Data.Builder data) {
     return transform(info(data.qe), gpu -> data.setGpu(gpu));
   }
 
   private static ListenableFuture<GpuInfo> info(QueryEngine qe) {
     return
-        transformAsync(qe.queries(MAX_DEPTH_QUERY), res ->
-          transform(qe.queries(FRAME_SLICE_QUERY), frame -> {
+        transform(qe.queries(MAX_DEPTH_QUERY), res -> {
             List<Queue> queues = Lists.newArrayList();
             List<VkApiEvent> vkApiEvents = Lists.newArrayList();
-            List<Buffer> buffers = Lists.newArrayList();
             res.forEachRow(($, r) -> {
               switch (r.getString(2)) {
                 case "gpu_render_stage":
@@ -103,23 +84,8 @@ public class GpuInfo {
                   break;
               }
             });
-
-            frame.forEachRow(($, r) -> {
-              buffers.add(new Buffer(r));
-            });
-
-            // Sort buffers by name, the query is sorted by track id for the queues.
-            buffers.sort((b1, b2) -> {
-              // Displayed Frame track should always be at top
-              if (b1.name.equals("Displayed Frame")) {
-                return -1;
-              } else if(b2.name.equals("Displayed Frame")) {
-                return 1;
-              }
-              return b1.name.compareTo(b2.name);
-            });
-            return new GpuInfo(queues, vkApiEvents, buffers);
-          }));
+            return new GpuInfo(queues, vkApiEvents);
+        });
   }
 
   public static class Queue {
@@ -154,26 +120,6 @@ public class GpuInfo {
     }
 
     public VkApiEvent(QueryEngine.Row row) {
-      this(row.getLong(0), row.getString(1), row.getInt(3));
-    }
-
-    public String getDisplay() {
-      return name;
-    }
-  }
-
-  public static class Buffer {
-    public final long trackId;
-    public final String name;
-    public final int maxDepth;
-
-    public Buffer(long trackId, String name, int maxDepth) {
-      this.trackId = trackId;
-      this.name = name;
-      this.maxDepth = maxDepth;
-    }
-
-    public Buffer(QueryEngine.Row row) {
       this(row.getLong(0), row.getString(1), row.getInt(3));
     }
 

--- a/gapic/src/main/com/google/gapid/perfetto/models/Track.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Track.java
@@ -235,6 +235,14 @@ public abstract class Track<D extends Track.Data> {
       }
     }
 
+    public static Window compute(DataRequest request, int bucketSizePx, long cutoff) {
+      if (request.resolution >= cutoff) {
+        return quantized(request, bucketSizePx);
+      } else {
+        return compute(request);
+      }
+    }
+
     public static Window quantized(DataRequest request, int bucketSizePx) {
       long quantum = request.resolution * bucketSizePx;
       long start = (request.range.start / quantum) * quantum;

--- a/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
@@ -64,6 +64,7 @@ public class Tracks {
       enumerateCpu(data);
       enumerateCounters(data);
       enumerateGpu(data);
+      enumerateFrame(data);
       enumerateProcesses(data);
       enumerateVSync(data);
       return data;
@@ -149,20 +150,6 @@ public class Tracks {
       }
     }
 
-    if (data.getGpu().bufferCount() > 0) {
-      String parent = "gpu";
-      if (data.getGpu().bufferCount() > 1) {
-        data.tracks.addLabelGroup("gpu", "sf_events", "Surface Flinger Events",
-            group(state -> new TitlePanel("Surface Flinger Events"), true));
-        parent = "sf_events";
-      }
-      for (GpuInfo.Buffer buffer : data.getGpu().buffers()) {
-        FrameEventsTrack track = FrameEventsTrack.forBuffer(data.qe, buffer);
-        data.tracks.addTrack(parent, track.getId(), buffer.getDisplay(),
-            single(state -> new FrameEventsSummaryPanel(state, buffer, track), true, false));
-      }
-    }
-
     if (!counters.isEmpty()) {
       String parent = "gpu";
       if (counters.size() > 1) {
@@ -175,6 +162,20 @@ public class Tracks {
         data.tracks.addTrack(parent, track.getId(), counter.name,
             single(state -> new CounterPanel(state, track, DEFAULT_COUNTER_TRACK_HEIGHT), true,
                 /*right truncate*/ true));
+      }
+    }
+    return data;
+  }
+
+  public static Perfetto.Data.Builder enumerateFrame(Perfetto.Data.Builder data) {
+    if (data.getFrame().bufferCount() > 0) {
+      data.tracks.addLabelGroup(null, "sf_events", "Surface Flinger Events",
+          group(state -> new TitlePanel("Surface Flinger Events"), true));
+      String parent = "sf_events";
+      for (FrameInfo.Buffer buffer : data.getFrame().buffers()) {
+        FrameEventsTrack track = FrameEventsTrack.forBuffer(data.qe, buffer);
+        data.tracks.addTrack(parent, track.getId(), buffer.getDisplay(),
+            single(state -> new FrameEventsSummaryPanel(state, buffer, track), true, false));
       }
     }
     return data;

--- a/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsMultiSelectionView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsMultiSelectionView.java
@@ -63,8 +63,8 @@ public class FrameEventsMultiSelectionView extends Composite {
     viewer.setLabelProvider(new LabelProvider());
 
     createTreeColumn(viewer, "Name", e -> n(e).name);
-    createTreeColumn(viewer, "TrackId", e -> Long.toString(n(e).trackId));
     createTreeColumn(viewer, "Self Time", e -> timeToString(n(e).self));
+    createTreeColumn(viewer, "Layers", e -> String.join(", ", n(e).layers));
     viewer.setInput(sel);
     packColumns(viewer.getTree());
   }

--- a/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSelectionView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSelectionView.java
@@ -32,6 +32,9 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 /**
  * Displays information about a selected Frame event.
  */
@@ -41,7 +44,7 @@ public class FrameEventsSelectionView extends Composite {
 
   public FrameEventsSelectionView(Composite parent, State state, FrameEventsTrack.Slice slice) {
     super(parent, SWT.NONE);
-    setLayout(withMargin(new GridLayout(2, false), 0, 0));
+    setLayout(withMargin(new GridLayout(3, false), 0, 0));
 
     Composite main = withLayoutData(createComposite(this, new GridLayout(2, false)),
         new GridData(SWT.LEFT, SWT.TOP, false, false));
@@ -55,6 +58,34 @@ public class FrameEventsSelectionView extends Composite {
 
     createLabel(main, "Duration:");
     createLabel(main, timeToString(slice.dur));
+
+    if (slice.dur > 0) {
+      // If the selected event is a displayed frame slice, show the frame stats
+      Composite stats = withLayoutData(createComposite(this, new GridLayout(2, false)),
+          withIndents(new GridData(SWT.LEFT, SWT.TOP, false, false), PANEL_INDENT, 0));
+      withLayoutData(createBoldLabel(stats, "Frame Stats:"),
+          withSpans(new GridData(), 2, 1));
+
+      slice.frameStats.forEach((k, v) -> {
+        withLayoutData(createBoldLabel(stats, k.toString()),
+            withSpans(new GridData(), 2, 1));
+
+        createLabel(stats, "Queue to Acquire: ");
+        createLabel(stats, timeToString(v.queueToAcquireTime));
+
+        createLabel(stats, "Acquire to Latch: ");
+        createLabel(stats, timeToString(v.acquireToLatchTime));
+
+        createLabel(stats, "Latch to Present: ");
+        createLabel(stats, timeToString(v.latchToPresentTime));
+      });
+    } else {
+      // Show the frame number associated with the event
+      createLabel(main, "Frame Number:");
+      createLabel(main, Arrays.stream(slice.frameNumbers)
+          .mapToObj(Long::toString)
+          .collect(Collectors.joining(", ")));
+    }
 
     if (!slice.args.isEmpty()) {
       String[] keys = Iterables.toArray(slice.args.keys(), String.class);

--- a/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSelectionView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSelectionView.java
@@ -59,7 +59,7 @@ public class FrameEventsSelectionView extends Composite {
     createLabel(main, "Duration:");
     createLabel(main, timeToString(slice.dur));
 
-    if (slice.dur > 0) {
+    if (slice.frameStats != null) {
       // If the selected event is a displayed frame slice, show the frame stats
       Composite stats = withLayoutData(createComposite(this, new GridLayout(2, false)),
           withIndents(new GridData(SWT.LEFT, SWT.TOP, false, false), PANEL_INDENT, 0));
@@ -69,6 +69,9 @@ public class FrameEventsSelectionView extends Composite {
       slice.frameStats.forEach((k, v) -> {
         withLayoutData(createBoldLabel(stats, k.toString()),
             withSpans(new GridData(), 2, 1));
+
+        createLabel(stats, "Frame number: ");
+        createLabel(stats, Long.toString(v.frameNumber));
 
         createLabel(stats, "Queue to Acquire: ");
         createLabel(stats, timeToString(v.queueToAcquireTime));

--- a/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSummaryPanel.java
@@ -31,7 +31,7 @@ import com.google.gapid.perfetto.canvas.Size;
 import com.google.gapid.perfetto.models.ArgSet;
 import com.google.gapid.perfetto.models.FrameEventsTrack;
 import com.google.gapid.perfetto.models.FrameEventsTrack.FrameSelection;
-import com.google.gapid.perfetto.models.GpuInfo;
+import com.google.gapid.perfetto.models.FrameInfo;
 import com.google.gapid.perfetto.models.Selection;
 import com.google.gapid.perfetto.models.Selection.CombiningBuilder;
 import com.google.gapid.util.Arrays;
@@ -54,7 +54,7 @@ public class FrameEventsSummaryPanel extends TrackPanel<FrameEventsSummaryPanel>
   private static final double CURSOR_SIZE = 5;
   private static final int BOUNDING_BOX_LINE_WIDTH = 3;
 
-  private final GpuInfo.Buffer buffer;
+  private final FrameInfo.Buffer buffer;
   protected final FrameEventsTrack track;
 
   protected double mouseXpos, mouseYpos;
@@ -63,12 +63,11 @@ public class FrameEventsSummaryPanel extends TrackPanel<FrameEventsSummaryPanel>
   protected Size hoveredSize = Size.ZERO;
   protected HoverCard hovered;
 
-  public FrameEventsSummaryPanel(State state, GpuInfo.Buffer buffer, FrameEventsTrack track) {
+  public FrameEventsSummaryPanel(State state, FrameInfo.Buffer buffer, FrameEventsTrack track) {
     super(state);
     this.buffer = buffer;
     this.track = track;
   }
-
 
   @Override
   public String getTitle() {

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -174,7 +174,7 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
         locals = locals,
         remote = "https://android.googlesource.com/platform/external/perfetto",
         commit = "4d9bf4234b682c2ec79ab925c028d8c033c9c409",
-        shallow_since = "1584655664 -0700",
+        shallow_since = "1585081996 -0700",
     )
 
     maybe_repository(

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -173,8 +173,8 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
         name = "perfetto",
         locals = locals,
         remote = "https://android.googlesource.com/platform/external/perfetto",
-        commit = "f447425f9f7f676bf22d3c5e4a78f30d43c92c95",
-        shallow_since = "1582916230 +0000",
+        commit = "4d9bf4234b682c2ec79ab925c028d8c033c9c409",
+        shallow_since = "1584655664 -0700",
     )
 
     maybe_repository(


### PR DESCRIPTION
Now that the frame events are separated from the gpu_slice table, this PR addresses that change and the following:
- Show statistics of all the frames/buffers that got composited into a displayed frame, when it is selected
- Highlight(draw in color) all related events of the frame when an instant event is selected, greying out other events
- Highlight(draw in color) all related events of all the frames within a displayed frame slice when it is selected, greying out other events
- Minor: Make sure that displayed frame track always goes on top of all other tracks under the SF events group
- Minor: Remove trackId from multiselection view and show layer name instead

Bug: 152533807, 150172851