### PR TITLE
Add a hidden flag to gapis to disable eager dep-graph resolving.

### DIFF
--- a/cmd/gapis/main.go
+++ b/cmd/gapis/main.go
@@ -60,6 +60,7 @@ var (
 	adbPath          = flag.String("adb", "", "Path to the adb executable; leave empty to search the environment")
 	enableLocalFiles = flag.Bool("enable-local-files", false, "Allow clients to access local .gfxtrace files by path")
 	remoteSSHConfig  = flag.String("ssh-config", "", "_Path to an ssh config file for remote devices")
+	preloadDepGraph  = flag.Bool("preload-dep-graph", true, "_Preload the dependency graph when loading captures")
 )
 
 func main() {
@@ -146,6 +147,7 @@ func run(ctx context.Context) error {
 		},
 		StringTables:     loadStrings(ctx),
 		EnableLocalFiles: *enableLocalFiles,
+		PreloadDepGraph:  *preloadDepGraph,
 		AuthToken:        auth.Token(*gapisAuthToken),
 		DeviceScanDone:   deviceScanDone,
 		LogBroadcaster:   logBroadcaster,

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -71,6 +71,7 @@ type Config struct {
 	Info             *service.ServerInfo
 	StringTables     []*stringtable.StringTable
 	EnableLocalFiles bool
+	PreloadDepGraph  bool
 	AuthToken        auth.Token
 	DeviceScanDone   task.Signal
 	LogBroadcaster   *log.Broadcaster
@@ -88,6 +89,7 @@ func New(ctx context.Context, cfg Config) Server {
 		cfg.Info,
 		cfg.StringTables,
 		cfg.EnableLocalFiles,
+		cfg.PreloadDepGraph,
 		cfg.DeviceScanDone,
 		cfg.LogBroadcaster,
 	}
@@ -97,6 +99,7 @@ type server struct {
 	info             *service.ServerInfo
 	stbs             []*stringtable.StringTable
 	enableLocalFiles bool
+	preloadDepGraph  bool
 	deviceScanDone   task.Signal
 	logBroadcaster   *log.Broadcaster
 }
@@ -280,7 +283,7 @@ func (s *server) LoadCapture(ctx context.Context, path string) (*path.Capture, e
 	}
 
 	// Pre-resolve the dependency graph.
-	if !config.DisableDeadCodeElimination {
+	if !config.DisableDeadCodeElimination && s.preloadDepGraph {
 		newCtx := keys.Clone(context.Background(), ctx)
 		crash.Go(func() {
 			cctx := status.PutTask(newCtx, nil)


### PR DESCRIPTION
This helps in debugging problematic traces with gapit that would otherwise
crash gapis in the dependency graph resolve (e.g. panic in mutate) as they
can now be loaded.