### PR TITLE
Load all the decoded memory struct values in one grpc session.

### DIFF
--- a/gapic/src/main/com/google/gapid/models/MemoryTypes.java
+++ b/gapic/src/main/com/google/gapid/models/MemoryTypes.java
@@ -107,12 +107,12 @@ public class MemoryTypes {
    * containing relevant information.
    */
   public ListenableFuture<StructNode> loadStructNode(StructObservation structOb) {
-    Path.Any memoryAsType = memoryAsType(structOb.source.command, structOb.source.pool, structOb.range);
-    return transformAsync(client.get(memoryAsType, structOb.device),
-        val -> transform(loadTypes(structOb.getRange().getType()),
-            $ -> new StructNode(structOb.getRange().getType().getAPI(),
-                getType(structOb.getRange().getType()), val.getMemoryBox(),
-                structOb.range.getRoot(), this)));
+    return transform(loadTypes(structOb.getRange().getType()), $ ->
+        new StructNode(structOb.getRange().getType().getAPI(),
+            getType(structOb.getRange().getType()),
+            structOb.getRange().getValue(),
+            structOb.range.getRoot(),
+            this));
   }
 
   /**

--- a/gapic/src/main/com/google/gapid/views/MemoryView.java
+++ b/gapic/src/main/com/google/gapid/views/MemoryView.java
@@ -792,15 +792,12 @@ public class MemoryView extends Composite
         packColumns(treeViewer.getTree());
         return;
       }
-      // long start = System.currentTimeMillis();
 
       Rpc.listen(models.types.loadStructNodes(structs),
           new UiCallback<List<StructNode>, List<StructNode>>(this, LOG) {
         @Override
         protected List<StructNode> onRpcThread(Result<List<StructNode>> result)
             throws RpcException, ExecutionException {
-          // Snippet for time cost evaluation.
-          // System.out.println("loadStructNodes() method duration: " + (System.currentTimeMillis() - start) + "ms.");
           return StructNode.simplifyTrees(result.get());
         }
 

--- a/gapic/src/main/com/google/gapid/views/MemoryView.java
+++ b/gapic/src/main/com/google/gapid/views/MemoryView.java
@@ -792,12 +792,15 @@ public class MemoryView extends Composite
         packColumns(treeViewer.getTree());
         return;
       }
+      // long start = System.currentTimeMillis();
 
       Rpc.listen(models.types.loadStructNodes(structs),
           new UiCallback<List<StructNode>, List<StructNode>>(this, LOG) {
         @Override
         protected List<StructNode> onRpcThread(Result<List<StructNode>> result)
             throws RpcException, ExecutionException {
+          // Snippet for time cost evaluation.
+          // System.out.println("loadStructNodes() method duration: " + (System.currentTimeMillis() - start) + "ms.");
           return StructNode.simplifyTrees(result.get());
         }
 

--- a/gapis/resolve/memory.go
+++ b/gapis/resolve/memory.go
@@ -256,69 +256,8 @@ func MemoryAsType(ctx context.Context, p *path.MemoryAsType, rc *path.ResolveCon
 		return nil, err
 	}
 
-	// Check whether the requested pool was ever created.
-	pool, err := s.Memory.Get(memory.PoolID(p.Pool))
-	if err != nil {
-		return nil, &service.ErrDataUnavailable{Reason: messages.ErrInvalidMemoryPool(p.Pool)}
-	}
-	sz := p.Size
-	if sz == 0 {
-		sz = 0xFFFFFFFFFFFFFFFF
-	}
-
-	dec := s.MemoryDecoder(ctx, pool.Slice(memory.Range{
-		Base: p.Address,
-		Size: sz,
-	}))
-
-	e, err := types.GetType(p.Type.TypeIndex)
-	if err != nil {
-		return nil, err
-	}
-
-	nElems := 1
-	elemSize := 0
-	isSlice := false
-	ty := e
-	if sl, ok := e.Ty.(*types.Type_Slice); ok {
-		isSlice = true
-		sliceType, err := types.GetType(sl.Slice.Underlying)
-		if err != nil {
-			return nil, err
-		}
-		elemSize, err = sliceType.Size(ctx, s.MemoryLayout)
-		if err != nil {
-			return nil, err
-		}
-		if p.Size == 0 {
-			return nil, log.Err(ctx, nil, "Cannot have an unsized range with a slice")
-		}
-		nElems = int(sz / uint64(elemSize))
-		ty = sliceType
-	} else {
-		elemSize, err = e.Size(ctx, s.MemoryLayout)
-		if err != nil {
-			return nil, err
-		}
-	}
-	vals := []*memory_box.Value{}
-	for i := 0; i < nElems; i++ {
-		v, err := memory_box.Box(ctx, dec, ty, p, rc)
-		if err != nil {
-			return nil, err
-		}
-		vals = append(vals, v)
-	}
-
-	if isSlice {
-		return &memory_box.Value{
-			Val: &memory_box.Value_Slice{
-				Slice: &memory_box.Slice{
-					Values: vals,
-				}}}, nil
-	}
-
-	return vals[0], nil
+	rng := memory.Range{Base: p.Address, Size: p.Size}
+	return memoryAsType(ctx, s, rng, p.Pool, p.Type.TypeIndex, p, rc)
 }
 
 // Function memoryAsType resolves typed memory related raw data,

--- a/gapis/resolve/memory.go
+++ b/gapis/resolve/memory.go
@@ -127,6 +127,20 @@ func Memory(ctx context.Context, p *path.Memory, rc *path.ResolveConfig) (*servi
 				if rng.Overlaps(r) {
 					interval.Merge(&reads, rng.Window(r).Span(), false)
 					if p.IncludeTypes {
+						pathMemoryAsType := &path.MemoryAsType{
+							Address: rng.Base,
+							Size:    rng.Size,
+							Pool:    p.Pool,
+							After:   p.After,
+							Type: &path.Type{
+								TypeIndex: id,
+								API:       &path.API{ID: path.NewID(apiId)},
+							},
+						}
+						value, err := MemoryAsType(ctx, pathMemoryAsType, rc)
+						if err != nil {
+							return
+						}
 						typedRanges = append(typedRanges,
 							&service.TypedMemoryRange{
 								Type: &path.Type{
@@ -137,7 +151,8 @@ func Memory(ctx context.Context, p *path.Memory, rc *path.ResolveConfig) (*servi
 									Base: rng.Base,
 									Size: rng.Size,
 								},
-								Root: root,
+								Root:  root,
+								Value: value,
 							},
 						)
 					}
@@ -147,6 +162,20 @@ func Memory(ctx context.Context, p *path.Memory, rc *path.ResolveConfig) (*servi
 				if rng.Overlaps(r) {
 					interval.Merge(&writes, rng.Window(r).Span(), false)
 					if p.IncludeTypes {
+						pathMemoryAsType := &path.MemoryAsType{
+							Address: rng.Base,
+							Size:    rng.Size,
+							Pool:    p.Pool,
+							After:   p.After,
+							Type: &path.Type{
+								TypeIndex: id,
+								API:       &path.API{ID: path.NewID(apiId)},
+							},
+						}
+						value, err := MemoryAsType(ctx, pathMemoryAsType, rc)
+						if err != nil {
+							return
+						}
 						typedRanges = append(typedRanges,
 							&service.TypedMemoryRange{
 								Type: &path.Type{
@@ -157,7 +186,8 @@ func Memory(ctx context.Context, p *path.Memory, rc *path.ResolveConfig) (*servi
 									Base: rng.Base,
 									Size: rng.Size,
 								},
-								Root: root,
+								Root:  root,
+								Value: value,
 							},
 						)
 					}

--- a/gapis/resolve/memory.go
+++ b/gapis/resolve/memory.go
@@ -281,7 +281,7 @@ func memoryAsType(ctx context.Context, s *api.GlobalState, rng memory.Range, poo
 		Size: sz,
 	}))
 
-	e, err := types.GetType(typeIndex)
+	ty, err := types.GetType(typeIndex)
 	if err != nil {
 		return nil, err
 	}
@@ -289,8 +289,7 @@ func memoryAsType(ctx context.Context, s *api.GlobalState, rng memory.Range, poo
 	nElems := 1
 	elemSize := 0
 	isSlice := false
-	ty := e
-	if sl, ok := e.Ty.(*types.Type_Slice); ok {
+	if sl, ok := ty.Ty.(*types.Type_Slice); ok {
 		isSlice = true
 		sliceType, err := types.GetType(sl.Slice.Underlying)
 		if err != nil {
@@ -306,7 +305,7 @@ func memoryAsType(ctx context.Context, s *api.GlobalState, rng memory.Range, poo
 		nElems = int(sz / uint64(elemSize))
 		ty = sliceType
 	} else {
-		elemSize, err = e.Size(ctx, s.MemoryLayout)
+		elemSize, err = ty.Size(ctx, s.MemoryLayout)
 		if err != nil {
 			return nil, err
 		}

--- a/gapis/service/path/path.proto
+++ b/gapis/service/path/path.proto
@@ -398,6 +398,7 @@ message Memory {
 
 // MemoryAsType is a path to a particular piece of memory
 //  interpreted as a specific type
+// Resolves to a memory_box.Value.
 message MemoryAsType {
   // Base address of the region of memory.
   uint64 address = 1;

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -916,6 +916,8 @@ message TypedMemoryRange {
   MemoryRange range = 2;
   // The root of the memory observation
   uint64 root = 3;
+  // The structured value of the typed memory observation.
+  memory_box.Value value = 4;
 }
 
 // Resources contains the full list of resources used by a capture.


### PR DESCRIPTION
 - Pre-resolve the struct value at backend, from path.MemoryAsType
 to memory_box.Value. In this way, we avoid client sending out the
 resolving request a sencond time for each struct.
 - Bug: b/155059249.