### PR TITLE
Stop embedding a JRE in macOS builds

### DIFF
--- a/kokoro/macos/copy_jre.sh
+++ b/kokoro/macos/copy_jre.sh
@@ -20,15 +20,7 @@ if [ $# -ne 1 ]; then
 	exit
 fi
 
-# Get JRE from AdoptOpenJDK (the JRE shipped with Kokoro is built with a too old
-# macos SDK version to be notarized)
-curl -fsSL -o jre.tar.gz https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jre_x64_mac_hotspot_8u252b09.tar.gz
-echo "f8206f0fef194c598de6b206a4773b2e517154913ea0e26c5726091562a034c8  jre.tar.gz" > jre_sha.txt
-sha256sum --check jre_sha.txt
-mkdir jre
-tar xzf jre.tar.gz --directory jre
-
-cp -r jre/jdk8u252-b09-jre/Contents/Home/ $1/
+cp -r $(/usr/libexec/java_home -v 1.8)/jre/ $1/
 
 # Remove unnecessary files.
 # See http://www.oracle.com/technetwork/java/javase/jre-8-readme-2095710.html

--- a/kokoro/macos/package.sh
+++ b/kokoro/macos/package.sh
@@ -44,9 +44,12 @@ VERSION=$(awk -F= 'BEGIN {major=0; minor=0; micro=0}
                   END {print major"."minor"."micro}' $BIN/pkg/build.properties)
 
 # Combine package contents.
-mkdir -p agi/jre
+mkdir agi
 cp -r $BIN/pkg/* agi/
-"$SRC/copy_jre.sh" agi/jre
+# TODO(b/150268876): update to a JRE usable for notarization. In the mean time,
+# do not embed a JRE.
+# mkdir -p agi/jre
+# "$SRC/copy_jre.sh" agi/jre
 
 # Create a zip file.
 zip -r agi-$VERSION-macos.zip agi/


### PR DESCRIPTION
AdoptOpenJDK JRE does not work on macOS Catalina. We are currently
exploring using an other JDK. In the meantime, we stop embedding a JRE
in macOS builds, and we offer a script (on agi-dev-releases repo) to
let the user download a external JRE.

Bug: b/150268876