### PR TITLE
Fix README images

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <!-- TODO(b/155159330) Once we reach a stable release, re-enabled godoc and switch to pkg.go.dev, see https://go.dev/about#adding-a-package -->
 <!-- [![GoDoc](https://godoc.org/github.com/google/gapid?status.svg)](https://godoc.org/github.com/google/gapid) -->
+![]()
 <img alt="Linux" src="kokoro/img/linux.png" width="20px" height="20px" hspace="2px"/>
 [![Linux Build Status](https://agi-build.storage.googleapis.com/badges/build_status_linux.svg)](https://agi-build.storage.googleapis.com/badges/build_result_linux.html)
 <img alt="MacOS" src="kokoro/img/macos.png" width="20px" height="20px" hspace="2px"/>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- TODO(b/155159330) Once we reach a stable release, re-enabled godoc and switch to pkg.go.dev, see https://go.dev/about#adding-a-package -->
 <!-- [![GoDoc](https://godoc.org/github.com/google/gapid?status.svg)](https://godoc.org/github.com/google/gapid) -->
-![]()
+![]() <!-- Empty image needed to have the markdown parser correctly parse the following lines -->
 <img alt="Linux" src="kokoro/img/linux.png" width="20px" height="20px" hspace="2px"/>
 [![Linux Build Status](https://agi-build.storage.googleapis.com/badges/build_status_linux.svg)](https://agi-build.storage.googleapis.com/badges/build_result_linux.html)
 <img alt="MacOS" src="kokoro/img/macos.png" width="20px" height="20px" hspace="2px"/>


### PR DESCRIPTION
Markdown doesn't like <img> tags at the start of a section so after commenting the godoc status the images are broken in the README file. This quick fixes it.