### PR TITLE
Fix gcc8 install in Kokoro

### DIFF
--- a/kokoro/linux-test/test.sh
+++ b/kokoro/linux-test/test.sh
@@ -29,7 +29,7 @@ bash bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh --prefix=$PWD/bazel
 sudo rm /etc/apt/sources.list.d/cuda.list*
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get -q update
-sudo apt-get -qy install gcc-8 g++-8
+sudo aptitude -y install gcc-8 g++-8
 export CC=/usr/bin/gcc-8
 
 cd $SRC

--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -29,7 +29,7 @@ bash bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh --prefix=$PWD/bazel
 sudo rm /etc/apt/sources.list.d/cuda.list*
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get -q update
-sudo apt-get -qy install gcc-8 g++-8
+sudo aptitude -y install gcc-8 g++-8
 export CC=/usr/bin/gcc-8
 
 # Get the Android NDK


### PR DESCRIPTION
Linux builds started to fail with:

```
The following packages have unmet dependencies:
 g++-8 : Depends: libstdc++-8-dev (= 8.4.0-1ubuntu1~16.04.1) but it is not going to be installed
 gcc-8 : Depends: libgcc-8-dev (= 8.4.0-1ubuntu1~16.04.1) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

This affects several projects, using aptitude instead of apt seems to solve the issue. See e.g.:
https://swiftshader-review.googlesource.com/c/SwiftShader/+/44130