### PR TITLE
Vulkan sample fixes and "improvements"

### DIFF
--- a/cmd/vulkan_sample/main.cpp
+++ b/cmd/vulkan_sample/main.cpp
@@ -1313,12 +1313,11 @@ int main(int argc, const char** argv) {
     }
 
     {
-      VkCommandBuffer cbs[2];
       VkCommandBufferAllocateInfo allocate_info{
           VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, nullptr,
-          command_pools[i], VK_COMMAND_BUFFER_LEVEL_PRIMARY, 2};
-      REQUIRE_SUCCESS(vkAllocateCommandBuffers(device, &allocate_info, cbs));
-      render_command_buffers[i] = cbs[1];
+          command_pools[i], VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1};
+      REQUIRE_SUCCESS(vkAllocateCommandBuffers(device, &allocate_info,
+                                               &render_command_buffers[i]));
     }
 
     {

--- a/cmd/vulkan_sample/main.cpp
+++ b/cmd/vulkan_sample/main.cpp
@@ -1571,25 +1571,6 @@ int main(int argc, const char** argv) {
 
     REQUIRE_SUCCESS(vkBeginCommandBuffer(render_command_buffers[frame_parity],
                                          &begin_info));
-    if (frame_count < kBufferingCount) {
-      // Pipeline barrier here to convert images into their initial format
-      VkImageMemoryBarrier image_barrier{
-          VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-          nullptr,
-          0,
-          VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT,
-          VK_IMAGE_LAYOUT_UNDEFINED,
-          VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
-          queue_family_index,
-          queue_family_index,
-          depth_buffers[frame_parity],
-          VkImageSubresourceRange{VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1}};
-
-      vkCmdPipelineBarrier(render_command_buffers[frame_parity],
-                           VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                           VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT, 0, 0,
-                           nullptr, 0, nullptr, 1, &image_barrier);
-    }
 
     if (framebuffers[frame_parity] != VK_NULL_HANDLE) {
       vkDestroyFramebuffer(device, framebuffers[frame_parity], nullptr);

--- a/cmd/vulkan_sample/main.cpp
+++ b/cmd/vulkan_sample/main.cpp
@@ -1597,8 +1597,8 @@ int main(int argc, const char** argv) {
     float ca = cosf(angle);
     float sa = sinf(angle);
 
-    float mat[16] = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, ca,   sa,    0.0f,
-                     0.0f, -sa,  ca,   0.0f, 0.0f, 0.0f, -3.0f, 1.0f};
+    float mat[16] = {ca, sa * sa,  -ca * sa, 0.0f, 0.0f, ca,   sa,    0.0f,
+                     sa, -ca * sa, ca * ca,  0.0f, 0.0f, 0.0f, -2.0f, 1.0f};
     float aspect = float(surface_capabilities.currentExtent.width) /
                    float(surface_capabilities.currentExtent.height);
 


### PR DESCRIPTION
- Remove the unnecessary image layout transitions of the framebuffers, since the render pass will do it for us.
- Fixed a small typo causing too many command buffers to be allocated.
- Create the fences in the signaled state, so we don't have to keep track of whether we've gone through the first few frames or not.
- Stop destroying and creating the framebuffer on every frame, but pre-allocate each combo.
- Made the cube stumble, cause spinning is booooring.
- Made the cube bigger, cause bigger cubes are better.