### PR TITLE
Remove -api flag from benchmark call

### DIFF
--- a/test/swarming/bot-task.sh
+++ b/test/swarming/bot-task.sh
@@ -58,5 +58,5 @@ if [ ! -z "${SWARMING_FORCE_INSTALL}" ] ; then
 fi
 
 # Run AGI test
-$SWARMING_AGI/gapit benchmark -api vulkan -startframe "${SWARMING_STARTFRAME}" -numframes "${SWARMING_NUMFRAME}" "${SWARMING_PACKAGE}/${SWARMING_ACTIVITY}"
+$SWARMING_AGI/gapit benchmark -startframe "${SWARMING_STARTFRAME}" -numframes "${SWARMING_NUMFRAME}" "${SWARMING_PACKAGE}/${SWARMING_ACTIVITY}"
 mv benchmark.gfxtrace ${SWARMING_OUT_DIR}/


### PR DESCRIPTION
This flag was removed with #198, which was merged in parallel with #196.