### PR TITLE
Introduce experimental flag.

### DIFF
--- a/cmd/gapit/common.go
+++ b/cmd/gapit/common.go
@@ -67,6 +67,9 @@ func getGapis(ctx context.Context, gapisFlags GapisFlags, gapirFlags GapirFlags)
 
 	args = append(args, "--enable-local-files")
 
+	args = append(args, "--experimental-enable-vulkan-tracing")
+	args = append(args, "--experimental-enable-frame-lifecycle")
+
 	if app.Flags.Analytics != "" {
 		args = append(args, "--analytics", app.Flags.Analytics)
 	}

--- a/core/app/flags/BUILD.bazel
+++ b/core/app/flags/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
     srcs = [
         "choices.go",
         "doc.go",
+        "experimental.go",
         "flags.go",
         "repeated.go",
         "strings.go",

--- a/core/app/flags/experimental.go
+++ b/core/app/flags/experimental.go
@@ -1,0 +1,28 @@
+// Copyright (C) 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flags
+
+import (
+	"flag"
+)
+
+// Experimental features are hidden behind the flags. All experimental feature flags must:
+//     1) be named --experimental-enable-<feature-name>
+//     2) be by default false/off
+//     3) be removed once the feature is no longer in experiment
+var (
+	EnableFrameLifecycle = flag.Bool("experimental-enable-frame-lifecycle", false, "Enable the experimental feature Frame Lifecycle.")
+	EnableVulkanTracing  = flag.Bool("experimental-enable-vulkan-tracing", false, "Enable the experimental feature Vulkan tracing.")
+)

--- a/core/os/android/adb/BUILD.bazel
+++ b/core/os/android/adb/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
     deps = [
         "//core/app:go_default_library",
         "//core/app/crash:go_default_library",
+        "//core/app/flags:go_default_library",
         "//core/context/keys:go_default_library",
         "//core/event/task:go_default_library",
         "//core/fault:go_default_library",

--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/app/flags"
 	"github.com/google/gapid/core/fault"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/android"
@@ -331,7 +332,7 @@ func (b *binding) QueryPerfettoServiceState(ctx context.Context) (*device.Perfet
 		result.GpuProfiling = gpu
 	}
 
-	if b.Instance().GetConfiguration().GetOS().GetAPIVersion() >= 30 {
+	if b.Instance().GetConfiguration().GetOS().GetAPIVersion() >= 30 && *flags.EnableFrameLifecycle {
 		gpu.HasFrameLifecycle = true
 	}
 

--- a/gapic/src/main/com/google/gapid/Main.java
+++ b/gapic/src/main/com/google/gapid/Main.java
@@ -32,6 +32,7 @@ import com.google.gapid.server.GapiPaths;
 import com.google.gapid.server.GapisProcess;
 import com.google.gapid.util.Crash2ExceptionHandler;
 import com.google.gapid.util.ExceptionHandler;
+import com.google.gapid.util.Experimental;
 import com.google.gapid.util.Flags;
 import com.google.gapid.util.Flags.Flag;
 import com.google.gapid.util.Logging;
@@ -204,6 +205,9 @@ public class Main {
     Flags.fullHelp,
     Flags.version,
     Devices.skipDeviceValidation,
+    Experimental.enableAll,
+    Experimental.enableFrameLifecycle,
+    Experimental.enableVulkanTracing,
     GapiPaths.gapidPath,
     GapiPaths.adbPath,
     GapisProcess.disableGapisTimeout,

--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
@@ -514,7 +514,7 @@ public class TraceConfigDialog extends DialogBase {
 
         if (gpuCaps.getHasFrameLifecycle()) {
           gpuFrame = createCheckbox(
-              gpuGroup, "Frame Lifecycle", sGpu.getSurfaceFlinger(), e -> updateGpu());
+              gpuGroup, "Frame Lifecycle (experimental)", sGpu.getSurfaceFlinger(), e -> updateGpu());
         } else {
           gpuFrame = null;
         }

--- a/gapic/src/main/com/google/gapid/server/GapisProcess.java
+++ b/gapic/src/main/com/google/gapid/server/GapisProcess.java
@@ -21,6 +21,7 @@ import static java.util.logging.Level.WARNING;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gapid.models.Settings;
+import com.google.gapid.util.Experimental;
 import com.google.gapid.util.Flags;
 import com.google.gapid.util.Flags.Flag;
 import com.google.gapid.util.Logging;
@@ -95,6 +96,9 @@ public class GapisProcess extends ChildProcess<Integer> {
       args.add("-analytics");
       args.add(settings.preferences().getAnalyticsClientId());
     }
+
+    // Append all experimental flags if any is enabled.
+    args.addAll(Experimental.getGapisFlags(settings.preferences().getEnableAllExperimentalFeatures()));
 
     File logDir = Logging.getLogDir();
     if (logDir != null) {

--- a/gapic/src/main/com/google/gapid/settings.proto
+++ b/gapic/src/main/com/google/gapid/settings.proto
@@ -54,6 +54,7 @@ message Preferences {
   string analytics_client_id = 7;  // Empty (default) means do not track.
   bool disable_replay_optimization = 8;
   bool report_crashes = 9;
+  bool enable_all_experimental_features = 10;
 }
 
 message UI {

--- a/gapic/src/main/com/google/gapid/util/Experimental.java
+++ b/gapic/src/main/com/google/gapid/util/Experimental.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.util;
+
+import com.google.common.collect.Lists;
+import com.google.gapid.util.Flags;
+import com.google.gapid.util.Flags.Flag;
+
+import java.util.List;
+
+/**
+ * Command line flag definition for experimental features.
+ */
+public class Experimental {
+  public static final Flag<Boolean> enableAll = Flags.value("experimental-enable-all", false,
+      "Enable all experimental features. " +
+      "Features turned on by this flag are all unstable and under development.");
+
+  public static final Flag<Boolean> enableFrameLifecycle = Flags.value("experimental-enable-frame-lifecycle",
+      false, "Enable the experimental feature Frame Lifecycle.");
+
+  public static final Flag<Boolean> enableVulkanTracing = Flags.value("experimental-enable-vulkan-tracing",
+      false, "Enable the experimental feature Vulakn tracing.");
+
+  public static List<String> getGapisFlags(boolean enableAllExperimentalFeatures) {
+    List<String> args = Lists.newArrayList();
+    // The --experimental-enable-all flag is a sugar flag from the UI. GAPIS knows nothing about it.
+    if (enableAllExperimentalFeatures || Experimental.enableAll.get()) {
+      // All --experimental-enable-<feature-name> flags must be added here.
+      args.add("--experimental-enable-frame-lifecycle");
+      args.add("--experimental-enable-vulkan-tracing");
+    } else {
+      if (Experimental.enableFrameLifecycle.get()) {
+        args.add("--experimental-enable-frame-lifecycle");
+      }
+      if (Experimental.enableVulkanTracing.get()) {
+        args.add("--experimental-enable-vulkan-tracing");
+      }
+    }
+    return args;
+  }
+}

--- a/gapic/src/main/com/google/gapid/views/SettingsDialog.java
+++ b/gapic/src/main/com/google/gapid/views/SettingsDialog.java
@@ -52,6 +52,7 @@ public class SettingsDialog extends DialogBase {
   protected final Models models;
   private SettingsFormBase form;
   protected Button disableReplayOptimization;
+  protected Button enableAllExperimentalFeatures;
 
   public SettingsDialog(Shell parent, Models models, Theme theme) {
     super(parent, theme);
@@ -79,6 +80,10 @@ public class SettingsDialog extends DialogBase {
             "Disable replay optimization",
             models.settings.preferences().getDisableReplayOptimization()),
             withSpans(new GridData(SWT.LEFT, SWT.TOP, false, false), 2, 1));
+        enableAllExperimentalFeatures = withLayoutData(createCheckbox(this,
+            "Enable all unsupported experimental features (requires restart)",
+            models.settings.preferences().getEnableAllExperimentalFeatures()),
+            withSpans(new GridData(SWT.LEFT, SWT.TOP, false, false), 2, 1));
       }
     };
     form.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
@@ -103,6 +108,8 @@ public class SettingsDialog extends DialogBase {
   private void update() {
     models.settings.writePreferences().setDisableReplayOptimization(
         disableReplayOptimization.getSelection());
+    models.settings.writePreferences().setEnableAllExperimentalFeatures(
+        enableAllExperimentalFeatures.getSelection());
   }
 
   public static class SettingsFormBase extends Composite {

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -576,7 +576,7 @@ public class TracerDialog {
           public String getText(Object element) {
             TraceTypeCapabilities ttc = (TraceTypeCapabilities)element;
             switch (ttc.getType()) {
-              case Graphics: return ttc.getApi();
+              case Graphics: return ttc.getApi() + " (Experimental)";
               case Perfetto: return "System Profile";
               default: throw new AssertionError();
             }

--- a/gapis/trace/android/BUILD.bazel
+++ b/gapis/trace/android/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     deps = [
         "//core/app:go_default_library",
         "//core/app/crash:go_default_library",
+        "//core/app/flags:go_default_library",
         "//core/app/status:go_default_library",
         "//core/event/task:go_default_library",
         "//core/log:go_default_library",

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -35,6 +35,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/app/crash"
+	"github.com/google/gapid/core/app/flags"
 	"github.com/google/gapid/core/app/status"
 	"github.com/google/gapid/core/event/task"
 	"github.com/google/gapid/core/log"
@@ -280,7 +281,7 @@ func (t *androidTracer) TraceConfiguration(ctx context.Context) (*service.Device
 		apis = append(apis, tracer.GLESTraceOptions())
 	}
 	*/
-	if len(t.b.Instance().GetConfiguration().GetDrivers().GetVulkan().GetPhysicalDevices()) > 0 {
+	if len(t.b.Instance().GetConfiguration().GetDrivers().GetVulkan().GetPhysicalDevices()) > 0 && *flags.EnableVulkanTracing {
 		apis = append(apis, tracer.VulkanTraceOptions())
 	}
 	if t.b.SupportsPerfetto(ctx) {

--- a/gapis/trace/desktop/BUILD.bazel
+++ b/gapis/trace/desktop/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
     deps = [
         "//core/app:go_default_library",
         "//core/app/crash:go_default_library",
+        "//core/app/flags:go_default_library",
         "//core/event/task:go_default_library",
         "//core/log:go_default_library",
         "//core/os/device:go_default_library",

--- a/gapis/trace/desktop/ggp_trace.go
+++ b/gapis/trace/desktop/ggp_trace.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/app/crash"
+	"github.com/google/gapid/core/app/flags"
 	"github.com/google/gapid/core/event/task"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/device/bind"
@@ -69,7 +70,7 @@ func NewGGPTracer(ctx context.Context, dev bind.Device) (*GGPTracer, error) {
 // TraceConfiguration returns the device's supported trace configuration.
 func (t *GGPTracer) TraceConfiguration(ctx context.Context) (*service.DeviceTraceConfiguration, error) {
 	apis := make([]*service.TraceTypeCapabilities, 0, 1)
-	if len(t.b.Instance().GetConfiguration().GetDrivers().GetVulkan().GetPhysicalDevices()) > 0 {
+	if len(t.b.Instance().GetConfiguration().GetDrivers().GetVulkan().GetPhysicalDevices()) > 0 && *flags.EnableVulkanTracing {
 		apis = append(apis, tracer.VulkanTraceOptions())
 	}
 

--- a/gapis/trace/desktop/trace.go
+++ b/gapis/trace/desktop/trace.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/app/flags"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/core/os/device/bind"
@@ -61,7 +62,7 @@ func (t *DesktopTracer) Validate(ctx context.Context) error {
 // TraceConfiguration returns the device's supported trace configuration.
 func (t *DesktopTracer) TraceConfiguration(ctx context.Context) (*service.DeviceTraceConfiguration, error) {
 	apis := make([]*service.TraceTypeCapabilities, 0, 1)
-	if len(t.b.Instance().GetConfiguration().GetDrivers().GetVulkan().GetPhysicalDevices()) > 0 {
+	if len(t.b.Instance().GetConfiguration().GetDrivers().GetVulkan().GetPhysicalDevices()) > 0 && *flags.EnableVulkanTracing {
 		apis = append(apis, tracer.VulkanTraceOptions())
 	}
 


### PR DESCRIPTION
This patch introduces the experimental flag for all under development features.
Features under development are unstable and unshaped, and are changed a lot
frequently. However, they are also under team-fooding actively. To balance
this, we put such features behind the experimental flag. UI elements must also
have clear indication that the features are experimental.

This patch also puts frame lifecycle behind the experimental flag.

Bug: b/155889093