### PR TITLE
Remove caller machinery

### DIFF
--- a/gapil/compiler/testutils/cmd.go
+++ b/gapil/compiler/testutils/cmd.go
@@ -41,12 +41,6 @@ var _ api.Cmd = &Cmd{}
 // API stubs the api.Cmd interface.
 func (c *Cmd) API() api.API { return nil }
 
-// Caller stubs the api.Cmd interface.
-func (c *Cmd) Caller() api.CmdID { return 0 }
-
-// SetCaller stubs the api.Cmd interface.
-func (c *Cmd) SetCaller(api.CmdID) {}
-
 // Thread stubs the api.Cmd interface.
 func (c *Cmd) Thread() uint64 { return c.T }
 

--- a/gapis/api/cmd.go
+++ b/gapis/api/cmd.go
@@ -27,13 +27,6 @@ type Cmd interface {
 	// All commands belong to an API
 	APIObject
 
-	// Caller returns the identifier of the command that called this command,
-	// or CmdNoID if the command has no caller.
-	Caller() CmdID
-
-	// SetCaller sets the identifier of the command that called this command.
-	SetCaller(CmdID)
-
 	// Thread returns the thread index this command was executed on.
 	Thread() uint64
 

--- a/gapis/api/cmd_service.go
+++ b/gapis/api/cmd_service.go
@@ -79,7 +79,6 @@ func ServiceToCmd(a arena.Arena, c *Command) (Cmd, error) {
 		return nil, fmt.Errorf("Unknown command '%v.%v'", api.Name(), c.Name)
 	}
 
-	cmd.SetCaller(CmdNoID) // TODO: Include this in the proto
 	cmd.SetThread(c.Thread)
 
 	for _, s := range c.Parameters {

--- a/gapis/api/sync/data.go
+++ b/gapis/api/sync/data.go
@@ -43,9 +43,6 @@ type SubcommandReference struct {
 	// If GeneratingCmd is nil, then MidExecutionCommandData contains the data
 	// that the API needs in order to reconstruct this command.
 	MidExecutionCommandData interface{}
-	// IsCalledGroup is true if the reference is to a nested call, otherwise
-	// the reference belongs to a command-list.
-	IsCallerGroup bool
 }
 
 // SyncNodeIdx is the identifier for a node in the sync dependency graph.

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -1740,7 +1740,6 @@ import (
 
   type {{$name}} struct {
     extras ϟapi.CmdExtras
-    caller ϟapi.CmdID
     thread uint64
     {{range $p := $.FullParameters}}
       {{$p | GoPrivateName}} {{Template "Go.Type" $p}} {{Template "CommandParameterTags" $p}}
@@ -1757,10 +1756,6 @@ import (
   func (ϟc *{{$name}}) Thread() uint64 { return ϟc.thread }
 
   func (ϟc *{{$name}}) SetThread(v uint64) { ϟc.thread = v }
-
-  func (ϟc *{{$name}}) Caller() ϟapi.CmdID { return ϟc.caller }
-
-  func (ϟc *{{$name}}) SetCaller(id ϟapi.CmdID) { ϟc.caller = id }
 
   func (ϟc *{{$name}}) Terminated() bool { return !ϟc.notTerminated }
 
@@ -1852,7 +1847,6 @@ import (
   func (ϟc *{{$name}}) clone(ϟa arena.Arena) *{{$name}} {
     out := &{{$name}}{
       extras: ϟc.extras,
-      caller: ϟc.caller,
       thread: ϟc.thread,
       arena: ϟa,
     }
@@ -1916,7 +1910,6 @@ import (
           {{end}}
         ) *{{$name}} {
         out := &{{$name}} {§
-          caller: ϟapi.CmdNoID,
           thread: cb.Thread,
           arena:  cb.Arena,
         }

--- a/gapis/api/test/helpers.go
+++ b/gapis/api/test/helpers.go
@@ -38,7 +38,6 @@ func init() {
 	Cmds.B = cb.CmdTypeMix(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, false, Voidᵖ(0xabcdef9), 200)
 
 	Cmds.IgnoreArena.Register(func(c compare.Comparator, reference, value *CmdTypeMix) {
-		c.With(c.Path.Member("Caller", reference, value)).Compare(reference.Caller(), value.Caller())
 		c.With(c.Path.Member("Thread", reference, value)).Compare(reference.Thread(), value.Thread())
 		c.With(c.Path.Member("CmdName", reference, value)).Compare(reference.CmdName(), value.CmdName())
 		c.With(c.Path.Member("Extras", reference, value)).Compare(reference.Extras(), value.Extras())

--- a/gapis/api/transform/capture_log.go
+++ b/gapis/api/transform/capture_log.go
@@ -69,14 +69,6 @@ func (t *captureLog) Flush(ctx context.Context, out Writer) error {
 	for idx := range t.cmds {
 		cmd := t.cmds[idx].Clone(a)
 		t.cmds[idx] = cmd
-		if caller := cmd.Caller(); caller.IsReal() {
-			if id, ok := t.ids[caller]; ok {
-				cmd.SetCaller(id)
-			} else {
-				log.W(ctx, "Callee without caller %v: %v", caller, cmd)
-				cmd.SetCaller(api.CmdNoID)
-			}
-		}
 	}
 
 	c, err := capture.NewGraphicsCapture(ctx, a, "capturelog", t.header, nil, t.cmds)

--- a/gapis/api/vulkan/command_splitter.go
+++ b/gapis/api/vulkan/command_splitter.go
@@ -44,14 +44,6 @@ func (*InsertionCommand) Mutate(ctx context.Context, cmd api.CmdID, g *api.Globa
 	return nil
 }
 
-func (s *InsertionCommand) Caller() api.CmdID {
-	return s.callee.Caller()
-}
-
-func (s *InsertionCommand) SetCaller(c api.CmdID) {
-	s.callee.SetCaller(c)
-}
-
 func (s *InsertionCommand) Thread() uint64 {
 	return s.callee.Thread()
 }

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -227,14 +227,12 @@ func (API) ResolveSynchronization(ctx context.Context, d *sync.Data, c *path.Cap
 					append(api.SubCmdIdx{}, nv[1:]...),
 					api.CmdNoID,
 					cb.CommandReferences().Get(uint32(i)),
-					false,
 				}
 			} else {
 				ref = sync.SubcommandReference{
 					append(api.SubCmdIdx{}, nv[1:]...),
 					commandMap[generatingId],
 					nil,
-					false,
 				}
 			}
 			d.SubcommandLookup.SetValue(nv, ref)

--- a/gapis/capture/decoder.go
+++ b/gapis/capture/decoder.go
@@ -89,10 +89,12 @@ func (d *decoder) endGroupImpl(ctx context.Context, id uint64, terminated bool) 
 	case *cmdGroup:
 		obj.invoked = true
 		obj.cmd.SetTerminated(terminated)
-		id := d.builder.addCmd(ctx, obj.cmd)
-		for _, c := range obj.children {
-			c.SetCaller(id)
+
+		if len(obj.children) > 0 {
+			return fmt.Errorf("Nested commands not supported, but command %v has children", id)
 		}
+
+		d.builder.addCmd(ctx, obj.cmd)
 	}
 
 	return nil

--- a/gapis/capture/encoder.go
+++ b/gapis/capture/encoder.go
@@ -123,21 +123,9 @@ func (e *encoder) startCmd(ctx context.Context, cmd api.Cmd) (uint64, error) {
 		return 0, err
 	}
 
-	var cmdID uint64
-	if id := cmd.Caller(); id != api.CmdNoID {
-		parentID, err := e.startCmd(ctx, e.c.Commands[id])
-		if err != nil {
-			return 0, err
-		}
-		cmdID, err = e.w.BeginChildGroup(ctx, cmdProto, parentID)
-		if err != nil {
-			return 0, err
-		}
-	} else {
-		cmdID, err = e.w.BeginGroup(ctx, cmdProto)
-		if err != nil {
-			return 0, err
-		}
+	cmdID, err := e.w.BeginGroup(ctx, cmdProto)
+	if err != nil {
+		return 0, err
 	}
 	e.cmdIDs[cmd] = cmdID
 	return cmdID, nil

--- a/gapis/replay/custom.go
+++ b/gapis/replay/custom.go
@@ -41,8 +41,6 @@ func (c Custom) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState,
 }
 
 // api.Cmd compliance
-func (Custom) Caller() api.CmdID             { return api.CmdNoID }
-func (Custom) SetCaller(api.CmdID)           {}
 func (cmd Custom) Thread() uint64            { return cmd.T }
 func (cmd Custom) SetThread(t uint64)        { cmd.T = t }
 func (Custom) CmdName() string               { return "<Custom>" }

--- a/gapis/resolve/dependencygraph2/dce.go
+++ b/gapis/resolve/dependencygraph2/dce.go
@@ -276,12 +276,6 @@ func (b *DCEBuilder) processLiveCmd(ctx context.Context, a arena.Arena, id api.C
 		}
 	}
 
-	// Adjust the command's `Caller`, if necessary
-	if b.LiveCmdID(cmd.Caller()) != cmd.Caller() {
-		cloneCmd()
-		cmd.SetCaller(b.LiveCmdID(cmd.Caller()))
-	}
-
 	// Attach any orphan observations to this command
 	if len(b.orphanObs) > 0 {
 		cloneCmd()

--- a/gapis/resolve/dependencygraph2/dependency_graph_test.go
+++ b/gapis/resolve/dependencygraph2/dependency_graph_test.go
@@ -32,8 +32,6 @@ import (
 type TestCmd struct{}
 
 func (TestCmd) API() api.API           { return nil }
-func (TestCmd) Caller() api.CmdID      { return 0 }
-func (TestCmd) SetCaller(api.CmdID)    {}
 func (TestCmd) Thread() uint64         { return 0 }
 func (TestCmd) SetThread(uint64)       {}
 func (TestCmd) CmdName() string        { return "TestCmd" }

--- a/gapis/resolve/set.go
+++ b/gapis/resolve/set.go
@@ -133,9 +133,6 @@ func change(ctx context.Context, a arena.Arena, p path.Node, val interface{}, r 
 			cmd.Extras().Add(oldCmd.Extras().All()...)
 		}
 
-		// Propagate caller (not exposed to client)
-		cmd.SetCaller(oldCmd.Caller())
-
 		// Replace the command
 		cmds[cmdIdx] = cmd
 


### PR DESCRIPTION
This was necessary for EGL, where we could see for example eglInitialize
call eglGetError. Vulkan has no such thing.