### PR TITLE
Add a missing header.

### DIFF
--- a/core/vulkan/vk_virtual_swapchain/cc/layer.cpp
+++ b/core/vulkan/vk_virtual_swapchain/cc/layer.cpp
@@ -17,6 +17,7 @@
 #include "layer.h"
 
 #include <cstring>
+#include <string>
 #include <type_traits>
 #include <unordered_map>
 #include <vector>


### PR DESCRIPTION
Some compilers are more picky than others.