### PR TITLE
Adds a new SplitCapture API that allows splitting captures.

### DIFF
--- a/cmd/gapit/BUILD.bazel
+++ b/cmd/gapit/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "replace_resource.go",
         "report.go",
         "screenshot.go",
+        "split.go",
         "state.go",
         "status.go",
         "stresstest.go",

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -449,4 +449,13 @@ type (
 		Out        string               `help:"Output file."`
 		Format     PerfettoOutputFormat `help:"Output file format: {text|json}."`
 	}
+
+	SplitFlags struct {
+		Gapis GapisFlags
+		Gapir GapirFlags
+		CaptureFileFlags
+		From uint64 `help:"The inclusive start index of the command range. Default: 0 (first command)"`
+		To   uint64 `help:"The exclusive end index of the command range. Default: 0 (last command)"`
+		Out  string `help:"Output file."`
+	}
 )

--- a/cmd/gapit/split.go
+++ b/cmd/gapit/split.go
@@ -1,0 +1,60 @@
+// Copyright (C) 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+
+	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/log"
+)
+
+type splitVerb struct{ SplitFlags }
+
+func init() {
+	verb := &splitVerb{}
+
+	app.AddVerb(&app.Verb{
+		Name:      "split",
+		ShortHelp: "Splits traces by carving out subranges into new traces",
+		Action:    verb,
+	})
+}
+
+func (verb *splitVerb) Run(ctx context.Context, flags flag.FlagSet) error {
+	if flags.NArg() != 1 {
+		app.Usage(ctx, "Exactly one gfx trace file expected, got %d", flags.NArg())
+		return nil
+	}
+
+	client, capture, err := getGapisAndLoadCapture(ctx, verb.Gapis, verb.Gapir, flags.Arg(0), verb.CaptureFileFlags)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	newCapture, err := client.SplitCapture(ctx, capture.CommandRange(verb.From, verb.To))
+	if err != nil {
+		return err
+	}
+	log.I(ctx, "Created new capture; id: %s", newCapture.ID)
+
+	output := verb.Out
+	if output == "" {
+		output = "split.gfxtrace"
+	}
+	return client.SaveCapture(ctx, newCapture, output)
+}

--- a/gapis/client/client.go
+++ b/gapis/client/client.go
@@ -492,6 +492,19 @@ func (c *client) DCECapture(ctx context.Context, capture *path.Capture, commands
 	return res.GetCapture(), nil
 }
 
+func (c *client) SplitCapture(ctx context.Context, rng *path.Commands) (*path.Capture, error) {
+	res, err := c.client.SplitCapture(ctx, &service.SplitCaptureRequest{
+		Commands: rng,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := res.GetError(); err != nil {
+		return nil, err.Get()
+	}
+	return res.GetCapture(), nil
+}
+
 func (c *client) UpdateSettings(ctx context.Context, req *service.UpdateSettingsRequest) error {
 	res, err := c.client.UpdateSettings(ctx, req)
 	if err != nil {

--- a/gapis/server/BUILD.bazel
+++ b/gapis/server/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//core/event/task:go_default_library",
         "//core/log:go_default_library",
         "//core/log/log_pb:go_default_library",
+        "//core/memory/arena:go_default_library",
         "//core/net/grpcutil:go_default_library",
         "//core/os/android/adb:go_default_library",
         "//core/os/device/bind:go_default_library",

--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -573,6 +573,15 @@ func (s *grpcServer) ClientEvent(ctx xctx.Context, req *service.ClientEventReque
 	return &service.ClientEventResponse{}, nil
 }
 
+func (s *grpcServer) SplitCapture(ctx xctx.Context, req *service.SplitCaptureRequest) (*service.SplitCaptureResponse, error) {
+	defer s.inRPC()()
+	res, err := s.handler.SplitCapture(s.bindCtx(ctx), req.Commands)
+	if err := service.NewError(err); err != nil {
+		return &service.SplitCaptureResponse{Res: &service.SplitCaptureResponse_Error{Error: err}}, nil
+	}
+	return &service.SplitCaptureResponse{Res: &service.SplitCaptureResponse_Capture{Capture: res}}, nil
+}
+
 func (s *grpcServer) TraceTargetTreeNode(ctx xctx.Context, req *service.TraceTargetTreeNodeRequest) (*service.TraceTargetTreeNodeResponse, error) {
 	defer s.inRPC()()
 	res, err := s.handler.TraceTargetTreeNode(s.bindCtx(ctx), req)

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -177,6 +177,9 @@ type Service interface {
 	// Run a perfetto query
 	PerfettoQuery(ctx context.Context, c *path.Capture, query string) (*perfetto.QueryResult, error)
 
+	// Split out a new capture containing a subset of another capture's commands.
+	SplitCapture(ctx context.Context, rng *path.Commands) (*path.Capture, error)
+
 	// ValidateDevice validates the GPU profiling capabilities of the given device and returns
 	// an error if validation failed or the GPU profiling data is invalid.
 	ValidateDevice(ctx context.Context, d *path.Device) error

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -702,6 +702,11 @@ service Gapid {
   rpc GpuProfile(GpuProfileRequest) returns (GpuProfileResponse) {
   }
 
+  // SplitCapture creates a new capture containing the requested subset of
+  // commands.
+  rpc SplitCapture(SplitCaptureRequest) returns (SplitCaptureResponse) {
+  }
+
   ///////////////////////////////////////////////////////////////
   // Below are debugging APIs which may be removed in the future.
   ///////////////////////////////////////////////////////////////
@@ -1278,6 +1283,17 @@ message GpuProfileResponse {
 message GpuProfileRequest {
   path.Capture capture = 1;
   path.Device device = 2;
+}
+
+message SplitCaptureRequest {
+  path.Commands commands = 1;
+}
+
+message SplitCaptureResponse {
+  oneof res {
+    path.Capture capture = 1;
+    Error error = 2;
+  }
 }
 
 // GetTimestampsRequest is the request send to server to get the timestamps for


### PR DESCRIPTION
Along with a gapit command to exercise the API, this allows debugging
captures by chopping them into bits.