### PR TITLE
Show individual process' memory usage (RSS)

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/Unit.java
+++ b/gapic/src/main/com/google/gapid/perfetto/Unit.java
@@ -154,6 +154,10 @@ public class Unit {
     }
   }
 
+  public static String bytesToString(long val) {
+    return Unit.BYTE.format(val);
+  }
+
   private static interface Formatter {
     public String format(long value);
     public String format(double value);

--- a/gapic/src/main/com/google/gapid/perfetto/models/BatterySummaryTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/BatterySummaryTrack.java
@@ -35,11 +35,13 @@ import com.google.gapid.perfetto.TimeSpan;
 import com.google.gapid.perfetto.views.BatterySelectionView;
 import com.google.gapid.perfetto.views.BatterySummaryPanel;
 import com.google.gapid.perfetto.views.State;
+
+import org.eclipse.swt.widgets.Composite;
+
 import java.util.Arrays;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
-import org.eclipse.swt.widgets.Composite;
 
 public class BatterySummaryTrack extends Track.WithQueryEngine<BatterySummaryTrack.Data>{
   private static final String VIEW_SQL =
@@ -244,7 +246,7 @@ public class BatterySummaryTrack extends Track.WithQueryEngine<BatterySummaryTra
 
     @Override
     public String getTitle() {
-      return "Batteries";
+      return "Battery Usage";
     }
 
     @Override

--- a/gapic/src/main/com/google/gapid/perfetto/models/BatterySummaryTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/BatterySummaryTrack.java
@@ -15,135 +15,37 @@
  */
 package com.google.gapid.perfetto.models;
 
-import static com.google.gapid.perfetto.models.QueryEngine.createSpan;
-import static com.google.gapid.perfetto.models.QueryEngine.createView;
-import static com.google.gapid.perfetto.models.QueryEngine.createWindow;
-import static com.google.gapid.perfetto.models.QueryEngine.dropTable;
-import static com.google.gapid.perfetto.models.QueryEngine.dropView;
-import static com.google.gapid.perfetto.models.QueryEngine.expectOneRow;
+import static com.google.gapid.perfetto.models.CounterInfo.needQuantize;
 import static com.google.gapid.perfetto.views.TrackContainer.single;
-import static com.google.gapid.util.MoreFutures.transform;
-import static com.google.gapid.util.MoreFutures.transformAsync;
-import static java.lang.String.format;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gapid.models.Perfetto;
-import com.google.gapid.perfetto.TimeSpan;
+import com.google.gapid.perfetto.models.QueryEngine.Row;
 import com.google.gapid.perfetto.views.BatterySelectionView;
 import com.google.gapid.perfetto.views.BatterySummaryPanel;
 import com.google.gapid.perfetto.views.State;
 
 import org.eclipse.swt.widgets.Composite;
 
-import java.util.Arrays;
-import java.util.Set;
-import java.util.function.Consumer;
-import java.util.stream.IntStream;
+import java.util.function.BinaryOperator;
 
-public class BatterySummaryTrack extends Track.WithQueryEngine<BatterySummaryTrack.Data>{
-  private static final String VIEW_SQL =
-      "select min(id) id, ts, lead(ts) over (order by ts) - ts dur, max(a) capacity, max(b) charge," +
-      "   max(c) current " +
-      "from (select id, ts," +
-      "  case when track_id = %d then cast(value as int) end a," +
-      "  case when track_id = %d then cast(value as int) end b," +
-      "  case when track_id = %d then cast(value as int) end c " +
-      "  from counter where track_id in (%d, %d, %d))" +
-      "group by ts";
-  private static final String SUMMARY_SQL =
-      "select id, min(start), max(end), cast(avg(capacity) as int), cast(avg(charge) as int), " +
-      "    cast(avg(current) as int) from ( " +
-      "  select min(id) id, min(ts) start, max(ts + dur) end, cast(avg(capacity) as int) capacity, " +
-      "      cast(avg(charge) as int) charge, cast(avg(current) as int) current " +
-      "  from %s group by quantum_ts)" +
-      "group by id";
-  private static final String COUNTER_SQL =
-      "select id, ts, ts + dur, capacity, charge, current from %s";
-  private static final String VALUE_SQL =
-      "select id, ts, dur, capacity, charge, current from %s where id = %d";
-  private static final String RANGE_SQL =
-      "select id, ts, dur, capacity, charge, current from %s " +
-          "where ts + dur >= %d and ts <= %d order by ts";
-
-  private final long capacityId;
-  private final long chargeId;
-  private final long currentId;
+public class BatterySummaryTrack
+    extends CombinedCountersTrack<BatterySummaryTrack.Data, BatterySummaryTrack.Values> {
   private final double maxAbsCurrent;
-  private final boolean needQuantize;
 
   public BatterySummaryTrack(
       QueryEngine qe, CounterInfo capacity, CounterInfo charge, CounterInfo current) {
-    super(qe, "bat_sum");
-    this.capacityId = capacity.id;
-    this.chargeId = charge.id;
-    this.currentId = current.id;
-    long maxCount = Math.max(capacity.count, Math.max(charge.count, current.count));
+    super(qe, "bat_sum", new Column[] {
+        new Column(capacity.id, "int", "0", "avg"),
+        new Column(charge.id, "int", "0", "avg"),
+        new Column(current.id, "int", "0", "avg"),
+    }, needQuantize(capacity, charge, current));
     this.maxAbsCurrent = Math.max(Math.abs(current.min), Math.abs(current.max));
-    this.needQuantize = maxCount > Track.QUANTIZE_CUT_OFF;
   }
 
   public double getMaxAbsCurrent() {
     return maxAbsCurrent;
-  }
-
-  @Override
-  protected ListenableFuture<?> initialize() {
-    String vals = tableName("vals");
-    String span = tableName("span");
-    String window = tableName("window");
-    return qe.queries(
-        dropTable(span),
-        dropTable(window),
-        dropView(vals),
-        createView(vals, viewSql()),
-        createWindow(window),
-        createSpan(span, vals + ", " + window));
-  }
-
-  private String viewSql() {
-    return format(VIEW_SQL, capacityId, chargeId, currentId, capacityId, chargeId, currentId);
-  }
-
-  @Override
-  protected ListenableFuture<Data> computeData(DataRequest req) {
-    Window win = needQuantize ? Window.compute(req, 5) : Window.compute(req);
-    return transformAsync(win.update(qe, tableName("window")), $ -> computeData(req, win));
-  }
-
-  private ListenableFuture<Data> computeData(DataRequest req, Window win) {
-    return transform(qe.query(win.quantized ? summarySql() : counterSQL()), res -> {
-      int rows = res.getNumRows();
-      if (rows == 0) {
-        return Data.empty(req);
-      }
-
-      Data data = new Data(req, new long[rows + 1], new long[rows + 1], new long[rows + 1],
-          new long[rows + 1], new long[rows + 1]);
-      res.forEachRow((i, r) -> {
-        data.id[i] = r.getLong(0);
-        data.ts[i] = r.getLong(1);
-        data.capacity[i] = r.getLong(3);
-        data.charge[i] = r.getLong(4);
-        data.current[i] = r.getLong(5);
-      });
-      data.id[rows] = data.id[rows - 1];
-      data.ts[rows] = res.getLong(rows - 1, 2, 0);
-      data.capacity[rows] = data.capacity[rows - 1];
-      data.charge[rows] = data.charge[rows - 1];
-      data.current[rows] = data.current[rows - 1];
-      return data;
-    });
-  }
-
-  private String summarySql() {
-    return format(SUMMARY_SQL, tableName("span"));
-  }
-
-  private String counterSQL() {
-    return format(COUNTER_SQL, tableName("span"));
   }
 
   public static Perfetto.Data.Builder enumerate(Perfetto.Data.Builder data) {
@@ -161,87 +63,74 @@ public class BatterySummaryTrack extends Track.WithQueryEngine<BatterySummaryTra
     return data;
   }
 
-  public ListenableFuture<Values> getValue(long id) {
-    return transform(expectOneRow(qe.query(valueSql(id))), row -> {
-      Values v = new Values(new long[1], new long[1], new long[1], new long[1], new long[1],
-          Sets.newHashSet());
-      v.valueKeys.add(row.getLong(0));
-      v.ts[0] = row.getLong(1);
-      v.dur[0] = row.getLong(2);
-      v.capacity[0] = row.getLong(3);
-      v.charge[0] = row.getLong(4);
-      v.current[0] = row.getLong(5);
-      return v;
-    });
-  }
-
-  private String valueSql(long id) {
-    return format(VALUE_SQL, tableName("vals"), id);
-  }
-
-  public ListenableFuture<Values> getValues(TimeSpan ts) {
-    return transform(qe.query(rangeSql(ts)), res -> {
-      int rows = res.getNumRows();
-      Values v = new Values(new long[rows], new long[rows], new long[rows], new long[rows],
-          new long[rows], Sets.newHashSet());
-      res.forEachRow((i, r) -> {
-        v.valueKeys.add(r.getLong(0));
-        v.ts[i] = r.getLong(1);
-        v.dur[i] = r.getLong(2);
-        v.capacity[i] = r.getLong(3);
-        v.charge[i] = r.getLong(4);
-        v.current[i] = r.getLong(5);
-      });
-      return v;
-    });
-  }
-
-  private String rangeSql(TimeSpan ts) {
-    return format(RANGE_SQL, tableName("vals"), ts.start, ts.end);
-  }
-
   private static CounterInfo onlyOne(ImmutableList<CounterInfo> counters) {
     return (counters.size() != 1) ? null : counters.get(0);
   }
 
-  public static class Data extends Track.Data {
-    public final long[] id;
-    public final long[] ts;
+  @Override
+  protected Data createData(DataRequest request, int numRows) {
+    return new Data(request, numRows);
+  }
+
+  @Override
+  protected Values createValues(int numRows, BinaryOperator<Values> combiner) {
+    return new Values(numRows, combiner);
+  }
+
+  public static class Data extends CombinedCountersTrack.Data {
     public final long[] capacity;
     public final long[] charge;
     public final long[] current;
 
-    public Data(DataRequest request, long[] id, long[] ts, long[] capacity, long[] charge,
-        long[] current) {
-      super(request);
-      this.id = id;
-      this.ts = ts;
-      this.capacity = capacity;
-      this.charge = charge;
-      this.current = current;
+    public Data(DataRequest request, int numRows) {
+      super(request, numRows);
+      this.capacity = new long[numRows];
+      this.charge = new long[numRows];
+      this.current = new long[numRows];
     }
 
-    public static Data empty(DataRequest req) {
-      return new Data(req, new long[0], new long[0], new long[0], new long[0], new long[0]);
+    @Override
+    public void set(int idx, Row row) {
+      super.set(idx, row);
+      capacity[idx] = row.getLong(FIRST_DATA_COLUMN + 0);
+      charge[idx] = row.getLong(FIRST_DATA_COLUMN + 1);
+      current[idx] = row.getLong(FIRST_DATA_COLUMN + 2);
+    }
+
+    @Override
+    public void copyRow(long time, int src, int dst) {
+      super.copyRow(time, src, dst);
+      capacity[dst] = capacity[src];
+      charge[dst] = charge[src];
+      current[dst] = current[src];
     }
   }
 
-  public static class Values implements Selection, Selection.Builder<Values> {
-    public final long[] ts;
-    public final long[] dur;
+  public static class Values extends CombinedCountersTrack.Values<Values> {
     public final long[] capacity;
     public final long[] charge;
     public final long[] current;
-    private final Set<Long> valueKeys;
 
-    public Values(long[] ts, long[] dur, long[] capacity, long[] charge, long[] current,
-        Set<Long> valueKeys) {
-      this.ts = ts;
-      this.dur = dur;
-      this.capacity = capacity;
-      this.charge = charge;
-      this.current = current;
-      this.valueKeys = valueKeys;
+    public Values(int numRows, BinaryOperator<Values> combiner) {
+      super(numRows, combiner);
+      this.capacity = new long[numRows];
+      this.charge = new long[numRows];
+      this.current = new long[numRows];
+    }
+
+    @Override
+    public void set(int idx, Row row) {
+      super.set(idx, row);
+      capacity[idx] = row.getLong(FIRST_DATA_COLUMN + 0);
+      charge[idx] = row.getLong(FIRST_DATA_COLUMN + 1);
+      current[idx] = row.getLong(FIRST_DATA_COLUMN + 2);
+    }
+
+    @Override
+    public void copyFrom(Values other, int src, int dst) {
+      capacity[dst] = other.capacity[src];
+      charge[dst] = other.charge[src];
+      current[dst] = other.current[src];
     }
 
     @Override
@@ -250,98 +139,8 @@ public class BatterySummaryTrack extends Track.WithQueryEngine<BatterySummaryTra
     }
 
     @Override
-    public boolean contains(Long key) {
-      return valueKeys.contains(key);
-    }
-
-    @Override
     public Composite buildUi(Composite parent, State state) {
       return new BatterySelectionView(parent, state, this);
-    }
-
-    @Override
-    public Selection.Builder<Values> getBuilder() {
-      return this;
-    }
-
-    @Override
-    public void getRange(Consumer<TimeSpan> span) {
-      long min = Arrays.stream(ts).min().getAsLong();
-      long max = IntStream.range(0, ts.length).mapToLong(i -> ts[i] + dur[i]).max().getAsLong();
-      span.accept(new TimeSpan(min, max));
-    }
-
-    @Override
-    public Values combine(Values that) {
-      if (ts.length == 0) {
-        return that;
-      } else if (that.ts.length == 0) {
-        return this;
-      }
-
-      long[] newTs = new long[this.ts.length + that.ts.length];
-      long[] newDur = new long[this.ts.length + that.ts.length];
-      long[] newCapacity = new long[this.ts.length + that.ts.length];
-      long[] newCharge = new long[this.ts.length + that.ts.length];
-      long[] newCurrent = new long[this.ts.length + that.ts.length];
-
-      int ai = 0, bi = 0, ri = 0;
-      for (; ai < this.ts.length && bi < that.ts.length; ri++) {
-        long at = this.ts[ai], bt = that.ts[bi];
-        boolean selectThis = true;
-        if (at == bt) {
-          ai++;
-          bi++;
-        } else if (at < bt) {
-          ai++;
-        } else {
-          bi++;
-          selectThis = false;
-        }
-        if (selectThis) {
-          newTs[ri] = at;
-          newDur[ri] = this.dur[ai - 1];
-          newCapacity[ri] = this.capacity[ai - 1];
-          newCharge[ri] = this.charge[ai - 1];
-          newCurrent[ri] = this.current[ai - 1];
-        } else {
-          newTs[ri] = bt;
-          newDur[ri] = that.dur[bi - 1];
-          newCapacity[ri] = that.capacity[bi - 1];
-          newCharge[ri] = that.charge[bi - 1];
-          newCurrent[ri] = that.current[bi - 1];
-        }
-      }
-
-      // Copy the rest trailing parts from the unfinished arrays.
-      for (; ai < this.ts.length; ri++, ai++) {
-        newTs[ri] = this.ts[ai];
-        newDur[ri] = this.dur[ai];
-        newCapacity[ri] = this.capacity[ai];
-        newCharge[ri] = this.charge[ai];
-        newCurrent[ri] = this.current[ai];
-      }
-      for (; bi < that.ts.length; ri++, bi++) {
-        newTs[ri] = that.ts[bi];
-        newDur[ri] = that.dur[bi];
-        newCapacity[ri] = that.capacity[bi];
-        newCharge[ri] = that.charge[bi];
-        newCurrent[ri] = that.current[bi];
-      }
-
-      Set<Long> newValueKeys = Sets.newHashSet(this.valueKeys);
-      newValueKeys.addAll(that.valueKeys);
-
-      // Truncate.
-      int newL = ri;
-      return new Values(Arrays.copyOf(newTs, newL), Arrays.copyOf(newDur, newL),
-          Arrays.copyOf(newCapacity, newL), Arrays.copyOf(newCharge, newL),
-          Arrays.copyOf(newCurrent, newL), newValueKeys);
-    }
-
-    @Override
-    public Selection build() {
-      return this;
     }
   }
 }

--- a/gapic/src/main/com/google/gapid/perfetto/models/CombinedCountersTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/CombinedCountersTrack.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright (C) 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.perfetto.models;
+
+import static com.google.gapid.perfetto.models.QueryEngine.createSpan;
+import static com.google.gapid.perfetto.models.QueryEngine.createView;
+import static com.google.gapid.perfetto.models.QueryEngine.createWindow;
+import static com.google.gapid.perfetto.models.QueryEngine.dropTable;
+import static com.google.gapid.perfetto.models.QueryEngine.dropView;
+import static com.google.gapid.perfetto.models.QueryEngine.expectOneRow;
+import static com.google.gapid.util.MoreFutures.transform;
+import static com.google.gapid.util.MoreFutures.transformAsync;
+import static java.lang.String.format;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.IntStream.range;
+
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.gapid.perfetto.TimeSpan;
+
+import java.util.Set;
+import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
+
+/**
+ * {@link Track} that combines multiple counters into a single graph.
+ */
+public abstract class CombinedCountersTrack
+    <D extends CombinedCountersTrack.Data, V extends CombinedCountersTrack.Values<V>>
+    extends Track.WithQueryEngine<D> {
+  private final boolean needQuantize;
+  private final String viewSql;
+  private final String summarySql;
+  private final String dataSql;
+  private final String valueSql;
+  private final String rangeSql;
+
+  public CombinedCountersTrack(
+      QueryEngine qe, String trackId, Column[] columns, boolean needQuantize) {
+    super(qe, trackId);
+    if (stream(columns).allMatch(Column::isNil)) {
+      throw new IllegalArgumentException("At least one counter needs to be non-nil");
+    }
+
+    this.needQuantize = needQuantize;
+    this.viewSql = buildViewSql(columns);
+    this.summarySql = buildSummarySql(columns, tableName("span"));
+    this.dataSql = buildDataSql(columns, tableName("span"));
+    this.valueSql = buildValueSql(columns, tableName("vals"));
+    this.rangeSql = buildRangeSql(columns, tableName("vals"));
+  }
+
+  private static String buildViewSql(Column[] columns) {
+    // select id, ts, lead(ts, 1, <end>) over win - ts dur, [last_non_null(v_<#>) over win v_<#>]+
+    // from (
+    //   select min(id) id, ts, [max(case when track_id = <id> then value else null end) v_<#>]+
+    //   from counter where track_id in ([<id>]+)
+    //   group by ts)
+    // window win as (order by ts)
+
+    StringBuilder sb = new StringBuilder()
+        .append("select id, ts, ")
+        .append("lead(ts, 1, (select end_ts from trace_bounds)) over win - ts dur");
+    for (int i = 0; i < columns.length; i++) {
+      if (columns[i].isNil()) {
+        sb.append(", ").append(columns[i].sqlDefault);
+      } else {
+        sb.append(", last_non_null(v_").append(i).append(") over win v_").append(i);
+      }
+    }
+    sb.append(" from (select min(id) id, ts");
+    for (int i = 0; i < columns.length; i++) {
+      Column c = columns[i];
+      if (!c.isNil()) {
+        sb.append(", max(case when track_id = ").append(c.trackId).append(" then ")
+            .append("cast(value as ").append(c.sqlType).append(") else null end) v_").append(i);
+      }
+    }
+    sb.append(" from counter where track_id in ");
+    sb.append(stream(columns)
+        .filter(c -> !c.isNil())
+        .map(c -> Long.toString(c.trackId))
+        .collect(joining(", ", "(", ")")));
+    sb.append(" group by ts) window win as (order by ts)");
+    return sb.toString();
+  }
+
+  private static String buildSummarySql(Column[] columns, String tableName) {
+    // select id, min(start), max(end), [v_<#>]+
+    // from (
+    //   select min(id) id, min(ts) start, max(ts + dur) end, [v_<#>]+
+    //   from <tableName>
+    //   group by quantum_ts)
+    // group by id
+
+    StringBuilder sb = new StringBuilder();
+    sb.append("select id, min(start), max(end)");
+    for (int i = 0; i < columns.length; i++) {
+      Column c = columns[i];
+      sb.append(", cast(")
+          .append(c.sqlAggregate).append("(")
+          .append("v_").append(i).append(") ")
+          .append("as ").append(c.sqlType).append(")");
+    }
+    sb.append(" from (");
+    sb.append("select min(id) id, min(ts) start, max(ts + dur) end");
+    for (int i = 0; i < columns.length; i++) {
+      Column c = columns[i];
+      sb.append(", cast(")
+          .append(c.sqlAggregate).append("(")
+          .append("v_").append(i).append(") ")
+          .append("as ").append(c.sqlType).append(") v_").append(i);
+    }
+    sb.append(" from ").append(tableName).append(" group by quantum_ts) group by id");
+    return sb.toString();
+  }
+
+  private static String buildDataSql(Column[] columns, String span) {
+    // select id, ts, ts + dur, [coalesce(v_<#>, <default>)]+ from <span>
+
+    StringBuilder sb = new StringBuilder()
+        .append("select id, ts, ts + dur");
+    for (int i = 0; i < columns.length; i++) {
+      sb.append(", coalesce(v_").append(i).append(", ").append(columns[i].sqlDefault).append(")");
+    }
+    sb.append(" from ").append(span);
+    return sb.toString();
+  }
+
+  private static String buildValueSql(Column[] columns, String tableName) {
+    // select id, ts, dur, [v_<#>]+ from <table> where id = ?
+
+    StringBuilder sb = new StringBuilder("select id, ts, dur");
+    for (int i = 0; i < columns.length; i++) {
+      sb.append(", v_").append(i);
+    }
+    sb.append(" from ").append(tableName).append(" where id = %d");
+    return sb.toString();
+  }
+
+  private static String buildRangeSql(Column[] columns, String tableName) {
+    // select id, ts, dur, [v_<#>]+ from <table> where ts + dur >= ? and ts <= ? order by ts
+
+    StringBuilder sb = new StringBuilder("select id, ts, dur");
+    for (int i = 0; i < columns.length; i++) {
+      sb.append(", v_").append(i);
+    }
+    sb.append(" from ").append(tableName)
+        .append(" where ts + dur >= %d and ts <= %d order by ts");
+    return sb.toString();
+  }
+
+  @Override
+  protected ListenableFuture<?> initialize() {
+    String vals = tableName("vals");
+    String span = tableName("span");
+    String window = tableName("window");
+    return qe.queries(
+        dropTable(span),
+        dropTable(window),
+        dropView(vals),
+        createView(vals, viewSql),
+        createWindow(window),
+        createSpan(span, vals + ", " + window));
+  }
+
+  @Override
+  protected ListenableFuture<D> computeData(DataRequest req) {
+    Window win = needQuantize ? Window.compute(req, 5) : Window.compute(req);
+    return transformAsync(win.update(qe, tableName("window")), $ -> computeData(req, win));
+  }
+
+  private ListenableFuture<D> computeData(DataRequest req, Window win) {
+    return transform(qe.query(win.quantized ? summarySql : dataSql), res -> {
+      int rows = res.getNumRows();
+      if (rows == 0) {
+        return createData(req, 0);
+      }
+
+      D data = createData(req, rows + 1);
+      res.forEachRow(data::set);
+      data.copyRow(res.getLong(rows - 1, 2, 0), rows - 1, rows);
+      return data;
+    });
+  }
+
+  protected abstract D createData(DataRequest request, int numRows);
+
+  public ListenableFuture<V> getValue(long id) {
+    return transform(expectOneRow(qe.query(valueSql(id))), row -> {
+      V v = createValues(1, this::combine);
+      v.set(0, row);
+      return v;
+    });
+  }
+
+  private String valueSql(long id) {
+    return format(valueSql, id);
+  }
+
+  public ListenableFuture<V> getValues(TimeSpan ts) {
+    return transform(qe.query(rangeSql(ts)), res -> {
+      V v = createValues(res.getNumRows(), this::combine);
+      res.forEachRow(v::set);
+      return v;
+    });
+  }
+
+  private String rangeSql(TimeSpan ts) {
+    return format(rangeSql, ts.start, ts.end);
+  }
+
+  protected abstract V createValues(int numRows, BinaryOperator<V> combiner);
+
+  private V combine(V a, V b) {
+    if (a.ts.length == 0) {
+      return b;
+    } else if (b.ts.length == 0) {
+      return a;
+    }
+
+    long[] ts = new long[a.ts.length + b.ts.length];
+    int count = combineTs(a.ts, b.ts, ts);
+    V v = createValues(count, this::combine);
+    System.arraycopy(ts, 0, v.ts, 0, count);
+
+    int ai = 0, bi = 0, ri = 0;
+    for (; ai < a.ts.length && bi < b.ts.length; ri++) {
+      long ats = a.ts[ai], bts = b.ts[bi], rts = v.ts[ri];
+      if (rts == ats) {
+        v.copyFrom(a, ai, ri);
+        ai++;
+        if (rts == bts) {
+          bi++;
+        }
+      } else {
+        v.copyFrom(b, bi, ri);
+        bi++;
+      }
+    }
+
+    for (; ai < a.ts.length; ai++, ri++) {
+      v.copyFrom(a, ai, ri);
+    }
+    for (; bi < b.ts.length; bi++, ri++) {
+      v.copyFrom(b, bi, ri);
+    }
+
+    for (int i = 1; i < count; i++) {
+      v.dur[i - 1] = v.ts[i] - v.ts[i - 1];
+    }
+    v.dur[count - 1] = Math.max(
+        a.ts[a.ts.length - 1] + a.dur[a.dur.length - 1],
+        b.ts[b.ts.length - 1] + b.dur[b.dur.length - 1]) - v.ts[count - 1];
+
+    v.combineIds(a);
+    v.combineIds(b);
+    return v;
+  }
+
+  private static int combineTs(long[] a, long[] b, long[] r) {
+    int ai = 0, bi = 0, ri = 0;
+    for (; ai < a.length && bi < b.length; ri++) {
+      long av = a[ai], bv = b[bi];
+      if (av == bv) {
+        r[ri] = av;
+        ai++;
+        bi++;
+      } else if (av < bv) {
+        r[ri] = av;
+        ai++;
+      } else {
+        r[ri] = bv;
+        bi++;
+      }
+    }
+    // One of these copies does nothing.
+    System.arraycopy(a, ai, r, ri, a.length - ai);
+    System.arraycopy(b, bi, r, ri, b.length - bi);
+    return ri + (a.length - ai) + (b.length - bi);
+  }
+
+
+  public static class Data extends Track.Data {
+    protected static final int FIRST_DATA_COLUMN = 3;
+
+    public final long[] id;
+    public final long[] ts;
+
+    public Data(DataRequest request, int numRows) {
+      super(request);
+      this.id = new long[numRows];
+      this.ts = new long[numRows];
+    }
+
+    public void set(int idx, QueryEngine.Row row) {
+      id[idx] = row.getLong(0);
+      ts[idx] = row.getLong(1);
+    }
+
+    public void copyRow(long time, int src, int dst) {
+      id[dst] = id[src];
+      ts[dst] = time;
+    }
+  }
+
+  public abstract static class Values<T extends Values<T>>
+      implements Selection, Selection.Builder<T> {
+    protected static final int FIRST_DATA_COLUMN = 3;
+
+    public final long[] ts;
+    public final long[] dur;
+    private final Set<Long> valueKeys;
+    private final BinaryOperator<T> combiner;
+
+    public Values(int numRows, BinaryOperator<T> combiner) {
+      this.ts = new long[numRows];
+      this.dur = new long[numRows];
+      this.valueKeys = Sets.newHashSet();
+      this.combiner = combiner;
+    }
+
+    public void combineIds(Values<?> other) {
+      valueKeys.addAll(other.valueKeys);
+    }
+
+    public void set(int idx, QueryEngine.Row row) {
+      valueKeys.add(row.getLong(0));
+      ts[idx] = row.getLong(1);
+      dur[idx] = row.getLong(2);
+    }
+
+    public abstract void copyFrom(T other, int src, int dst);
+
+    @Override
+    public boolean contains(Long key) {
+      return valueKeys.contains(key);
+    }
+
+    @Override
+    public Selection.Builder<T> getBuilder() {
+      return this;
+    }
+
+    @Override
+    public void getRange(Consumer<TimeSpan> span) {
+      long min = stream(ts).min().getAsLong();
+      long max = range(0, ts.length).mapToLong(i -> ts[i] + dur[i]).max().getAsLong();
+      span.accept(new TimeSpan(min, max));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T combine(T that) {
+      return combiner.apply((T)this, that);
+    }
+
+    @Override
+    public Selection build() {
+      return this;
+    }
+  }
+
+  protected static class Column {
+    public final long trackId;
+    public final String sqlType;
+    public final String sqlDefault;
+    public final String sqlAggregate;
+
+    public Column(long trackId, String sqlType, String sqlDefault, String sqlAggregate) {
+      this.trackId = trackId;
+      this.sqlType = sqlType;
+      this.sqlDefault = sqlDefault;
+      this.sqlAggregate = sqlAggregate;
+    }
+
+    public static Column nil(String sqlDefault) {
+      return new Column(-1, "", sqlDefault, "max");
+    }
+
+    public boolean isNil() {
+      return trackId < 0;
+    }
+  }
+}

--- a/gapic/src/main/com/google/gapid/perfetto/models/CounterInfo.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/CounterInfo.java
@@ -176,6 +176,15 @@ public class CounterInfo {
     });
   }
 
+  public static boolean needQuantize(CounterInfo... infos) {
+    for (CounterInfo info : infos) {
+      if (info != null && info.count > Track.QUANTIZE_CUT_OFF) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public static enum Type {
     Global, Cpu, Gpu, Process, Thread;
 

--- a/gapic/src/main/com/google/gapid/perfetto/models/MemorySummaryTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/MemorySummaryTrack.java
@@ -15,142 +15,42 @@
  */
 package com.google.gapid.perfetto.models;
 
-import static com.google.gapid.perfetto.models.QueryEngine.createSpan;
-import static com.google.gapid.perfetto.models.QueryEngine.createView;
-import static com.google.gapid.perfetto.models.QueryEngine.createWindow;
-import static com.google.gapid.perfetto.models.QueryEngine.dropTable;
-import static com.google.gapid.perfetto.models.QueryEngine.dropView;
-import static com.google.gapid.perfetto.models.QueryEngine.expectOneRow;
+import static com.google.gapid.perfetto.models.CounterInfo.needQuantize;
 import static com.google.gapid.perfetto.views.TrackContainer.single;
-import static com.google.gapid.util.MoreFutures.transform;
-import static com.google.gapid.util.MoreFutures.transformAsync;
-import static java.lang.String.format;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gapid.models.Perfetto;
-import com.google.gapid.perfetto.TimeSpan;
+import com.google.gapid.perfetto.models.QueryEngine.Row;
 import com.google.gapid.perfetto.views.MemorySelectionView;
 import com.google.gapid.perfetto.views.MemorySummaryPanel;
 import com.google.gapid.perfetto.views.State;
 
 import org.eclipse.swt.widgets.Composite;
 
-import java.util.Arrays;
-import java.util.Set;
-import java.util.function.Consumer;
-import java.util.stream.IntStream;
+import java.util.function.BinaryOperator;
 
 /**
  * {@link Track} containing the total system memory usage data.
  */
-public class MemorySummaryTrack extends Track.WithQueryEngine<MemorySummaryTrack.Data> {
-  private static final String VIEW_SQL =
-      "select min(id) id, ts, lead(ts) over (order by ts) - ts dur, max(a) total, max(b) unused," +
-      "   max(c) + max(d) + max(e) buffCache " +
-      "from (select id, ts," +
-      "  case when track_id = %d then cast(value as int) end a," +
-      "  case when track_id = %d then cast(value as int) end b," +
-      "  case when track_id = %d then cast(value as int) end c," +
-      "  case when track_id = %d then cast(value as int) end d," +
-      "  case when track_id = %d then cast(value as int) end e " +
-      "  from counter where track_id in (%d, %d, %d, %d, %d))" +
-      "group by ts";
-  private static final String SUMMARY_SQL =
-      "select id, min(start), max(end), cast(avg(total) as int), cast(avg(unused) as int), " +
-      "    cast(avg(buffCache) as int) from ( " +
-      "  select min(id) id, min(ts) start, max(ts + dur) end, cast(avg(total) as int) total, " +
-      "      cast(avg(unused) as int) unused, cast(avg(buffCache) as int) buffCache " +
-      "  from %s group by quantum_ts)" +
-      "group by id";
-  private static final String COUNTER_SQL =
-      "select id, ts, ts + dur, total, unused, buffCache from %s";
-  private static final String VALUE_SQL =
-      "select id, ts, dur, total, unused, buffCache from %s where id = %d";
-  private static final String RANGE_SQL =
-      "select id, ts, dur, total, unused, buffCache from %s " +
-      "where ts + dur >= %d and ts <= %d order by ts";
-
+public class MemorySummaryTrack
+    extends CombinedCountersTrack<MemorySummaryTrack.Data, MemorySummaryTrack.Values> {
   private final long maxTotal;
-  private final long totalId;
-  private final long unusedId;
-  private final long buffersId;
-  private final long cachedId;
-  private final long swapCachedId;
 
-  public MemorySummaryTrack(QueryEngine qe, long maxTotal, long totalId, long unusedId,
-      long buffersId, long cachedId, long swapCachedId) {
-    super(qe, "mem_sum");
-    this.maxTotal = maxTotal;
-    this.totalId = totalId;
-    this.unusedId = unusedId;
-    this.buffersId = buffersId;
-    this.cachedId = cachedId;
-    this.swapCachedId = swapCachedId;
+  public MemorySummaryTrack(QueryEngine qe, CounterInfo total, CounterInfo unused,
+      CounterInfo buffers, CounterInfo cached, CounterInfo swapCached) {
+    super(qe, "mem_sum", new Column[] {
+        new Column(total.id, "int", "0", "avg"),
+        new Column(unused.id, "int", "0", "avg"),
+        new Column(buffers.id, "int", "0", "avg"),
+        new Column(cached.id, "int", "0", "avg"),
+        new Column(swapCached.id, "int", "0", "avg"),
+    }, needQuantize(total, unused, buffers, cached, swapCached));
+    this.maxTotal = (long)total.max;
   }
 
   public long getMaxTotal() {
     return maxTotal;
-  }
-
-  @Override
-  protected ListenableFuture<?> initialize() {
-    String vals = tableName("vals");
-    String span = tableName("span");
-    String window = tableName("window");
-    return qe.queries(
-        dropTable(span),
-        dropTable(window),
-        dropView(vals),
-        createView(vals, viewSql()),
-        createWindow(window),
-        createSpan(span, vals + ", " + window));
-  }
-
-  private String viewSql() {
-    return format(VIEW_SQL, totalId, unusedId, buffersId, cachedId, swapCachedId,
-        totalId, unusedId, buffersId, cachedId, swapCachedId);
-  }
-
-  @Override
-  protected ListenableFuture<Data> computeData(DataRequest req) {
-    Window win = Window.compute(req, 5);
-    return transformAsync(win.update(qe, tableName("window")), $ -> computeData(req, win));
-  }
-
-  private ListenableFuture<Data> computeData(DataRequest req, Window win) {
-    return transform(qe.query(win.quantized ? summarySql() : counterSQL()), res -> {
-      int rows = res.getNumRows();
-      if (rows == 0) {
-        return Data.empty(req);
-      }
-
-      Data data = new Data(req, new long [rows + 1], new long[rows + 1], new long[rows + 1],
-          new long[rows + 1], new long[rows + 1]);
-      res.forEachRow((i, r) -> {
-        data.id[i] = r.getLong(0);
-        data.ts[i] = r.getLong(1);
-        data.total[i] = r.getLong(3);
-        data.unused[i] = r.getLong(4);
-        data.buffCache[i] = r.getLong(5);
-      });
-      data.id[rows] = data.id[rows - 1];
-      data.ts[rows] = res.getLong(rows - 1, 2, 0);
-      data.total[rows] = data.total[rows - 1];
-      data.unused[rows] = data.unused[rows - 1];
-      data.buffCache[rows] = data.buffCache[rows - 1];
-      return data;
-    });
-  }
-
-  private String summarySql() {
-    return format(SUMMARY_SQL, tableName("span"));
-  }
-
-  private String counterSQL() {
-    return format(COUNTER_SQL, tableName("span"));
   }
 
   public static Perfetto.Data.Builder enumerate(Perfetto.Data.Builder data) {
@@ -165,94 +65,87 @@ public class MemorySummaryTrack extends Track.WithQueryEngine<MemorySummaryTrack
       return data;
     }
 
-    MemorySummaryTrack track = new MemorySummaryTrack(
-        data.qe, (long)total.max, total.id, free.id, buffers.id, cached.id, swapCached.id);
+    MemorySummaryTrack track =
+        new MemorySummaryTrack(data.qe, total, free, buffers, cached, swapCached);
     data.tracks.addTrack(null, track.getId(), "Memory Usage",
         single(state -> new MemorySummaryPanel(state, track), true, false));
     return data;
-  }
-
-  public ListenableFuture<Values> getValue(long id) {
-    return transform(expectOneRow(qe.query(valueSql(id))), row -> {
-      Values v = new Values(new long[1], new long[1], new long[1], new long[1], new long[1],
-          Sets.newHashSet());
-      v.valueKeys.add(row.getLong(0));
-      v.ts[0] = row.getLong(1);
-      v.dur[0] = row.getLong(2);
-      v.total[0] = row.getLong(3);
-      v.unused[0] = row.getLong(4);
-      v.buffCache[0] = row.getLong(5);
-      return v;
-    });
-  }
-
-  private String valueSql(long id) {
-    return format(VALUE_SQL, tableName("vals"), id);
-  }
-
-  public ListenableFuture<Values> getValues(TimeSpan ts) {
-    return transform(qe.query(rangeSql(ts)), res -> {
-      int rows = res.getNumRows();
-      Values v = new Values(new long[rows], new long[rows], new long[rows], new long[rows],
-          new long[rows], Sets.newHashSet());
-      res.forEachRow((i, r) -> {
-        v.valueKeys.add(r.getLong(0));
-        v.ts[i] = r.getLong(1);
-        v.dur[i] = r.getLong(2);
-        v.total[i] = r.getLong(3);
-        v.unused[i] = r.getLong(4);
-        v.buffCache[i] = r.getLong(5);
-      });
-      return v;
-    });
-  }
-
-  private String rangeSql(TimeSpan ts) {
-    return format(RANGE_SQL, tableName("vals"), ts.start, ts.end);
   }
 
   private static CounterInfo onlyOne(ImmutableList<CounterInfo> counters) {
     return (counters.size() != 1) ? null : counters.get(0);
   }
 
-  public static class Data extends Track.Data {
-    public final long[] id;
-    public final long[] ts;
+  @Override
+  protected Data createData(DataRequest request, int numRows) {
+    return new Data(request, numRows);
+  }
+
+  @Override
+  protected Values createValues(int numRows, BinaryOperator<Values> combiner) {
+    return new Values(numRows, combiner);
+  }
+
+  public static class Data extends CombinedCountersTrack.Data {
     public final long[] total;
     public final long[] unused;
     public final long[] buffCache;
 
-    public Data(DataRequest request, long[] id, long[] ts, long[] total, long[] unusued,
-        long[] buffCache) {
-      super(request);
-      this.id = id;
-      this.ts = ts;
-      this.total = total;
-      this.unused = unusued;
-      this.buffCache = buffCache;
+    public Data(DataRequest request, int numRows) {
+      super(request, numRows);
+      this.total = new long[numRows];
+      this.unused = new long[numRows];
+      this.buffCache = new long[numRows];
     }
 
-    public static Data empty(DataRequest req) {
-      return new Data(req, new long[0], new long[0], new long[0], new long[0], new long[0]);
+    @Override
+    public void set(int idx, QueryEngine.Row row) {
+      super.set(idx, row);
+      total[idx] = row.getLong(FIRST_DATA_COLUMN + 0);
+      unused[idx] = row.getLong(FIRST_DATA_COLUMN + 1);
+      buffCache[idx] =
+          row.getLong(FIRST_DATA_COLUMN + 2) +
+          row.getLong(FIRST_DATA_COLUMN + 3) +
+          row.getLong(FIRST_DATA_COLUMN + 4);
+    }
+
+    @Override
+    public void copyRow(long time, int src, int dst) {
+      super.copyRow(time, src, dst);
+      total[dst] = total[src];
+      unused[dst] = unused[src];
+      buffCache[dst] = buffCache[src];
     }
   }
 
-  public static class Values implements Selection, Selection.Builder<Values> {
-    public final long[] ts;
-    public final long[] dur;
+  public static class Values extends CombinedCountersTrack.Values<Values> {
     public final long[] total;
     public final long[] unused;
     public final long[] buffCache;
-    private final Set<Long> valueKeys;
 
-    public Values(long[] ts, long[] dur, long[] total, long[] unused, long[] buffCache,
-        Set<Long> valueKeys) {
-      this.ts = ts;
-      this.dur = dur;
-      this.total = total;
-      this.unused = unused;
-      this.buffCache = buffCache;
-      this.valueKeys = valueKeys;
+    public Values(int numRows, BinaryOperator<Values> combiner) {
+      super(numRows, combiner);
+      this.total = new long[numRows];
+      this.unused = new long[numRows];
+      this.buffCache = new long[numRows];
+    }
+
+    @Override
+    public void set(int idx, Row row) {
+      super.set(idx, row);
+      total[idx] = row.getLong(FIRST_DATA_COLUMN + 0);
+      unused[idx] = row.getLong(FIRST_DATA_COLUMN + 1);
+      buffCache[idx] =
+          row.getLong(FIRST_DATA_COLUMN + 2) +
+          row.getLong(FIRST_DATA_COLUMN + 3) +
+          row.getLong(FIRST_DATA_COLUMN + 4);
+    }
+
+    @Override
+    public void copyFrom(Values other, int src, int dst) {
+      total[dst] = other.total[src];
+      unused[dst] = other.unused[src];
+      buffCache[dst] = other.buffCache[src];
     }
 
     @Override
@@ -261,98 +154,8 @@ public class MemorySummaryTrack extends Track.WithQueryEngine<MemorySummaryTrack
     }
 
     @Override
-    public boolean contains(Long key) {
-      return valueKeys.contains(key);
-    }
-
-    @Override
     public Composite buildUi(Composite parent, State state) {
       return new MemorySelectionView(parent, state, this);
-    }
-
-    @Override
-    public Selection.Builder<Values> getBuilder() {
-      return this;
-    }
-
-    @Override
-    public void getRange(Consumer<TimeSpan> span) {
-      long min = Arrays.stream(ts).min().getAsLong();
-      long max = IntStream.range(0, ts.length).mapToLong(i -> ts[i] + dur[i]).max().getAsLong();
-      span.accept(new TimeSpan(min, max));
-    }
-
-    @Override
-    public Values combine(Values that) {
-      if (ts.length == 0) {
-        return that;
-      } else if (that.ts.length == 0) {
-        return this;
-      }
-
-      long[] newTs = new long[this.ts.length + that.ts.length];
-      long[] newDur = new long[this.ts.length + that.ts.length];
-      long[] newTotal = new long[this.ts.length + that.ts.length];
-      long[] newUnused = new long[this.ts.length + that.ts.length];
-      long[] newBuffCache = new long[this.ts.length + that.ts.length];
-
-      int ai = 0, bi = 0, ri = 0;
-      for (; ai < this.ts.length && bi < that.ts.length; ri++) {
-        long at = this.ts[ai], bt = that.ts[bi];
-        boolean selectThis = true;
-        if (at == bt) {
-          ai++;
-          bi++;
-        } else if (at < bt) {
-          ai++;
-        } else {
-          bi++;
-          selectThis = false;
-        }
-        if (selectThis) {
-          newTs[ri] = at;
-          newDur[ri] = this.dur[ai - 1];
-          newTotal[ri] = this.total[ai - 1];
-          newUnused[ri] = this.unused[ai - 1];
-          newBuffCache[ri] = this.buffCache[ai - 1];
-        } else {
-          newTs[ri] = bt;
-          newDur[ri] = that.dur[bi - 1];
-          newTotal[ri] = that.total[bi - 1];
-          newUnused[ri] = that.unused[bi - 1];
-          newBuffCache[ri] = that.buffCache[bi - 1];
-        }
-      }
-
-      // Copy the rest trailing parts from the unfinished arrays.
-      for (; ai < this.ts.length; ri++, ai++) {
-        newTs[ri] = this.ts[ai];
-        newDur[ri] = this.dur[ai];
-        newTotal[ri] = this.total[ai];
-        newUnused[ri] = this.unused[ai];
-        newBuffCache[ri] = this.buffCache[ai];
-      }
-      for (; bi < that.ts.length; ri++, bi++) {
-        newTs[ri] = that.ts[bi];
-        newDur[ri] = that.dur[bi];
-        newTotal[ri] = that.total[bi];
-        newUnused[ri] = that.unused[bi];
-        newBuffCache[ri] = that.buffCache[bi];
-      }
-
-      Set<Long> newValueKeys = Sets.newHashSet(this.valueKeys);
-      newValueKeys.addAll(that.valueKeys);
-
-      // Truncate.
-      int newL = ri;
-      return new Values(Arrays.copyOf(newTs, newL), Arrays.copyOf(newDur, newL),
-          Arrays.copyOf(newTotal, newL), Arrays.copyOf(newUnused, newL),
-          Arrays.copyOf(newBuffCache, newL), newValueKeys);
-    }
-
-    @Override
-    public Selection build() {
-      return this;
     }
   }
 }

--- a/gapic/src/main/com/google/gapid/perfetto/models/MemorySummaryTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/MemorySummaryTrack.java
@@ -35,14 +35,13 @@ import com.google.gapid.perfetto.TimeSpan;
 import com.google.gapid.perfetto.views.MemorySelectionView;
 import com.google.gapid.perfetto.views.MemorySummaryPanel;
 import com.google.gapid.perfetto.views.State;
+
+import org.eclipse.swt.widgets.Composite;
+
 import java.util.Arrays;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.LongStream;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.widgets.Composite;
 
 /**
  * {@link Track} containing the total system memory usage data.
@@ -258,7 +257,7 @@ public class MemorySummaryTrack extends Track.WithQueryEngine<MemorySummaryTrack
 
     @Override
     public String getTitle() {
-      return "Memories";
+      return "Memory Usage";
     }
 
     @Override

--- a/gapic/src/main/com/google/gapid/perfetto/models/ProcessMemoryTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/ProcessMemoryTrack.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.perfetto.models;
+
+import static com.google.gapid.perfetto.models.CounterInfo.needQuantize;
+
+import com.google.gapid.models.Perfetto;
+import com.google.gapid.perfetto.models.QueryEngine.Row;
+import com.google.gapid.perfetto.views.MemorySelectionView;
+import com.google.gapid.perfetto.views.ProcessMemoryPanel;
+import com.google.gapid.perfetto.views.State;
+import com.google.gapid.perfetto.views.TrackContainer;
+
+import org.eclipse.swt.widgets.Composite;
+
+import java.util.Map;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class ProcessMemoryTrack
+    extends CombinedCountersTrack<ProcessMemoryTrack.Data, ProcessMemoryTrack.Values> {
+  private final long maxUsage;
+  private final long maxSwap;
+
+  public ProcessMemoryTrack(QueryEngine qe, long upid,
+      CounterInfo file, CounterInfo anon, CounterInfo shared, CounterInfo swap) {
+    super(qe, "mem_" + upid, new Column[] {
+        file == null ? Column.nil("0") : new Column(file.id, "int", "0", "avg"),
+        anon == null ? Column.nil("0") : new Column(anon.id, "int", "0", "avg"),
+        shared == null ? Column.nil("0") : new Column(shared.id, "int", "0", "avg"),
+        swap == null ? Column.nil("0") : new Column(swap.id, "int", "0", "avg"),
+    }, needQuantize(file, anon, shared, swap));
+    this.maxUsage = (long)(
+        (file == null ? 0 : file.max) +
+        (anon == null ? 0 : anon.max) +
+        (shared == null ? 0 : shared.max));
+    this.maxSwap = swap == null ? 0 : (long)swap.max;
+  }
+
+  public long getMaxUsage() {
+    return maxUsage;
+  }
+
+  public long getMaxSwap() {
+    return maxSwap;
+  }
+
+  public static Perfetto.Data.Builder enumerate(Perfetto.Data.Builder data, String parent, long upid) {
+    Map<String, CounterInfo> counters = data.getCounters().values().stream()
+        .filter(c -> c.type == CounterInfo.Type.Process && c.ref == upid &&
+            c.count > 0 && isMemoryCounter(c))
+        .collect(Collectors.toMap(c -> c.name, Function.identity()));
+    if (!counters.isEmpty()) {
+      ProcessMemoryTrack track = new ProcessMemoryTrack(data.qe, upid,
+          counters.get("mem.rss.file"),
+          counters.get("mem.rss.anon"),
+          counters.get("mem.rss.shmem"),
+          counters.get("mem.swap"));
+      data.tracks.addTrack(parent, track.getId(), "Memory Usage",
+          TrackContainer.single(state -> new ProcessMemoryPanel(state, track), true, true));
+    }
+
+    return data;
+  }
+
+  private static boolean isMemoryCounter(CounterInfo c) {
+    return "mem.rss.file".equals(c.name) ||
+        "mem.rss.anon".equals(c.name) ||
+        "mem.rss.shmem".equals(c.name) ||
+        "mem.swap".equals(c.name);
+  }
+
+  @Override
+  protected Data createData(DataRequest request, int numRows) {
+    return new Data(request, numRows);
+  }
+
+  @Override
+  protected Values createValues(int numRows, BinaryOperator<Values> combiner) {
+    return new Values(numRows, combiner);
+  }
+
+  public static class Data extends CombinedCountersTrack.Data {
+    public final long[] file;
+    public final long[] anon;
+    public final long[] shared;
+    public final long[] swap;
+
+    public Data(DataRequest request, int numRows) {
+      super(request, numRows);
+      this.file = new long[numRows];
+      this.anon = new long[numRows];
+      this.shared = new long[numRows];
+      this.swap = new long[numRows];
+    }
+
+    @Override
+    public void set(int idx, Row row) {
+      super.set(idx, row);
+      file[idx] = row.getLong(FIRST_DATA_COLUMN + 0);
+      anon[idx] = row.getLong(FIRST_DATA_COLUMN + 1);
+      shared[idx] = row.getLong(FIRST_DATA_COLUMN + 2);
+      swap[idx] = row.getLong(FIRST_DATA_COLUMN + 3);
+    }
+
+    @Override
+    public void copyRow(long time, int src, int dst) {
+      super.copyRow(time, src, dst);
+      file[dst] = file[src];
+      anon[dst] = anon[src];
+      shared[dst] = shared[src];
+      swap[dst] = swap[src];
+    }
+  }
+
+  public static class Values extends CombinedCountersTrack.Values<Values> {
+    public final long[] file;
+    public final long[] anon;
+    public final long[] shared;
+    public final long[] swap;
+
+    public Values(int numRows, BinaryOperator<Values> combiner) {
+      super(numRows, combiner);
+      this.file = new long[numRows];
+      this.anon = new long[numRows];
+      this.shared = new long[numRows];
+      this.swap = new long[numRows];
+    }
+
+    @Override
+    public void set(int idx, Row row) {
+      super.set(idx, row);
+      file[idx] = row.getLong(FIRST_DATA_COLUMN + 0);
+      anon[idx] = row.getLong(FIRST_DATA_COLUMN + 1);
+      shared[idx] = row.getLong(FIRST_DATA_COLUMN + 2);
+      swap[idx] = row.getLong(FIRST_DATA_COLUMN + 3);
+    }
+
+    @Override
+    public void copyFrom(Values other, int src, int dst) {
+      file[dst] = other.file[src];
+      anon[dst] = other.anon[src];
+      shared[dst] = other.shared[src];
+      swap[dst] = other.swap[src];
+    }
+
+    @Override
+    public String getTitle() {
+      return "Process Memory Usage";
+    }
+
+    @Override
+    public Composite buildUi(Composite parent, State state) {
+      return new MemorySelectionView(parent, state, this);
+    }
+  }
+}

--- a/gapic/src/main/com/google/gapid/perfetto/models/Selection.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Selection.java
@@ -121,7 +121,6 @@ public interface Selection {
       return selections.containsKey(type) ? selections.get(type) : Selection.emptySelection();
     }
 
-    @SuppressWarnings({"rawtypes" })
     public void addSelection(MultiSelection other) {
       for (Selection.Kind k : other.selections.keySet()) {
         this.addSelection(k, other.selections.get(k));
@@ -194,7 +193,6 @@ public interface Selection {
     public Selection build();
   }
 
-  @SuppressWarnings("unused")
   public static class Kind implements Comparable<Kind>{
     public static final Kind Thread = new Kind(0);
     public static final Kind ThreadState = new Kind(1);
@@ -205,6 +203,7 @@ public interface Selection {
     public static final Kind FrameEvents = new Kind(6);
     public static final Kind Memory = new Kind(7);
     public static final Kind Battery = new Kind(8);
+    public static final Kind ProcessMemory = new Kind(9);
 
     public int priority;
 

--- a/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
@@ -219,6 +219,9 @@ public class Tracks {
         }
       }
 
+      // For each process, add the memory usage panel if it exists.
+      ProcessMemoryTrack.enumerate(data, summary.getId(), process.upid);
+
       // For each process, add any other process counters if any exist.
       counters = data.getCounters().values().stream()
           .filter(c -> c.type == CounterInfo.Type.Process && c.ref == process.upid &&

--- a/gapic/src/main/com/google/gapid/perfetto/models/VulkanEventTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/VulkanEventTrack.java
@@ -230,7 +230,7 @@ public class VulkanEventTrack extends Track.WithQueryEngine<VulkanEventTrack.Dat
 
     @Override
     public String getTitle() {
-      return "Vulkan API Event Slices";
+      return "Vulkan API Events";
     }
 
     @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/MemorySelectionView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/MemorySelectionView.java
@@ -18,10 +18,11 @@ package com.google.gapid.perfetto.views;
 import static com.google.gapid.perfetto.TimeSpan.timeToString;
 import static com.google.gapid.widgets.Widgets.createTableColumn;
 import static com.google.gapid.widgets.Widgets.createTableViewer;
-import static com.google.gapid.widgets.Widgets.createTreeColumn;
 import static com.google.gapid.widgets.Widgets.packColumns;
 
 import com.google.gapid.perfetto.models.MemorySummaryTrack;
+import com.google.gapid.perfetto.models.ProcessMemoryTrack;
+
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.TableViewer;
@@ -29,28 +30,47 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 
+import java.util.function.Consumer;
+
 public class MemorySelectionView extends Composite {
-  public MemorySelectionView(Composite parent, State state, MemorySummaryTrack.Values sel) {
-    super(parent, SWT.None);
+  private MemorySelectionView(Composite parent, int numRows, Consumer<TableViewer> createColumns) {
+    super(parent, SWT.NONE);
     setLayout(new FillLayout());
 
     TableViewer viewer = createTableViewer(this, SWT.NONE);
     viewer.setContentProvider(new ArrayContentProvider());
     viewer.setLabelProvider(new LabelProvider());
 
-    createTableColumn(
-        viewer, "Time", r -> timeToString(sel.ts[(Integer)r] - state.getTraceTime().start));
-    createTableColumn(viewer, "Dur", r -> String.valueOf(sel.dur[(Integer)r]));
-    createTableColumn(viewer, "Total", r -> String.valueOf(sel.total[(Integer)r]));
-    createTableColumn(viewer, "Unused", r -> String.valueOf(sel.unused[(Integer)r]));
-    createTableColumn(viewer, "BuffCache", r -> String.valueOf(sel.buffCache[(Integer)r]));
+    createColumns.accept(viewer);
 
-
-    Integer[] rows = new Integer[sel.ts.length];
+    Integer[] rows = new Integer[numRows];
     for (int i = 0; i < rows.length; i++) {
       rows[i] = i;
     }
     viewer.setInput(rows);
     packColumns(viewer.getTable());
+  }
+
+  public MemorySelectionView(Composite parent, State state, MemorySummaryTrack.Values sel) {
+    this(parent, sel.ts.length, viewer -> {
+      createTableColumn(
+          viewer, "Time", r -> timeToString(sel.ts[(Integer)r] - state.getTraceTime().start));
+      createTableColumn(viewer, "Dur", r -> timeToString(sel.dur[(Integer)r]));
+      createTableColumn(viewer, "Total", r -> String.valueOf(sel.total[(Integer)r]));
+      createTableColumn(viewer, "Unused", r -> String.valueOf(sel.unused[(Integer)r]));
+      createTableColumn(viewer, "BuffCache", r -> String.valueOf(sel.buffCache[(Integer)r]));
+    });
+  }
+
+  public MemorySelectionView(Composite parent, State state, ProcessMemoryTrack.Values sel) {
+    this(parent, sel.ts.length, viewer -> {
+      createTableColumn(
+          viewer, "Time", r -> timeToString(sel.ts[(Integer)r] - state.getTraceTime().start));
+      createTableColumn(viewer, "Dur", r -> timeToString(sel.dur[(Integer)r]));
+      createTableColumn(viewer, "File", r -> String.valueOf(sel.file[(Integer)r]));
+      createTableColumn(viewer, "Anon", r -> String.valueOf(sel.anon[(Integer)r]));
+      createTableColumn(viewer, "Shared", r -> String.valueOf(sel.shared[(Integer)r]));
+      createTableColumn(viewer, "Swap", r -> String.valueOf(sel.swap[(Integer)r]));
+    });
   }
 }

--- a/gapic/src/main/com/google/gapid/perfetto/views/MemorySummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/MemorySummaryPanel.java
@@ -15,6 +15,7 @@
  */
 package com.google.gapid.perfetto.views;
 
+import static com.google.gapid.perfetto.Unit.bytesToString;
 import static com.google.gapid.perfetto.views.Loading.drawLoading;
 import static com.google.gapid.perfetto.views.StyleConstants.TRACK_MARGIN;
 import static com.google.gapid.perfetto.views.StyleConstants.colors;
@@ -32,10 +33,12 @@ import com.google.gapid.perfetto.models.MemorySummaryTrack;
 import com.google.gapid.perfetto.models.Selection;
 import com.google.gapid.perfetto.models.Selection.CombiningBuilder;
 import com.google.gapid.perfetto.models.Selection.Kind;
-import java.util.List;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.widgets.Display;
+
+import java.util.List;
 
 /**
  * Displays information about the system memory usage.
@@ -47,7 +50,7 @@ public class MemorySummaryPanel extends TrackPanel<MemorySummaryPanel> implement
   private static final double CURSOR_SIZE = 5;
   private static final double LEGEND_SIZE = 8;
 
-  private final MemorySummaryTrack track;
+  protected final MemorySummaryTrack track;
 
   protected HoverCard hovered = null;
   protected double mouseXpos, mouseYpos;
@@ -222,26 +225,6 @@ public class MemorySummaryPanel extends TrackPanel<MemorySummaryPanel> implement
         return true;
       }
     };
-  }
-
-  protected static String bytesToString(long val) {
-    if (val < 1024 + 512) {
-      return val + "b";
-    }
-    double v = val / 1024.0;
-    if (v < 1024 + 512) {
-      return String.format("%.1fKb", v);
-    }
-    v /= 1024;
-    if (v < 1024 + 512) {
-      return String.format("%.1fMb", v);
-    }
-    v /= 1024;
-    if (v < 1024 + 512) {
-      return String.format("%.1fGb", v);
-    }
-    v /= 1024;
-    return String.format("%.1fTb", v);
   }
 
   @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/ProcessMemoryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/ProcessMemoryPanel.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright (C) 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.perfetto.views;
+
+import static com.google.gapid.perfetto.Unit.bytesToString;
+import static com.google.gapid.perfetto.views.Loading.drawLoading;
+import static com.google.gapid.perfetto.views.StyleConstants.TRACK_MARGIN;
+import static com.google.gapid.perfetto.views.StyleConstants.colors;
+import static com.google.gapid.perfetto.views.StyleConstants.memoryRssAnonGradient;
+import static com.google.gapid.perfetto.views.StyleConstants.memoryRssFileGradient;
+import static com.google.gapid.perfetto.views.StyleConstants.memoryRssSharedGradient;
+import static com.google.gapid.perfetto.views.StyleConstants.memorySwapGradient;
+import static com.google.gapid.util.MoreFutures.transform;
+
+import com.google.common.collect.Lists;
+import com.google.gapid.perfetto.TimeSpan;
+import com.google.gapid.perfetto.canvas.Area;
+import com.google.gapid.perfetto.canvas.Fonts;
+import com.google.gapid.perfetto.canvas.Fonts.TextMeasurer;
+import com.google.gapid.perfetto.canvas.RenderContext;
+import com.google.gapid.perfetto.canvas.Size;
+import com.google.gapid.perfetto.models.ProcessMemoryTrack;
+import com.google.gapid.perfetto.models.Selection;
+import com.google.gapid.perfetto.models.Selection.CombiningBuilder;
+import com.google.gapid.perfetto.models.Selection.Kind;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Cursor;
+import org.eclipse.swt.widgets.Display;
+
+import java.util.List;
+
+public class ProcessMemoryPanel extends TrackPanel<ProcessMemoryPanel> implements Selectable {
+  private static final double HEIGHT = 80;
+  private static final double HOVER_MARGIN = 10;
+  private static final double HOVER_PADDING = 4;
+  private static final double CURSOR_SIZE = 5;
+  private static final double LEGEND_SIZE = 8;
+
+  protected final ProcessMemoryTrack track;
+  protected HoverCard hovered = null;
+  protected double mouseXpos, mouseYpos;
+
+  public ProcessMemoryPanel(State state, ProcessMemoryTrack track) {
+    super(state);
+    this.track = track;
+  }
+
+  @Override
+  public ProcessMemoryPanel copy() {
+    return new ProcessMemoryPanel(state, track);
+  }
+
+  @Override
+  public String getTitle() {
+    return "Memory Usage";
+  }
+
+  @Override
+  public double getHeight() {
+    return HEIGHT;
+  }
+
+  @Override
+  protected void renderTrack(RenderContext ctx, Repainter repainter, double w, double h) {
+    ctx.trace("ProcessMemory", () -> {
+      ProcessMemoryTrack.Data data = track.getData(state.toRequest(), onUiThread(repainter));
+      drawLoading(ctx, data, state, h);
+
+      if (data == null || data.ts.length == 0) {
+        return;
+      }
+
+      Selection selected = state.getSelection(Selection.Kind.ProcessMemory);
+      List<Integer> visibleSelected = Lists.newArrayList();
+      long maxUsage = track.getMaxUsage(), maxSwap = Math.max(maxUsage, track.getMaxSwap());
+
+      memoryRssSharedGradient().applyBase(ctx);
+      ctx.path(path -> {
+        path.moveTo(0, h);
+        double lastX = 0, lastY = h;
+        for (int i = 0; i < data.ts.length; i++) {
+          double nextX = state.timeToPx(data.ts[i]);
+          double nextY = h - (h * (data.file[i] + data.anon[i] + data.shared[i]) / maxUsage);
+          path.lineTo(nextX, lastY);
+          path.lineTo(nextX, nextY);
+          lastX = nextX;
+          lastY = nextY;
+          if (selected.contains(data.id[i])) {
+            visibleSelected.add(i);
+          }
+        }
+        path.lineTo(lastX, h);
+        path.close();
+        ctx.fillPath(path);
+      });
+
+      memoryRssAnonGradient().applyBase(ctx);
+      ctx.path(path -> {
+        path.moveTo(0, h);
+        double lastX = 0, lastY = h;
+        for (int i = 0; i < data.ts.length; i++) {
+          double nextX = state.timeToPx(data.ts[i]);
+          double nextY = h - (h * (data.file[i] + data.anon[i]) / maxUsage);
+          path.lineTo(nextX, lastY);
+          path.lineTo(nextX, nextY);
+          lastX = nextX;
+          lastY = nextY;
+        }
+        path.lineTo(lastX, h);
+        path.close();
+        ctx.fillPath(path);
+      });
+
+      memoryRssFileGradient().applyBase(ctx);
+      ctx.path(path -> {
+        path.moveTo(0, h);
+        double lastX = 0, lastY = h;
+        for (int i = 0; i < data.ts.length; i++) {
+          double nextX = state.timeToPx(data.ts[i]);
+          double nextY = h - (h * (data.file[i]) / maxUsage);
+          path.lineTo(nextX, lastY);
+          path.lineTo(nextX, nextY);
+          lastX = nextX;
+          lastY = nextY;
+        }
+        path.lineTo(lastX, h);
+        path.close();
+        ctx.fillPath(path);
+      });
+
+      memorySwapGradient().applyBorder(ctx);
+      ctx.path(path -> {
+        double lastX = state.timeToPx(data.ts[0]), lastY = h - (h * data.swap[0] / maxSwap);
+        path.moveTo(lastX, lastY);
+        for (int i = 0; i < data.ts.length; i++) {
+          double nextX = state.timeToPx(data.ts[i]);
+          double nextY = h - (h * data.swap[i] / maxSwap);
+          path.lineTo(nextX, lastY);
+          path.lineTo(nextX, nextY);
+          lastX = nextX;
+          lastY = nextY;
+        }
+        path.lineTo(lastX, h);
+        ctx.drawPath(path);
+      });
+
+      // Draw highlight line after the whole graph is rendered, so that the highlight is on the top.
+      for (int index : visibleSelected) {
+        double startX = state.timeToPx(data.ts[index]);
+        double endX = (index >= data.ts.length - 1) ? startX : state.timeToPx(data.ts[index + 1]);
+        ctx.setBackgroundColor(memoryRssSharedGradient().highlight);
+        ctx.fillRect(startX, h - h * (data.file[index] + data.anon[index] + data.shared[index]) / maxUsage - 1, endX - startX, 3);
+        ctx.setBackgroundColor(memoryRssAnonGradient().highlight);
+        ctx.fillRect(startX, h - h * (data.file[index] + data.anon[index]) / maxUsage - 1, endX - startX, 3);
+        ctx.setBackgroundColor(memoryRssFileGradient().highlight);
+        ctx.fillRect(startX, h - h * data.file[index] / maxUsage - 1, endX - startX, 3);
+        ctx.setBackgroundColor(memorySwapGradient().highlight);
+        ctx.fillRect(startX, h - h * data.swap[index] / maxSwap - 1, endX - startX, 3);
+      }
+
+
+      if (hovered != null) {
+        ctx.setBackgroundColor(colors().hoverBackground);
+        ctx.fillRect(mouseXpos + HOVER_MARGIN, mouseYpos,
+            hovered.allSize.w + 3 * HOVER_PADDING + LEGEND_SIZE, hovered.allSize.h);
+
+        double x = mouseXpos + HOVER_MARGIN + HOVER_PADDING, y = mouseYpos;
+        double dy = hovered.allSize.h / 4;
+        memoryRssSharedGradient().applyBase(ctx);
+        ctx.fillRect(x, y + 0 * dy + (dy - LEGEND_SIZE) / 2, LEGEND_SIZE, LEGEND_SIZE);
+        memoryRssAnonGradient().applyBase(ctx);
+        ctx.fillRect(x, y + 1 * dy + (dy - LEGEND_SIZE) / 2, LEGEND_SIZE, LEGEND_SIZE);
+        memoryRssFileGradient().applyBase(ctx);
+        ctx.fillRect(x, y + 2 * dy + (dy - LEGEND_SIZE) / 2, LEGEND_SIZE, LEGEND_SIZE);
+        memorySwapGradient().applyBase(ctx);
+        ctx.fillRect(x, y + 3 * dy + (dy - LEGEND_SIZE) / 2, LEGEND_SIZE, LEGEND_SIZE);
+
+        x += LEGEND_SIZE + HOVER_PADDING;
+        ctx.setForegroundColor(colors().textMain);
+        ctx.drawText(Fonts.Style.Bold, HoverCard.SHARED_LABEL, x, y + 0 * dy, dy);
+        ctx.drawText(Fonts.Style.Bold, HoverCard.ANON_LABEL,   x, y + 1 * dy, dy);
+        ctx.drawText(Fonts.Style.Bold, HoverCard.FILE_LABEL,   x, y + 2 * dy, dy);
+        ctx.drawText(Fonts.Style.Bold, HoverCard.SWAP_LABEL,   x, y + 3 * dy, dy);
+
+        x += hovered.labelSize.w + HOVER_PADDING + hovered.valueSize.w;
+        ctx.drawTextRightJustified(Fonts.Style.Normal, hovered.sharedS, x, y + 0 * dy, dy);
+        ctx.drawTextRightJustified(Fonts.Style.Normal, hovered.anonS,   x, y + 1 * dy, dy);
+        ctx.drawTextRightJustified(Fonts.Style.Normal, hovered.fileS,   x, y + 2 * dy, dy);
+        ctx.drawTextRightJustified(Fonts.Style.Normal, hovered.swapS,   x, y + 3 * dy, dy);
+
+        ctx.drawCircle(mouseXpos, h - h * (hovered.file + hovered.anon + hovered.shared) / maxUsage,
+            CURSOR_SIZE / 2);
+        ctx.drawCircle(
+            mouseXpos, h - h * (hovered.file + hovered.anon) / maxUsage, CURSOR_SIZE / 2);
+        ctx.drawCircle(mouseXpos, h - h * hovered.file / maxUsage, CURSOR_SIZE / 2);
+        ctx.drawCircle(mouseXpos, h - h * hovered.swap / maxSwap, CURSOR_SIZE / 2);
+      }
+    });
+  }
+
+  @Override
+  protected Hover onTrackMouseMove(TextMeasurer m, double x, double y, int mods) {
+    ProcessMemoryTrack.Data data = track.getData(state.toRequest(), onUiThread());
+    if (data == null || data.ts.length == 0) {
+      return Hover.NONE;
+    }
+
+    long time = state.pxToTime(x);
+    if (time < data.ts[0] || time > data.ts[data.ts.length - 1]) {
+      return Hover.NONE;
+    }
+    int idx = 0;
+    for (; idx < data.ts.length - 1; idx++) {
+      if (data.ts[idx + 1] > time) {
+        break;
+      }
+    }
+
+    long id = data.id[idx];
+    hovered = new HoverCard(m, data.shared[idx], data.anon[idx], data.file[idx], data.swap[idx]);
+    mouseXpos = x;
+    mouseYpos = (height - 2 * TRACK_MARGIN - hovered.allSize.h) / 2;
+    return new Hover() {
+      @Override
+      public Area getRedraw() {
+        return new Area(mouseXpos - CURSOR_SIZE, -TRACK_MARGIN,
+            CURSOR_SIZE + HOVER_MARGIN + hovered.allSize.w + 3 * HOVER_PADDING + LEGEND_SIZE,
+            HEIGHT + 2 * TRACK_MARGIN);
+      }
+
+      @Override
+      public void stop() {
+        hovered = null;
+      }
+
+      @Override
+      public Cursor getCursor(Display display) {
+        return display.getSystemCursor(SWT.CURSOR_HAND);
+      }
+
+      @Override
+      public boolean click() {
+        if ((mods & SWT.MOD1) == SWT.MOD1) {
+          state.addSelection(Kind.ProcessMemory, track.getValue(id));
+        } else {
+          state.setSelection(Kind.ProcessMemory, track.getValue(id));
+        }
+        return true;
+      }
+    };
+  }
+
+  @Override
+  public void computeSelection(CombiningBuilder builder, Area area, TimeSpan ts) {
+    builder.add(Selection.Kind.ProcessMemory, transform(track.getValues(ts), v -> v));
+  }
+
+  private static class HoverCard {
+    public static final String SHARED_LABEL = "Shared: ";
+    public static final String ANON_LABEL = "Anon: ";
+    public static final String FILE_LABEL = "File: ";
+    public static final String SWAP_LABEL = "Swap: ";
+
+    public final long shared;
+    public final long anon;
+    public final long file;
+    public final long swap;
+
+    public final String sharedS;
+    public final String anonS;
+    public final String fileS;
+    public final String swapS;
+
+    public final Size valueSize;
+    public final Size labelSize;
+    public final Size allSize;
+
+    public HoverCard(Fonts.TextMeasurer tm, long shared, long anon, long file, long swap) {
+      this.shared = shared;
+      this.anon = anon;
+      this.file = file;
+      this.swap = swap;
+      this.sharedS = bytesToString(shared);
+      this.anonS = bytesToString(anon);
+      this.fileS = bytesToString(file);
+      this.swapS = bytesToString(swap);
+
+      this.labelSize = Size.vertCombine(HOVER_PADDING, HOVER_PADDING / 2,
+          tm.measure(Fonts.Style.Bold, SHARED_LABEL),
+          tm.measure(Fonts.Style.Bold, ANON_LABEL),
+          tm.measure(Fonts.Style.Bold, FILE_LABEL),
+          tm.measure(Fonts.Style.Bold, SWAP_LABEL));
+
+      this.valueSize = Size.vertCombine(HOVER_PADDING, HOVER_PADDING / 2,
+          tm.measure(Fonts.Style.Normal, this.sharedS),
+          tm.measure(Fonts.Style.Normal, this.anonS),
+          tm.measure(Fonts.Style.Normal, this.fileS),
+          tm.measure(Fonts.Style.Normal, this.swapS));
+
+      this.allSize =
+          new Size(labelSize.w + HOVER_PADDING + valueSize.w, Math.max(labelSize.h, valueSize.h));
+    }
+  }
+}

--- a/gapic/src/main/com/google/gapid/perfetto/views/StyleConstants.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/StyleConstants.java
@@ -268,6 +268,26 @@ public class StyleConstants {
     return isDark ? Gradients.DARK[14] : Gradients.LIGHT[14];
   }
 
+  public static Gradient memoryRssFileGradient() {
+    // See Gradients.Colors for explanation of magic constants.
+    return isDark ? Gradients.DARK[13] : Gradients.LIGHT[16];
+  }
+
+  public static Gradient memoryRssAnonGradient() {
+    // See Gradients.Colors for explanation of magic constants.
+    return isDark ? Gradients.DARK[14] : Gradients.LIGHT[13];
+  }
+
+  public static Gradient memoryRssSharedGradient() {
+    // See Gradients.Colors for explanation of magic constants.
+    return isDark ? Gradients.DARK[16] : Gradients.LIGHT[14];
+  }
+
+  public static Gradient memorySwapGradient() {
+    // See Gradients.Colors for explanation of magic constants.
+    return isDark ? Gradients.DARK[2] : Gradients.LIGHT[2];
+  }
+
   public static boolean isLight() {
     return !isDark;
   }
@@ -383,6 +403,11 @@ public class StyleConstants {
       ctx.setForegroundColor(border);
       ctx.setBackgroundColor(base);
     }
+
+    /** Sets stroke to border. **/
+    public void applyBorder(RenderContext ctx) {
+      ctx.setForegroundColor(border);
+    }
   }
 
   private static class Gradients {
@@ -390,7 +415,7 @@ public class StyleConstants {
     private static final float[][] COLORS = {
         {  15.38f, 0.2633f, 0.6000f }, // Brown
         {  20.15f, 0.8954f, 0.7000f }, // Orange         // blocked OK, battery out
-        {  21.92f, 0.7626f, 0.4294f }, // Dark Orange    // blocked warn
+        {  21.92f, 0.7626f, 0.4294f }, // Dark Orange    // blocked warn, swap
         {  36.22f, 0.7312f, 0.5000f }, // Light Brown
         {  42.19f, 0.4412f, 0.7490f }, // Tan
         {  50.00f, 0.5822f, 0.5844f }, // Gold
@@ -401,10 +426,10 @@ public class StyleConstants {
         { 130.91f, 0.6548f, 0.6706f }, // Green          // running, battery in
         { 171.02f, 0.5787f, 0.5598f }, // Turquoise
         { 172.36f, 0.7432f, 0.2902f }, // Teal
-        { 198.40f, 1.0000f, 0.4157f }, // Pacific Blue   // runnable, mem used
-        { 200.22f, 0.9787f, 0.8157f }, // Light Blue     // main, mem buf/cache
+        { 198.40f, 1.0000f, 0.4157f }, // Pacific Blue   // runnable, mem used, rss anon
+        { 200.22f, 0.9787f, 0.8157f }, // Light Blue     // main, mem buf/cache, rss shared
         { 201.95f, 0.2455f, 0.6725f }, // Grey           // sleeping
-        { 214.85f, 1.0000f, 0.5510f }, // Vivid Blue
+        { 214.85f, 1.0000f, 0.5510f }, // Vivid Blue     // rss file
         { 217.06f, 0.5000f, 0.4000f }, // Indigo
         { 261.54f, 0.5065f, 0.6980f }, // Light Purple
         { 262.30f, 0.6981f, 0.5843f }, // Purple

--- a/gapic/src/main/com/google/gapid/views/ProfileView.java
+++ b/gapic/src/main/com/google/gapid/views/ProfileView.java
@@ -55,14 +55,14 @@ import com.google.gapid.widgets.LoadablePanel;
 import com.google.gapid.widgets.Theme;
 import com.google.gapid.widgets.Widgets;
 
-import java.util.Arrays;
-import java.util.Set;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 public class ProfileView extends Composite implements Tab, Capture.Listener, Profile.Listener {
   private final Models models;
@@ -346,7 +346,7 @@ public class ProfileView extends Composite implements Tab, Capture.Listener, Pro
         return new Slice(s.getId(), s.getTs(), s.getDur(), "", s.getLabel(), s.getDepth(), -1, -1, ArgSet.EMPTY) {
           @Override
           public String getTitle() {
-            return "GPU Render Stages";
+            return "GPU Queue Events";
           }
         };
       }


### PR DESCRIPTION
If the RSS (resident set size) counters are enabled, the kernel emits ftrace events when pages are added/removed from the various memory pools. A resident page is a page that is occupying real physical memory and so RSS is a good indicator of an app's memory usage. This changes adds a memory track similar to the system memory summary track to each process where we have RSS counter data showing the process' memory usage.

Bug: http://b/143885588