### PR TITLE
Build host coordination block for commands after vkQueueSubmit.

### DIFF
--- a/gapis/resolve/command_tree.go
+++ b/gapis/resolve/command_tree.go
@@ -403,12 +403,11 @@ func addContainingGroups(
 	kind service.EventKind,
 	label string) {
 
-	count := 0
 	lastLeft := api.CmdID(0)
 	for _, e := range events.List {
 		i := api.CmdID(e.Command.Indices[0])
 		switch e.Kind {
-		case kind:
+		case kind, service.EventKind_LastInFrame:
 			// Find group which contains this event
 			group := &t.root
 			for true {
@@ -437,11 +436,7 @@ func addContainingGroups(
 			lastLeft = end
 			if start < end {
 				t.root.AddGroup(start, end, label)
-				count++
 			}
-
-		case service.EventKind_LastInFrame:
-			count = 0
 		}
 	}
 }


### PR DESCRIPTION
 - So far when GroupBySubmission is toggled on, we do command grouping
 for the commands between two adjacent vkQueueSubmit commands. We should
 do another grouping for the commands after the last vkQueueSubmit in a
 frame as well.
 - Remove unused local variable `count`.
 - Bug: b/150944398.