### PR TITLE
Make state rebuilder deterministic

### DIFF
--- a/gapis/api/vulkan/image_primer.go
+++ b/gapis/api/vulkan/image_primer.go
@@ -787,10 +787,14 @@ func walkImageSubresourceRange(sb *stateBuilder, img ImageObjectʳ, rng VkImageS
 }
 
 func walkSparseImageMemoryBindings(sb *stateBuilder, img ImageObjectʳ, f func(aspect VkImageAspectFlagBits, layer, level uint32, blockData SparseBoundImageBlockInfoʳ)) {
-	for aspect, aspectData := range img.SparseImageMemoryBindings().All() {
-		for layer, layerData := range aspectData.Layers().All() {
-			for level, levelData := range layerData.Levels().All() {
-				for _, blockData := range levelData.Blocks().All() {
+	for _, aspect := range img.SparseImageMemoryBindings().Keys() {
+		aspectData := img.SparseImageMemoryBindings().Get(aspect)
+		for _, layer := range aspectData.Layers().Keys() {
+			layerData := aspectData.Layers().Get(layer)
+			for _, level := range layerData.Levels().Keys() {
+				levelData := layerData.Levels().Get(level)
+				for _, block := range levelData.Blocks().Keys() {
+					blockData := levelData.Blocks().Get(block)
 					f(VkImageAspectFlagBits(aspect), layer, level, blockData)
 				}
 			}

--- a/gapis/api/vulkan/image_primer_resources.go
+++ b/gapis/api/vulkan/image_primer_resources.go
@@ -14,7 +14,11 @@
 
 package vulkan
 
-import "github.com/google/gapid/gapis/memory"
+import (
+	"sort"
+
+	"github.com/google/gapid/gapis/memory"
+)
 
 // descriptorSetPoolReservation is the result of descriptor set reservation
 // request to homoDescriptorSetPool. It contains the descriptor sets reserved
@@ -127,7 +131,14 @@ func (dss *homoDescriptorSetPool) createDescriptorPool(sb *stateBuilder, setCoun
 		countPerType[t] *= setCount
 	}
 	poolSizes := []VkDescriptorPoolSize{}
-	for t, c := range countPerType {
+	// Create pool sizes in order
+	keys := make([]VkDescriptorType, 0, len(countPerType))
+	for k := range countPerType {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	for _, t := range keys {
+		c := countPerType[t]
 		poolSizes = append(poolSizes, NewVkDescriptorPoolSize(sb.ta, t, c))
 	}
 

--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -1526,9 +1526,12 @@ func (sb *stateBuilder) createImage(img ImageObjectʳ, srcState *api.GlobalState
 
 		nonSparseInfos := []VkSparseImageMemoryBind{}
 
-		for aspect, info := range img.SparseImageMemoryBindings().All() {
-			for layer, layerInfo := range info.Layers().All() {
-				for level, levelInfo := range layerInfo.Levels().All() {
+		for _, aspect := range img.SparseImageMemoryBindings().Keys() {
+			info := img.SparseImageMemoryBindings().Get(aspect)
+			for _, layer := range info.Layers().Keys() {
+				layerInfo := info.Layers().Get(layer)
+				for _, level := range layerInfo.Levels().Keys() {
+					levelInfo := layerInfo.Levels().Get(level)
 					for _, k := range levelInfo.Blocks().Keys() {
 						block := levelInfo.Blocks().Get(k)
 						if !img.Info().DedicatedAllocationNV().IsNil() {

--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -668,8 +668,10 @@ func (sb *stateBuilder) createSurface(s SurfaceObjectʳ) {
 			VkResult_VK_SUCCESS,
 		))
 	}
-	for phyDev, familyIndices := range s.PhysicalDeviceSupports().All() {
-		for index, supported := range familyIndices.QueueFamilySupports().All() {
+	for _, phyDev := range s.PhysicalDeviceSupports().Keys() {
+		familyIndices := s.PhysicalDeviceSupports().Get(phyDev)
+		for _, index := range familyIndices.QueueFamilySupports().Keys() {
+			supported := familyIndices.QueueFamilySupports().Get(index)
 			sb.write(sb.cb.VkGetPhysicalDeviceSurfaceSupportKHR(
 				phyDev,
 				index,


### PR DESCRIPTION
This is a follow-up on #261

A few more removal of non-determinism in the state rebuilder.

Manually tested with two apps for which state rebuilder generates  50k and 80k commands: the list of generated commands looks deterministic now.

Bug: b/155048196