### PR TITLE
Show submission node in command list for empty command buffer.

### DIFF
--- a/gapis/api/cmd_id_group.go
+++ b/gapis/api/cmd_id_group.go
@@ -433,7 +433,7 @@ func (c *SubCmdRoot) Insert(r []uint64, nameLookUp *SubCmdIdxTrie) {
 	if CmdID(id) > childRoot.SubGroup.Range.End {
 		childRoot.SubGroup.Range.End = CmdID(id + 1)
 	}
-	for i := CmdID(0); i <= CmdID(id); i++ {
+	for i := CmdID(0); i < CmdID(id); i++ {
 		childRoot.SubGroup.AddCommand(i)
 	}
 }

--- a/gapis/api/sync/data.go
+++ b/gapis/api/sync/data.go
@@ -76,7 +76,8 @@ type Data struct {
 	// SubcommandReferences contains the information about every subcommand
 	// run by a particular command.
 	SubcommandReferences map[api.CmdID][]SubcommandReference
-	// SubcommandGroups represents the last Subcommand in every command buffer.
+	// SubcommandGroups represents the next utilizable subcommand index in
+	// every command buffer.
 	SubcommandGroups map[api.CmdID][]api.SubCmdIdx
 	// Hidden contains all the commands that should be hidden from the regular
 	// command tree as they exist as a subcommand of another command.

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -250,7 +250,7 @@ func (API) ResolveSynchronization(ctx context.Context, d *sync.Data, c *path.Cap
 					refs = append(refs, newRefs...)
 					subgroups = append(subgroups, newSubgroups...)
 					if cbo.CommandReferences().Len() > 0 {
-						subgroups = append(subgroups, append(idx, uint64(i), uint64(j), uint64(cbo.CommandReferences().Len()-1)))
+						subgroups = append(subgroups, append(idx, uint64(i), uint64(j), uint64(cbo.CommandReferences().Len())))
 						d.SubcommandNames.SetValue(append(idx, uint64(i), j), fmt.Sprintf("Command Buffer: %v", cbo.VulkanHandle()))
 					}
 				}
@@ -392,14 +392,12 @@ func (API) ResolveSynchronization(ctx context.Context, d *sync.Data, c *path.Cap
 				for j, buff := range buffers {
 					d.SubcommandNames.SetValue(api.SubCmdIdx{uint64(id), uint64(submitIdx), uint64(j)}, fmt.Sprintf("Command Buffer: %v", buff))
 					cmdBuff := st.CommandBuffers().Get(buff)
-					// If a submitted command-buffer is empty, we shouldn't show it
-					if cmdBuff.CommandReferences().Len() > 0 {
+					if cmdBuff.CommandReferences().Len() >= 0 {
 						additionalRefs, additionalSubgroups := walkCommandBuffer(cmdBuff, api.SubCmdIdx{uint64(i), uint64(submitIdx), uint64(j)}, i, order)
 						for _, sg := range additionalSubgroups {
 							d.SubcommandGroups[i] = append(d.SubcommandGroups[i], sg[1:])
 						}
-						d.SubcommandGroups[i] = append(d.SubcommandGroups[i], api.SubCmdIdx{uint64(submitIdx), uint64(j), uint64(cmdBuff.CommandReferences().Len() - 1)})
-
+						d.SubcommandGroups[i] = append(d.SubcommandGroups[i], api.SubCmdIdx{uint64(submitIdx), uint64(j), uint64(cmdBuff.CommandReferences().Len())})
 						refs = append(refs, additionalRefs...)
 					}
 				}


### PR DESCRIPTION
 - Make sync.Data.SubcommandGroups point to the the next utilizable
    subcommand index, so that we can identify an empty command buffer at
    command tree creation time.
 - Bug: b/143733663.