### PR TITLE
Fix tree visibility tracking on Linux.

### DIFF
--- a/gapic/src/main/com/google/gapid/util/Trees.java
+++ b/gapic/src/main/com/google/gapid/util/Trees.java
@@ -20,6 +20,7 @@ import static java.util.Collections.emptySet;
 
 import com.google.common.collect.Sets;
 
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
 
@@ -32,11 +33,49 @@ public class Trees {
   private Trees() {
   }
 
+  public static TreeItem getTopItem(Tree tree) {
+    if (!OS.isLinux) {
+      return tree.getTopItem();
+    }
+
+    // Dirty work around for https://bugs.eclipse.org/bugs/show_bug.cgi?id=563232.
+    // Note this will often return an item that is above the visible one, as it only considers
+    // root items. The actual correct top item may be a child of the returned item.
+    int count = tree.getItemCount();
+    if (count == 0) {
+      return null;
+    }
+
+    TreeItem item = tree.getItem(0);
+    if (count <= 2) {
+      return item;
+    }
+    Rectangle bounds = item.getBounds();
+    if (bounds.y >= 0 || (bounds.y <= 0 && bounds.y + bounds.height >= 0)) {
+      return item;
+    }
+
+    int start = 0, end = count - 1;
+    while (end - start > 1) {
+      int mid = (start + end) / 2;
+      item = tree.getItem(mid);
+      bounds = item.getBounds();
+      if (bounds.y <= 0 && bounds.y + bounds.height >= 0) {
+        return item;
+      } else if (bounds.y > 0) {
+        end = mid;
+      } else {
+        start = mid;
+      }
+    }
+    return tree.getItem(start);
+  }
+
   /**
    * @return the {@link TreeItem TreeItems} that are currently visible in the tree.
    */
   public static Set<TreeItem> getVisibleItems(Tree tree) {
-    TreeItem top = tree.getTopItem();
+    TreeItem top = getTopItem(tree);
     if (top == null) {
       // Work around bug where getTopItem() returns null when scrolling
       // up past the top item (elastic scroll).


### PR DESCRIPTION
This is a workaround for a SWT issue on Linux, where Tree.getTopItem() returns the wrong thing.

See https://bugs.eclipse.org/bugs/show_bug.cgi?id=563232