### PR TITLE
Make state rebuilding more deterministic

### DIFF
--- a/gapis/api/vulkan/image_primer.go
+++ b/gapis/api/vulkan/image_primer.go
@@ -17,6 +17,7 @@ package vulkan
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/gapid/core/image"
@@ -52,17 +53,41 @@ const (
 )
 
 func (p *imagePrimer) Free() {
-	for i, b := range p.renderBuilders {
-		b.Free(p.sb)
-		delete(p.renderBuilders, i)
+	{
+		keys := make([]VkDevice, 0, len(p.renderBuilders))
+		for k := range p.renderBuilders {
+			keys = append(keys, k)
+		}
+		sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+		for _, i := range keys {
+			b := p.renderBuilders[i]
+			b.Free(p.sb)
+			delete(p.renderBuilders, i)
+		}
 	}
-	for i, b := range p.hostCopyBuilders {
-		b.Free(p.sb)
-		delete(p.hostCopyBuilders, i)
+	{
+		keys := make([]VkDevice, 0, len(p.hostCopyBuilders))
+		for k := range p.hostCopyBuilders {
+			keys = append(keys, k)
+		}
+		sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+		for _, i := range keys {
+			b := p.hostCopyBuilders[i]
+			b.Free(p.sb)
+			delete(p.hostCopyBuilders, i)
+		}
 	}
-	for i, b := range p.storeBuilders {
-		b.Free(p.sb)
-		delete(p.storeBuilders, i)
+	{
+		keys := make([]VkDevice, 0, len(p.storeBuilders))
+		for k := range p.storeBuilders {
+			keys = append(keys, k)
+		}
+		sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+		for _, i := range keys {
+			b := p.storeBuilders[i]
+			b.Free(p.sb)
+			delete(p.storeBuilders, i)
+		}
 	}
 }
 

--- a/gapis/api/vulkan/scratch_resources.go
+++ b/gapis/api/vulkan/scratch_resources.go
@@ -51,26 +51,58 @@ func newScratchResources() *scratchResources {
 // Free frees first submit all the pending commands held by all the queue
 // command handlers, then free all the memories and command pools.
 func (res *scratchResources) Free(sb *stateBuilder) {
-	for q, h := range res.queueCommandHandlers {
-		err := h.Submit(sb)
-		if err != nil {
-			panic(err)
+	{
+		keys := make([]VkQueue, 0, len(res.queueCommandHandlers))
+		for k := range res.queueCommandHandlers {
+			keys = append(keys, k)
 		}
-		err = h.WaitUntilFinish(sb)
-		if err != nil {
-			panic(err)
+		sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+		for _, q := range keys {
+			h := res.queueCommandHandlers[q]
+			err := h.Submit(sb)
+			if err != nil {
+				panic(err)
+			}
+			err = h.WaitUntilFinish(sb)
+			if err != nil {
+				panic(err)
+			}
+			delete(res.queueCommandHandlers, q)
 		}
-		delete(res.queueCommandHandlers, q)
 	}
-	for dev, mem := range res.memories {
-		mem.Free(sb)
-		delete(res.memories, dev)
-	}
-	for dev, families := range res.commandPools {
-		for _, pool := range families {
-			sb.write(sb.cb.VkDestroyCommandPool(dev, pool, memory.Nullptr))
+	{
+		keys := make([]VkDevice, 0, len(res.memories))
+		for k := range res.memories {
+			keys = append(keys, k)
 		}
-		delete(res.commandPools, dev)
+		sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+		for _, dev := range keys {
+			mem := res.memories[dev]
+			mem.Free(sb)
+			delete(res.memories, dev)
+		}
+	}
+	{
+		keys := make([]VkDevice, 0, len(res.commandPools))
+		for k := range res.commandPools {
+			keys = append(keys, k)
+		}
+		sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+		// Declare uKeys slice (used in inner loop) here so it is allocated only once
+		uKeys := []uint32{}
+		for _, dev := range keys {
+			families := res.commandPools[dev]
+			uKeys = []uint32{}
+			for k := range families {
+				uKeys = append(uKeys, k)
+			}
+			sort.Slice(uKeys, func(i, j int) bool { return uKeys[i] < uKeys[j] })
+			for _, k := range uKeys {
+				pool := families[k]
+				sb.write(sb.cb.VkDestroyCommandPool(dev, pool, memory.Nullptr))
+			}
+			delete(res.commandPools, dev)
+		}
 	}
 }
 

--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -720,11 +720,19 @@ func (sb *stateBuilder) createDevice(d DeviceObjectʳ) {
 		queuePriorities[q.QueueFamilyIndex()][q.QueueIndex()] = q.Priority()
 	}
 	reorderedQueueCreates := map[uint32]VkDeviceQueueCreateInfo{}
-	i := uint32(0)
-	for k, v := range queueCreate {
-		v.SetPQueuePriorities(NewF32ᶜᵖ(sb.MustAllocReadData(queuePriorities[k]).Ptr()))
-		reorderedQueueCreates[i] = v
-		i++
+	{
+		keys := []uint32{}
+		for k := range queueCreate {
+			keys = append(keys, k)
+		}
+		sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+		i := uint32(0)
+		for _, k := range keys {
+			v := queueCreate[k]
+			v.SetPQueuePriorities(NewF32ᶜᵖ(sb.MustAllocReadData(queuePriorities[k]).Ptr()))
+			reorderedQueueCreates[i] = v
+			i++
+		}
 	}
 
 	pNext := NewVoidᵖ(memory.Nullptr)

--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -2707,7 +2707,8 @@ func (sb *stateBuilder) createDescriptorPoolAndAllocateDescriptorSets(dp Descrip
 
 	descSetHandles := make([]VkDescriptorSet, 0, dp.DescriptorSets().Len())
 	descSetLayoutHandles := make([]VkDescriptorSetLayout, 0, dp.DescriptorSets().Len())
-	for vkDescSet, descSetObj := range dp.DescriptorSets().All() {
+	for _, vkDescSet := range dp.DescriptorSets().Keys() {
+		descSetObj := dp.DescriptorSets().Get(vkDescSet)
 		if vkDescSet != VkDescriptorSet(0) && sb.s.DescriptorSets().Contains(vkDescSet) && sb.s.DescriptorSetLayouts().Contains(descSetObj.Layout().VulkanHandle()) {
 			descSetHandles = append(descSetHandles, vkDescSet)
 			descSetLayoutHandles = append(descSetLayoutHandles, descSetObj.Layout().VulkanHandle())


### PR DESCRIPTION
This is a big but boring change to reduce the sources of non-determinism in the state rebuilder. It is only a first step, but it already massively reduces differences in the list of generated commands.

Make sure to review commit-by-commit, to have piecemeal diffs.

Tested on an MEC trace that generates 50k+ commands for state rebuilding, these changes brings the number of diff chunks (between the lists of state-rebuilding commands generated by several calls to `linearize_trace`) from ~2000 down to ~30.

Bug: b/155048196