### PR TITLE
Clean up layer handling for profiling and find_issues

### DIFF
--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -1050,9 +1050,11 @@ func (a API) Replay(
 			makeReadable.imagesOnly = true
 			optimize = false
 			transforms.Add(NewWaitForPerfetto(req.traceOptions, req.handler, req.buffer))
+			var layerName string
 			if device.GetConfiguration().GetPerfettoCapability().GetGpuProfiling().GetHasRenderStageProducerLayer() {
-				transforms.Add(&profilingLayers{})
+				layerName = "VkRenderStagesProducer"
 			}
+			transforms.Add(&profilingLayers{layerName: layerName})
 			transforms.Add(replay.NewMappingExporter(ctx, req.handleMappings))
 		}
 	}


### PR DESCRIPTION
Is critical that we don't have validation layers enabled during
profiling; the layers do handle remapping which destroys our ability to
correlate data coming directly from the driver through perfetto with the
replayer's own observations of handles.

Is also important to not have validation layers doubly-enabled during
the find_issues replay, as they don't work when loaded twice.

The existing code tried to do this in the find_issues case but failed to
because of a quirk in the way strings are handled.

All known layers which we'd want to leave enabled are imposed from
the environment rather than being part of the vkCreateInstance call
(eg Optimus on desktop). Just remove all explicit layers, and readd the
one we want if any (renderstages layer if profiling on a device which
requires it; validation layer if finding issues).

This fixes various bad behavior in these replays when running Bender.

Bug: b/156104191