### PR TITLE
Keep the same GCC version (8.x) everywhere

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -55,9 +55,9 @@ Using the msys64 shell (installed by choco at `C:\tools\msys64\mingw64`):
 1. Update MSYS with: `pacman -Syu`.
 2. If the update ends with “close the window and run it again”, close and reopen the window and repeat 1.
 3. Fetch required tools with: `pacman -S curl git zip unzip patch`
-4. Download gcc with: `curl -O http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-9.2.0-2-any.pkg.tar.xz`
-5. Download gcc-libs with: `curl -O http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-9.2.0-2-any.pkg.tar.xz`
-6. Install gcc with: `pacman -U mingw-w64-x86_64-gcc*-9.2.0-2-any.pkg.tar.xz`
+4. Download gcc *8.2* with: `curl -O http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-8.2.0-3-any.pkg.tar.xz`
+5. Download gcc-libs with: `curl -O http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-8.2.0-3-any.pkg.tar.xz`
+6. Install gcc with: `pacman -U mingw-w64-x86_64-gcc*-8.2.0-3-any.pkg.tar.xz`
 7. Close the MSYS terminal
 
 ### Install Java Development Kit 8

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -210,6 +210,11 @@ cd <sdk-path>
 tools/bin/sdkmanager platform-tools
 ```
 
+### Install gcc (required version is 8)
+sudo apt-get install gcc-8 g++-8
+export CC=gcc-8
+export CXX=g++-8
+
 ### Install other libraries
 
 ```

--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -31,6 +31,8 @@ sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get -q update
 sudo apt-get -qy install gcc-8 g++-8
 export CC=/usr/bin/gcc-8
+gcc --version
+ldd --version
 
 # Get the Android NDK
 curl -L -k -O -s https://dl.google.com/android/repository/android-ndk-r21-linux-x86_64.zip

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -52,13 +52,13 @@ REM Use an old version of patch known to work with the msys runtime
 REM version that comes on Kokoro.
 wget -q http://repo.msys2.org/msys/x86_64/patch-2.7.5-1-x86_64.pkg.tar.xz
 c:\tools\msys64\usr\bin\bash --login -c "pacman -v -U --noconfirm  /t/src/patch-2.7.5-1-x86_64.pkg.tar.xz"
-wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-binutils-2.33.1-1-any.pkg.tar.xz
-c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-binutils-2.33.1-1-any.pkg.tar.xz"
-wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-9.2.0-2-any.pkg.tar.xz
-wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-9.2.0-2-any.pkg.tar.xz
-c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-gcc-9.2.0-2-any.pkg.tar.xz /t/src/mingw-w64-x86_64-gcc-libs-9.2.0-2-any.pkg.tar.xz"
-wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-crt-git-8.0.0.5647.1fe2e62e-1-any.pkg.tar.xz
-c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-crt-git-8.0.0.5647.1fe2e62e-1-any.pkg.tar.xz"
+wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-binutils-2.34-2-any.pkg.tar.xz
+c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-binutils-2.34-2-any.pkg.tar.xz"
+wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-8.2.0-3-any.pkg.tar.xz
+wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-8.2.0-3-any.pkg.tar.xz
+c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-gcc-8.2.0-3-any.pkg.tar.xz /t/src/mingw-w64-x86_64-gcc-libs-8.2.0-3-any.pkg.tar.xz"
+wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-crt-git-8.0.0.5905.066f1b3c-1-any.pkg.tar.xz
+c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-crt-git-8.0.0.5905.066f1b3c-1-any.pkg.tar.xz"
 set PATH=c:\tools\msys64\mingw64\bin;c:\tools\msys64\usr\bin;%PATH%
 set BAZEL_SH=c:\tools\msys64\usr\bin\bash
 

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -52,13 +52,13 @@ REM Use an old version of patch known to work with the msys runtime
 REM version that comes on Kokoro.
 wget -q http://repo.msys2.org/msys/x86_64/patch-2.7.5-1-x86_64.pkg.tar.xz
 c:\tools\msys64\usr\bin\bash --login -c "pacman -v -U --noconfirm  /t/src/patch-2.7.5-1-x86_64.pkg.tar.xz"
-wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-binutils-2.34-2-any.pkg.tar.xz
-c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-binutils-2.34-2-any.pkg.tar.xz"
+wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-binutils-2.33.1-1-any.pkg.tar.xz
+c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-binutils-2.33.1-1-any.pkg.tar.xz"
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-8.2.0-3-any.pkg.tar.xz
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-8.2.0-3-any.pkg.tar.xz
 c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-gcc-8.2.0-3-any.pkg.tar.xz /t/src/mingw-w64-x86_64-gcc-libs-8.2.0-3-any.pkg.tar.xz"
-wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-crt-git-8.0.0.5905.066f1b3c-1-any.pkg.tar.xz
-c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-crt-git-8.0.0.5905.066f1b3c-1-any.pkg.tar.xz"
+wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-crt-git-8.0.0.5647.1fe2e62e-1-any.pkg.tar.xz
+c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-crt-git-8.0.0.5647.1fe2e62e-1-any.pkg.tar.xz"
 set PATH=c:\tools\msys64\mingw64\bin;c:\tools\msys64\usr\bin;%PATH%
 set BAZEL_SH=c:\tools\msys64\usr\bin\bash
 


### PR DESCRIPTION
This PR forces GCC 8.x on Windows builds (Linux already uses gcc8 and MacOS uses clang via XCode). The dependencies' versions are chosen based on what pacman chose in my local checkout after executing. 

```
pacman -U mingw-w64-x86_64-gcc*-8.2.0-3-any.pkg.tar.xz
```

Bug: b/157873397