### PR TITLE
Fix conversion for signed and depth thumbnails

### DIFF
--- a/core/stream/curve.go
+++ b/core/stream/curve.go
@@ -37,7 +37,7 @@ func (m *mapping) transform(count int, f func(float64) float64) error {
 			stride: 64,
 		},
 	}
-	if err := tmp.conv(count); err != nil {
+	if err := tmp.conv(count, 0, 0); err != nil {
 		return err
 	}
 	r := endian.Reader(bytes.NewReader(data), device.LittleEndian)

--- a/gapic/src/main/com/google/gapid/models/ImagesModel.java
+++ b/gapic/src/main/com/google/gapid/models/ImagesModel.java
@@ -107,6 +107,12 @@ public class ImagesModel {
         image -> processImage(image, size));
   }
 
+  public ListenableFuture<ImageData> getThumbnail(CommandIndex command,
+      int attachment, int size, Consumer<Image.Info> onInfo) {
+    return MoreFutures.transform(loadThumbnail(client, getReplayDevice(), thumbnail(command, attachment), onInfo),
+        image -> processImage(image, size));
+  }
+
   private Path.Thumbnail thumbnail(Path.Command command) {
     return Paths.thumbnail(command, THUMB_PIXELS, shouldDisableReplayOptimization());
   }
@@ -117,6 +123,10 @@ public class ImagesModel {
 
   private Path.Thumbnail thumbnail(Path.ResourceData resource) {
     return Paths.thumbnail(resource, THUMB_PIXELS, shouldDisableReplayOptimization());
+  }
+
+  private Path.Thumbnail thumbnail(CommandIndex command, int attachment) {
+    return Paths.thumbnail(command, attachment, THUMB_PIXELS, shouldDisableReplayOptimization());
   }
 
   private Path.Device getReplayDevice() {

--- a/gapic/src/main/com/google/gapid/util/Paths.java
+++ b/gapic/src/main/com/google/gapid/util/Paths.java
@@ -382,6 +382,20 @@ public class Paths {
         .build();
   }
 
+  public static Path.Thumbnail thumbnail(CommandIndex command, int attachment, int size, boolean disableOpt) {
+    return Path.Thumbnail.newBuilder()
+        .setFramebufferAttachment(framebufferAttachmentAfter(command, attachment,
+          renderSettings(size, size, Path.DrawMode.NORMAL, disableOpt),
+          Path.UsageHints.newBuilder()
+            .setPreview(true)
+            .build()).getFramebufferAttachment())
+        .setDesiredFormat(Images.FMT_RGBA_U8_NORM)
+        .setDesiredMaxHeight(size)
+        .setDesiredMaxWidth(size)
+        .setDisableOptimization(disableOpt)
+        .build();
+  }
+
   public static Path.Any thumbnail(Path.Thumbnail thumb) {
     return Path.Any.newBuilder()
         .setThumbnail(thumb)

--- a/gapic/src/main/com/google/gapid/views/FramebufferView.java
+++ b/gapic/src/main/com/google/gapid/views/FramebufferView.java
@@ -437,7 +437,7 @@ public class FramebufferView extends Composite
       }
 
       attachment.image = LoadableImage.newBuilder(widgets.loading)
-          .forImageData(noAlpha(models.images.getFramebufferImage(command, attachment.index, RenderSetting.RENDER_THUMB.getRenderSettings(models.settings),
+          .forImageData(noAlpha(models.images.getThumbnail(command, attachment.index, THUMB_SIZE,
               info -> scheduleIfNotDisposed(this, () -> setItemSize(index,
                       Math.max(MIN_SIZE, DPIUtil.autoScaleDown(info.getWidth())),
                       Math.max(MIN_SIZE, DPIUtil.autoScaleDown(info.getHeight())))))))

--- a/gapis/service/path/path.proto
+++ b/gapis/service/path/path.proto
@@ -565,9 +565,10 @@ message Thumbnail {
     ResourceData resource = 4;
     Command command = 5;
     CommandTreeNode command_tree_node = 6;
+    FramebufferAttachment framebuffer_attachment = 7;
   }
 
-  bool disable_optimization = 7;
+  bool disable_optimization = 8;
 }
 
 message ResolveConfig {


### PR DESCRIPTION
Note: This change only affects thumbnails, not the main image component in
FramebufferView

Bug: b/155322594