### PR TITLE
Add workaround Android preview notification

### DIFF
--- a/test/swarming/bot-harness.py
+++ b/test/swarming/bot-harness.py
@@ -80,11 +80,16 @@ def main():
     # Wake up (224) and unlock (82) screen, sleep to pass any kind of animation
     botutil.adb(['shell', 'input', 'keyevent', '224'])
     time.sleep(2)
+    # TODO(b/157444640): Temporary workaround: touch the screen before unlocking it to bypass a possible "Android preview" notification
+    botutil.adb(['shell', 'input', 'touchscreen', 'tap', '100', '100'])
+    time.sleep(1)
     botutil.adb(['shell', 'input', 'keyevent', '82'])
     time.sleep(1)
     # Turn brightness to a minimum, to prevent device to get too hot
     botutil.adb(['shell', 'settings', 'put', 'system', 'screen_brightness', '0'])
-    # remove any implicit vulkan layers
+    # Make sure to have the screen "stay awake" during the test, we turn off the screen ourselves at the end
+    botutil.adb(['shell', 'settings', 'put', 'global', 'stay_on_while_plugged_in', '7'])
+    # Remove any implicit vulkan layers
     botutil.adb(['shell', 'settings', 'delete', 'global', 'enable_gpu_debug_layers'])
     botutil.adb(['shell', 'settings', 'delete', 'global', 'gpu_debug_app'])
     botutil.adb(['shell', 'settings', 'delete', 'global', 'gpu_debug_layers'])

--- a/test/swarming/bot-scripts/botutil.py
+++ b/test/swarming/bot-scripts/botutil.py
@@ -86,7 +86,7 @@ def install_apk(test_params):
 '''
     force = False
     if 'force_install' in test_params.keys():
-        force = test_params['force']
+        force = test_params['force_install']
     # -g: grant all needed permissions, -t: accept test APK
     install_flags = ['-g', '-t']
     if 'install_flags' in test_params.keys():

--- a/test/swarming/bot-scripts/validate_gpu_profiling.py
+++ b/test/swarming/bot-scripts/validate_gpu_profiling.py
@@ -43,6 +43,9 @@ def main():
 
     #### Install APK
     if 'apk' in test_params.keys():
+        if not 'package' in test_params.keys():
+            botutil.log('Error: have "apk" but no "package" in params.json')
+            return 1
         botutil.install_apk(test_params)
 
     #### Call gapit command


### PR DESCRIPTION
Also some minor fixes.

Bug: b/157444640

Test: manually triggered swarming tasks.