### PR TITLE
Frame lifecycle UI Updates

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/models/FrameEventsTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/FrameEventsTrack.java
@@ -94,8 +94,7 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
   @Override
   public ListenableFuture<Data> computeData(DataRequest req) {
     Window window = Window.compute(req, 5);
-    return transformAsync(window.update(qe, tableName("window")),
-        $ -> computeSlices(req));
+    return transformAsync(window.update(qe, tableName("window")), $ -> computeSlices(req));
   }
 
   private ListenableFuture<Data> computeSlices(DataRequest req) {
@@ -197,11 +196,6 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
 
     public Slices(QueryEngine.Row row, ArgSet args, String layerName, String eventName) {
       add(row.getLong(0), row.getLong(1), row.getLong(2), row.getString(3), args,
-          row.getLong(8), layerName, eventName, row.getLong(9), row.getLong(10), row.getLong(11));
-    }
-
-    public Slices(QueryEngine.Row row, String layerName, String eventName) {
-      add(row.getLong(0), row.getLong(1), row.getLong(2), row.getString(3), ArgSet.EMPTY,
           row.getLong(8), layerName, eventName, row.getLong(9), row.getLong(10), row.getLong(11));
     }
 

--- a/gapic/src/main/com/google/gapid/perfetto/models/FrameEventsTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/FrameEventsTrack.java
@@ -16,21 +16,16 @@
 
 package com.google.gapid.perfetto.models;
 
-import static com.google.gapid.perfetto.models.QueryEngine.createSpan;
-import static com.google.gapid.perfetto.models.QueryEngine.createView;
 import static com.google.gapid.perfetto.models.QueryEngine.createWindow;
 import static com.google.gapid.perfetto.models.QueryEngine.dropTable;
-import static com.google.gapid.perfetto.models.QueryEngine.dropView;
 import static com.google.gapid.perfetto.models.QueryEngine.expectOneRow;
 import static com.google.gapid.util.MoreFutures.transform;
 import static com.google.gapid.util.MoreFutures.transformAsync;
 import static java.lang.String.format;
-import static java.util.concurrent.TimeUnit.MICROSECONDS;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gapid.perfetto.TimeSpan;
 import com.google.gapid.perfetto.views.FrameEventsSelectionView;
@@ -38,9 +33,7 @@ import com.google.gapid.perfetto.views.State;
 
 import org.eclipse.swt.widgets.Composite;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Consumer;
@@ -51,64 +44,53 @@ import java.util.function.Consumer;
 // TODO: dedupe code with SliceTrack.
 public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Data>{
   private static final String BASE_COLUMNS =
-      "id, ts, dur, name, depth, stack_id, parent_stack_id, arg_set_id, " +
-      "frame_numbers, layer_names";
-  private static final String SLICES_VIEW =
-      "select " + BASE_COLUMNS + " from frame_slice where track_id = %d";
+      "id, ts, dur, name, depth, stack_id, parent_stack_id, arg_set_id, frame_number";
+  private static final String STAT_COLUMNS =
+      "queue_to_acquire_time, acquire_to_latch_time, latch_to_present_time";
   private static final String SLICE_SQL =
-      "select " + BASE_COLUMNS + " from frame_slice where id = %d";
+      "select * from " +
+      "(select " + BASE_COLUMNS + " from frame_slice where id = %d) join " +
+      "(select " + STAT_COLUMNS + " from frame_slice " +
+        "where name = 'PresentFenceSignaled' and frame_number = " +
+          "(select frame_number from frame_slice where id = %d))";
   private static final String SLICES_SQL =
        "select " + BASE_COLUMNS + " from %s " +
        "where ts >= %d - dur and ts <= %d order by ts";
-  private static final String SUMMARY_SQL =
-      "select group_concat(id) ids, quantum_ts, count(*) from %s " +
-      "where name = 'PresentFenceSignaled' or name GLOB '*[0-9]*'" +
-      "group by quantum_ts";
   private static final String RANGE_SQL =
       "select " + BASE_COLUMNS + " from %s " +
       "where ts < %d and ts + dur >= %d and depth >= %d and depth <= %d";
-  private static final String RANGE_FOR_IDS_SQL =
-      "select " + BASE_COLUMNS + " from %s where id in (%s)";
-  private static final String STAT_TABLE_SQL =
-      "select frame_numbers, layer_names, queue_to_acquire_time, " +
-      "acquire_to_latch_time, latch_to_present_time " +
-      "from frame_slice left join frame_stats " +
-      "on frame_slice.id = frame_stats.slice_id " +
-      "where frame_stats.slice_id = %d";
 
   private static final long SIGNAL_MARGIN_NS = 10000;
-  private static final long FRAMELIFECYCLE_QUANTIZE_CUTOFF = MICROSECONDS.toNanos(500);
 
-  private final long trackId;
+  private final String layerName;
+  private final String viewName;
+  private final String eventName;
 
-  public FrameEventsTrack(QueryEngine qe, long trackId) {
-    super(qe, "sfevents_" + trackId);
-    this.trackId = trackId;
+  public FrameEventsTrack(QueryEngine qe, String layerName, String viewName, String eventName) {
+    super(qe, "sfevents_" + viewName);
+    this.layerName = layerName;
+    this.viewName = viewName;
+    this.eventName = eventName;
   }
 
-  public static FrameEventsTrack forBuffer(QueryEngine qe, FrameInfo.Buffer buffer) {
-    return new FrameEventsTrack(qe, buffer.trackId);
+  public static FrameEventsTrack forFrameEvent(QueryEngine qe, String layerName,
+      FrameInfo.Event event) {
+    return new FrameEventsTrack(qe, layerName, event.viewName, event.name);
   }
 
   @Override
   protected ListenableFuture<?> initialize() {
-    String slices = tableName("slices");
     String window = tableName("window");
-    String span = tableName("span");
     return qe.queries(
-        dropTable(span),
-        dropView(slices),
         dropTable(window),
-        createWindow(window),
-        createView(slices, format(SLICES_VIEW, trackId)),
-        createSpan(span, window + ", " + slices + " PARTITIONED depth"));
+        createWindow(window));
   }
 
   @Override
   public ListenableFuture<Data> computeData(DataRequest req) {
-    Window window = Window.compute(req, 5, FRAMELIFECYCLE_QUANTIZE_CUTOFF);
+    Window window = Window.compute(req, 5);
     return transformAsync(window.update(qe, tableName("window")),
-        $ -> window.quantized ? computeSummary(req, window) : computeSlices(req));
+        $ -> computeSlices(req));
   }
 
   private ListenableFuture<Data> computeSlices(DataRequest req) {
@@ -116,135 +98,62 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
     transform(qe.getAllArgs(res.stream().mapToLong(r -> r.getLong(7))), args -> {
       int rows = res.getNumRows();
       Data data = new Data(req, new long[rows], new long[rows], new long[rows],
-          new String[rows], new long[rows][], new String[rows][], new ArgSet[rows]);
+          new int[rows], new String[rows], new long[rows], new String[rows],
+          new ArgSet[rows]);
       res.forEachRow((i, row) -> {
         long start = row.getLong(1);
         data.ids[i] = row.getLong(0);
         data.starts[i] = start;
         data.ends[i] = start + row.getLong(2);
+        data.depths[i] = row.getInt(4);
         data.titles[i] = row.getString(3);
         data.args[i] = args.getOrDefault(row.getLong(7), ArgSet.EMPTY);
-        data.frameNumbers[i] = Arrays.stream(row.getString(8).split(", "))
-            .mapToLong(s -> s.isEmpty() ? 0 : Long.parseLong(s))
-            .toArray();
-        data.layerNames[i] = row.getString(9).split(", ");
+        data.frameNumbers[i] = row.getLong(8);
+        data.layerNames[i] = layerName;
       });
       return data;
     }));
   }
 
   private String slicesSql(DataRequest req) {
-    return format(SLICES_SQL, tableName("slices"), req.range.start, req.range.end);
-  }
-
-  private ListenableFuture<Data> computeSummary(DataRequest req, Window w) {
-    return transform(qe.query(summarySql()), result -> {
-      int len = w.getNumberOfBuckets();
-      String[] concatedIds = new String[len];
-      Arrays.fill(concatedIds, "");
-      Data data = new Data(req, w.bucketSize, concatedIds, new long[len]);
-      result.forEachRow(($, r) -> {
-        data.concatedIds[r.getInt(1)] = r.getString(0);
-        data.numEvents[r.getInt(1)] = r.getLong(2);
-      });
-      return data;
-    });
-  }
-
-  private String summarySql() {
-    return format(SUMMARY_SQL, tableName("span"));
+    return format(SLICES_SQL, viewName, req.range.start, req.range.end);
   }
 
   public ListenableFuture<Slices> getSlice(long id) {
     return transformAsync(expectOneRow(qe.query(sliceSql(id))), r ->
-        transformAsync(qe.getArgs(r.getLong(7)), args ->
-        transform(getStats(id, r.getLong(2)), stats -> new Slices(r, args, stats))));
-  }
-
-  private ListenableFuture<Map<String, FrameStats>> getStats(long id, long dur) {
-    if (dur == 0) { // No stats for instant events
-      return Futures.immediateFuture(null);
-    }
-    return transform(qe.query(statSql(id)), result -> {
-      Map<String, FrameStats> stats = Maps.newHashMap();
-      result.forEachRow((i, row) -> {
-        stats.put(row.getString(1).split(", ")[i],
-            new FrameStats(Long.parseLong(row.getString(0).split(", ")[i]),
-                row.getLong(2), row.getLong(3), row.getLong(4)));
-      });
-      return stats;
-    });
-  }
-
-  private static String statSql(long sliceId) {
-    return format(STAT_TABLE_SQL, sliceId);
+      transform(qe.getArgs(r.getLong(7)), args -> new Slices(r, args, layerName, eventName)));
   }
 
   private static String sliceSql(long id) {
-    return format(SLICE_SQL, id);
+    return format(SLICE_SQL, id, id);
   }
 
   public ListenableFuture<Slices> getSlices(TimeSpan ts, int minDepth, int maxDepth) {
-    return transform(qe.query(sliceRangeSql(ts, minDepth, maxDepth)), Slices::new);
+    return transform(qe.query(sliceRangeSql(ts, minDepth, maxDepth)),
+        r -> new Slices(r, layerName, eventName));
   }
 
   private String sliceRangeSql(TimeSpan ts, int minDepth, int maxDepth) {
-    return format(RANGE_SQL, tableName("slices"), ts.end, ts.start, minDepth, maxDepth);
-  }
-
-  public ListenableFuture<Slices> getSlices(String ids) {
-    return transform(qe.query(sliceRangeForIdsSql(ids)), Slices::new);
-  }
-
-  private String sliceRangeForIdsSql(String ids) {
-    return format(RANGE_FOR_IDS_SQL, tableName("slices"), ids);
+    return format(RANGE_SQL, viewName, ts.end, ts.start, minDepth, maxDepth);
   }
 
   public static class Data extends Track.Data {
-    public final Kind kind;
-    // Summary.
-    public final long bucketSize;
-    public final String[] concatedIds;
-    public final long[] numEvents;
-    // slices
     public final long[] ids;
     public final long[] starts;
     public final long[] ends;
+    public final int[] depths;
     public final String[] titles;
-    public final long[][] frameNumbers;
-    public final String[][] layerNames;
+    public final long[] frameNumbers;
+    public final String[] layerNames;
     public final ArgSet[] args;
 
-    public static enum Kind {
-      slices,
-      summary,
-    }
-
-    public Data(DataRequest request, long bucketSize, String[] concatedIds, long[] numEvents) {
+    public Data(DataRequest request, long[] ids, long[] starts, long[] ends, int[] depths,
+        String[] titles, long[] frameNumbers, String[] layerNames, ArgSet[] args) {
       super(request);
-      this.kind = Kind.summary;
-      this.bucketSize = bucketSize;
-      this.concatedIds = concatedIds;
-      this.numEvents = numEvents;
-      this.ids = null;
-      this.starts = null;
-      this.ends = null;
-      this.titles = null;
-      this.frameNumbers = null;
-      this.layerNames = null;
-      this.args = null;
-    }
-
-    public Data(DataRequest request, long[] ids, long[] starts, long[] ends,
-        String[] titles, long[][] frameNumbers, String[][] layerNames, ArgSet[] args) {
-      super(request);
-      this.kind = Kind.slices;
-      this.bucketSize = 0;
-      this.concatedIds = null;
-      this.numEvents = null;
       this.ids = ids;
       this.starts = starts;
       this.ends = ends;
+      this.depths = depths;
       this.titles = titles;
       this.frameNumbers = frameNumbers;
       this.layerNames = layerNames;
@@ -253,60 +162,70 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
   }
 
   public static class Slices implements Selection<Slices> {
-    private int count = 0;
+    public int count = 0;
     public final List<Long> ids = Lists.newArrayList();
     public final List<Long> times = Lists.newArrayList();
     public final List<Long> durs = Lists.newArrayList();
     public final List<String> names = Lists.newArrayList();
     public final List<ArgSet> argsets = Lists.newArrayList();
-    public final List<Long[]> frameNumbers = Lists.newArrayList();
-    public final List<String[]> layerNames = Lists.newArrayList();
-    // Map of each buffer(layerName) that contributed to the displayed frame, to
-    // its corresponding FrameStats
-    public final List<Map<String, FrameStats>> frameStats = Lists.newArrayList();
-    public final FrameSelection frameSelection = new FrameSelection();
+    public final List<Long> frameNumbers = Lists.newArrayList();
+    public final List<String> layerNames = Lists.newArrayList();
+    public final List<String> eventNames = Lists.newArrayList();
+    public final List<Long> queueToAcquireTimes = Lists.newArrayList();
+    public final List<Long> acquireToLatchTimes = Lists.newArrayList();
+    public final List<Long> latchToPresentTimes = Lists.newArrayList();
     public final Set<Long> sliceKeys = Sets.newHashSet();
+    public final Set<Long> selectedFrameNumbers = Sets.newHashSet();
 
-    public Slices(QueryEngine.Row row, ArgSet args, Map<String, FrameStats> frameStats) {
+    public Slices(QueryEngine.Row row, ArgSet args, String layerName, String eventName) {
       add(row.getLong(0), row.getLong(1), row.getLong(2), row.getString(3), args,
-          row.getString(8), row.getString(9), frameStats);
+          row.getLong(8), layerName, eventName, row.getLong(9), row.getLong(10), row.getLong(11));
     }
 
-    public Slices(QueryEngine.Row row, Map<String, FrameStats> frameStats) {
+    public Slices(QueryEngine.Row row, String layerName, String eventName) {
       add(row.getLong(0), row.getLong(1), row.getLong(2), row.getString(3), ArgSet.EMPTY,
-          row.getString(8), row.getString(9), frameStats);
+          row.getLong(8), layerName, eventName, row.getLong(9), row.getLong(10), row.getLong(11));
     }
 
-    public Slices(QueryEngine.Result result) {
+    public Slices(QueryEngine.Result result, String layerName, String eventName) {
       result.forEachRow((i, row) -> this.add(row.getLong(0), row.getLong(1), row.getLong(2),
-          row.getString(3), ArgSet.EMPTY, row.getString(8), row.getString(9), null));
+          row.getString(3), ArgSet.EMPTY, row.getLong(8), layerName, eventName));
     }
 
-    private void add(long id, long time, long dur, String name, ArgSet args, String frameNumbers,
-        String layerNames, Map<String, FrameStats> frameStats) {
-      Long[] parsedFrameNumbers = Arrays.stream(frameNumbers.split(", "))
-          .mapToLong(Long::parseLong).boxed().toArray(Long[]::new);
-      String[] parsedLayerNames = layerNames.split(", ");
-      add(id, time, dur, name, args, parsedFrameNumbers, parsedLayerNames, frameStats);
-    }
-
-    private void add(long id, long time, long dur, String name, ArgSet args, Long[] frameNumbers,
-        String[] layerNames, Map<String, FrameStats> frameStats) {
+    private void add(long id, long time, long dur, String name, ArgSet args, long frameNumber,
+        String layerName, String eventName, long qaTime, long alTime, long lpTime) {
       count++;
       this.ids.add(id);
       this.times.add(time);
       this.durs.add(dur);
       this.names.add(name);
       this.argsets.add(args);
-      this.frameNumbers.add(frameNumbers);
-      this.layerNames.add(layerNames);
-      this.frameStats.add(frameStats);
-      this.frameSelection.combine(new FrameSelection(frameNumbers, layerNames));
+      this.frameNumbers.add(frameNumber);
+      this.layerNames.add(layerName);
+      this.eventNames.add(eventName);
+      this.queueToAcquireTimes.add(qaTime);
+      this.acquireToLatchTimes.add(alTime);
+      this.latchToPresentTimes.add(lpTime);
       this.sliceKeys.add(id);
+      this.selectedFrameNumbers.add(frameNumber);
     }
 
-    public FrameSelection getSelection() {
-      return frameSelection;
+    private void add(long id, long time, long dur, String name, ArgSet args,
+        long frameNumber, String layerName, String eventName) {
+      count++;
+      this.ids.add(id);
+      this.times.add(time);
+      this.durs.add(dur);
+      this.names.add(name);
+      this.argsets.add(args);
+      this.frameNumbers.add(frameNumber);
+      this.layerNames.add(layerName);
+      this.eventNames.add(eventName);
+      this.queueToAcquireTimes.add((long)0);
+      this.acquireToLatchTimes.add((long)0);
+      this.latchToPresentTimes.add((long)0);
+      this.sliceKeys.add(id);
+      this.selectedFrameNumbers.add(frameNumber);
     }
 
     @Override
@@ -334,7 +253,8 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
         if (durs.get(i) > 0) {
           span.accept(new TimeSpan(times.get(i), times.get(i) + durs.get(i)));
         } else { // Expand the zoom/highlight time range for signal selections whose dur is 0.
-          span.accept(new TimeSpan(times.get(i), times.get(i) + durs.get(i)).expand(SIGNAL_MARGIN_NS));
+          span.accept(new TimeSpan(times.get(i), times.get(i) +
+              durs.get(i)).expand(SIGNAL_MARGIN_NS));
         }
       }
     }
@@ -345,7 +265,8 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
         if (!this.sliceKeys.contains(other.ids.get(i))) {
           add(other.ids.get(i), other.times.get(i), other.durs.get(i), other.names.get(i),
               other.argsets.get(i), other.frameNumbers.get(i), other.layerNames.get(i),
-              other.frameStats.get(i));
+              other.eventNames.get(i), other.queueToAcquireTimes.get(i),
+              other.acquireToLatchTimes.get(i), other.latchToPresentTimes.get(i));
         }
       }
       return this;
@@ -354,54 +275,9 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
     public int getCount() {
       return count;
     }
-  }
 
-  public static class FrameSelection {
-    public static FrameSelection EMPTY = new FrameSelection();
-    // key = concat(layerName, '_', frameNumber)
-    private Set<String> keys;
-
-    public FrameSelection() {
-      keys = Sets.newHashSet();
-    }
-
-    public FrameSelection(Long[] f, String[] l) {
-      keys = Sets.newHashSet();
-      for (int i = 0; i < l.length; i++) {
-        keys.add(l[i] + "_" + f[i]);
-      }
-    }
-
-    public boolean contains(long[] f, String[] l) {
-      for (int i = 0; i < f.length; i++) {
-        if (keys.contains(l[i] + "_" + f[i])) {
-          return true;
-        }
-      }
-      return false;
-    }
-
-    public void combine(FrameSelection other) {
-      keys.addAll(other.keys);
-    }
-
-    public boolean isEmpty() {
-      return keys.isEmpty();
-    }
-  }
-
-  public static class FrameStats {
-    public final long frameNumber;
-    public final long queueToAcquireTime;
-    public final long acquireToLatchTime;
-    public final long latchToPresentTime;
-
-    public FrameStats(long frameNumber, long queueToAcquireTime, long acquireToLatchTime,
-        long latchToPresentTime) {
-      this.frameNumber = frameNumber;
-      this.queueToAcquireTime = queueToAcquireTime;
-      this.acquireToLatchTime = acquireToLatchTime;
-      this.latchToPresentTime = latchToPresentTime;
+    public Set<Long> getSelectedFrameNumbers() {
+      return selectedFrameNumbers;
     }
   }
 
@@ -409,7 +285,7 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
     TreeMap<Long, Node> roots = Maps.newTreeMap();
     for (int i = 0; i < slices.count; i++) {
       roots.put(slices.ids.get(i), new Node(slices.names.get(i), slices.durs.get(i),
-          slices.durs.get(i), slices.layerNames.get(i)));
+          slices.durs.get(i), slices.eventNames.get(i), slices.layerNames.get(i)));
     }
     return roots.values().stream().toArray(Node[]::new);
   }
@@ -418,13 +294,15 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
     public final String name;
     public final long dur;
     public final long self;
-    public final String[] layers;
+    public final String eventName;
+    public final String layerName;
 
-    public Node(String name, long dur, long self, String[] layers) {
+    public Node(String name, long dur, long self, String eventName, String layerName) {
       this.name = name;
       this.dur = dur;
       this.self = self;
-      this.layers = layers;
+      this.eventName = eventName;
+      this.layerName = layerName;
     }
   }
 }

--- a/gapic/src/main/com/google/gapid/perfetto/models/FrameInfo.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/FrameInfo.java
@@ -15,10 +15,16 @@
  */
 package com.google.gapid.perfetto.models;
 
+import static com.google.gapid.perfetto.models.QueryEngine.createView;
+import static com.google.gapid.perfetto.models.QueryEngine.dropView;
+import static com.google.gapid.perfetto.models.QueryEngine.expectOneRow;
 import static com.google.gapid.util.MoreFutures.transform;
+import static com.google.gapid.util.MoreFutures.transformAsync;
+import static java.lang.String.format;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gapid.models.Perfetto;
 
@@ -31,70 +37,307 @@ import java.util.List;
 public class FrameInfo {
   public static final FrameInfo NONE = new FrameInfo(Collections.emptyList());
 
-  private static final String FRAME_SLICE_QUERY =
-      "select t.id, t.name, t.scope, max(depth) + 1 " +
-      "from gpu_track t join frame_slice s on (t.id = s.track_id) " +
-      "group by t.id " +
-      "order by t.id";
-  private static final String DISPLAYED_FRAME_TRACK_NAME = "Displayed Frame";
+  private static final String LAYER_NAME_QUERY =
+      "select distinct layer_name from frame_slice";
+  private static final String LAYER_TRACKS_QUERY =
+      "select name, track_id from gpu_track inner join " +
+      "(select distinct track_id from frame_slice where layer_name = '%s') t" +
+      " on gpu_track.id = t.track_id";
+  private static final String TRACK_ID_QUERY =
+      "select group_concat(track_id) from (%s) where name GLOB '%s'";
 
-  private final List<Buffer> buffers;
+  // The following queries use experimental_slice_layout from perfetto. Its a function which takes
+  // comma separated string of track_ids and stacks overlapping slices vertically. This is useful
+  // for generating ownership phases where there can be more than one slice (not related) at the
+  // same time.
 
-  private FrameInfo(List<Buffer> buffers) {
-    this.buffers = buffers;
+  // Cast name as int for the phases. This is needed because experimental_slice_layout generates
+  // columns only based on slice_table. frame_slice is a child of slice_table and the extra columns
+  // such as frame_number and layer_name won't be generated. The alternate is doing a join on
+  // frame_slice table with slice_id but that query is very expensive in that it visibly slows down
+  // the loading of tracks.
+  private static final String PHASE_QUERY =
+      "select phase.*, cast(NAME as INT) as frame_number from " +
+      "(select id, ts, dur, name, layout_depth as depth, stack_id, parent_stack_id, arg_set_id " +
+      "from experimental_slice_layout where filter_track_ids = (%s)) phase";
+  // We don't need layout_depth for display phase because slice1.end = slice2.start in this track
+  // and the generator will consider this as overlapping and push slice2 to the next depth.
+  private static final String DISPLAY_PHASE_QUERY =
+      "select t.*, CAST(name as INT) as frame_number from " +
+      "(select id, ts, dur, name, depth, stack_id, parent_stack_id, arg_set_id " +
+      "from experimental_slice_layout where filter_track_ids = (%s)) t";
+
+  private static final String BUFFERS_QUERY =
+      "select track_id, name from (%s) where name GLOB '*Buffer*'";
+  private static final String BUFFERS_VIEW_QUERY =
+      "select frame_slice.* from frame_slice join gpu_track " +
+      "on frame_slice.track_id = gpu_track.id " +
+      "where gpu_track.id = %d";
+  private static final String MAX_DEPTH_QUERY =
+      "select max(depth) from %s";
+
+  private static final String DISPLAY_TOOLTIP =
+      "Shows how long the frame was on screen";
+  private static final String APP_TOOLTIP =
+      "The time from when the buffer was dequeued by the app to when it was enqueued back";
+  private static final String GPU_TOOLTIP =
+      "Duration for which the buffer was owned by GPU. This is the time from when the buffer " +
+      "was sent to GPU to the time when GPU finishes its work on the buffer. " +
+      "This *does not* mean the time GPU was working solely on the buffer during this time.";
+  private static final String COMPOSITION_TOOLTIP =
+      "The time from when SurfaceFlinger latched on to the buffer and sent for composition " +
+      "to when it was sent to the display";
+
+  private List<Layer> layers;
+
+  private FrameInfo(List<Layer> layers) {
+    this.layers = layers;
   }
 
-  public boolean isEmpty() {
-    return buffers.isEmpty();
+  public int layerCount() {
+    return layers.size();
   }
 
-  public int bufferCount() {
-    return buffers.size();
-  }
-
-  public Iterable<Buffer> buffers() {
-    return Iterables.unmodifiableIterable(buffers);
+  public Iterable<Layer> layers() {
+    return Iterables.unmodifiableIterable(layers);
   }
 
   public static ListenableFuture<Perfetto.Data.Builder> listFrames(Perfetto.Data.Builder data) {
-    return transform(info(data.qe), frame -> data.setFrame(frame));
+    List<String> layerNames = Lists.newArrayList();
+    List<Layer> layers = Lists.newArrayList();
+    return transformAsync(data.qe.query(LAYER_NAME_QUERY), r -> {
+      r.forEachRow(($, row) -> {
+        layerNames.add(row.getString(0));
+      });
+      if (layerNames.isEmpty()) {
+        data.setFrame(FrameInfo.NONE);
+        return Futures.immediateFuture(data);
+      }
+      return transform(getLayers(data.qe, layers, layerNames), $ -> {
+        data.setFrame(new FrameInfo(layers));
+        return data;
+      });
+    });
   }
 
-  private static ListenableFuture<FrameInfo> info(QueryEngine qe) {
-    return
-        transform(qe.queries(FRAME_SLICE_QUERY), frame -> {
-            List<Buffer> buffers = Lists.newArrayList();
-            frame.forEachRow(($, r) -> {
-              buffers.add(new Buffer(r));
-            });
+  private static ListenableFuture<List<Layer>> getLayers(QueryEngine qe, List<Layer> layers,
+      List<String> layerNames) {
+    List<List<Event>> phases = Lists.newArrayList();
+    List<List<Event>> buffers = Lists.newArrayList();
+    // The group hierarchy looks like:
+    // > Layer 1
+    //   - DISPLAY
+    //   - APP
+    //   - Wait for GPU
+    //   - COMPOSITION
+    //   - > Buffers
+    //   -   - Buffer 1
+    //   -   - ...
+    //   -   - Buffer n
+    // ...
+    // > Layer m
 
-            // Sort buffers by name, the query is sorted by track id.
-            buffers.sort((b1, b2) -> {
-              // Displayed Frame track should always be at top
-              if (b1.name.equals(DISPLAYED_FRAME_TRACK_NAME)) {
-                return -1;
-              } else if(b2.name.equals(DISPLAYED_FRAME_TRACK_NAME)) {
-                return 1;
-              }
-              return b1.name.compareTo(b2.name);
-            });
-            return new FrameInfo(buffers);
-        });
+    // For every layer, add the four phases first, then add the buffers.
+    return transformAsync(createPhases(qe, phases, layerNames, 0), $1 -> {
+      return transform(createBuffers(qe, buffers, layerNames, 0), $2 -> {
+        for (int i = 0; i < layerNames.size(); i++) {
+          layers.add(new Layer(layerNames.get(i), buffers.get(i), phases.get(i)));
+        }
+        return layers;
+      });
+    });
   }
 
-  public static class Buffer {
-    public final long trackId;
-    public final String name;
-    public final int maxDepth;
+  private static ListenableFuture<List<List<Event>>> createPhases(QueryEngine qe,
+      List<List<Event>> phases, List<String> layerNames, int idx) {
+    String layerName = layerNames.get(idx);
+    String baseName = layerName.replaceAll("[^A-Za-z0-9]", "");
+    List<Event> currentLayerPhases = Lists.newArrayList();
 
-    public Buffer(long trackId, String name, int maxDepth) {
-      this.trackId = trackId;
-      this.name = name;
-      this.maxDepth = maxDepth;
+    // Example:
+    // create view comxxLayer1_APP as
+    // select phase.*, cast(NAME as INT) as frame_number from
+    //  (select id, ts, dur, name, layout_depth as depth, stack_id, parent_stack_id, arg_set_id
+    //  from experimental_slice_layout where filter_track_ids =
+    //      (select group_concat(track_id) from
+    //          (select name, track_id from gpu_track inner join
+    //              (select distinct track_id from frame_slice where layer_name = 'com.xx.Layer1') t
+    //          on gpu_track.id = t.track_id);
+    //      where name GLOB 'APP_*')) phase
+    String displayQuery =
+        displayPhaseQuery(trackIdQuery(layerTracksQuery(layerName),"Display_*"));
+    String appQuery = phaseQuery(trackIdQuery(layerTracksQuery(layerName), "APP_*"));
+    String gpuQuery = phaseQuery(trackIdQuery(layerTracksQuery(layerName), "GPU_*"));
+    String compositionQuery = phaseQuery(trackIdQuery(layerTracksQuery(layerName), "SF_*"));
+    String displayViewName = baseName + "_DISPLAY";
+    String appViewName = baseName + "_APP";
+    String gpuViewName = baseName + "_GPU";
+    String compositionViewName = baseName + "_COMPOSITION";
+
+    // we need to determine the max depth of these views here, so that panel creation
+    // can happen appropriately.
+    return transformAsync(qe.queries(
+        dropView(appViewName),
+        dropView(gpuViewName),
+        dropView(compositionViewName),
+        dropView(displayViewName),
+        createView(appViewName, appQuery),
+        createView(gpuViewName, gpuQuery),
+        createView(compositionViewName, compositionQuery),
+        createView(displayViewName, displayQuery)), $ -> {
+          return transformAsync(getMaxDepth(qe, displayViewName), displayDepth -> {
+            currentLayerPhases.add(new Event("DISPLAY",baseName + "_DISPLAY", displayDepth + 1,
+                DISPLAY_TOOLTIP));
+            return transformAsync(getMaxDepth(qe, appViewName), appDepth -> {
+              currentLayerPhases.add(new Event("APP", baseName + "_APP", appDepth + 1,
+                  APP_TOOLTIP));
+              return transformAsync(getMaxDepth(qe, gpuViewName), gpuDepth -> {
+                currentLayerPhases.add(new Event("Wait for GPU", baseName + "_GPU", gpuDepth + 1,
+                    GPU_TOOLTIP));
+                return transformAsync(getMaxDepth(qe, compositionViewName), compositionDepth -> {
+                  currentLayerPhases.add(new Event("COMPOSITION", baseName + "_COMPOSITION",
+                      compositionDepth + 1, COMPOSITION_TOOLTIP));
+                  phases.add(currentLayerPhases);
+                  if (idx + 1 >= layerNames.size()) {
+                    return Futures.immediateFuture(phases);
+                  }
+                  return createPhases(qe, phases, layerNames, idx + 1);
+                });
+              });
+            });
+          });
+    });
+  }
+
+  private static ListenableFuture<Long> getMaxDepth(QueryEngine qe, String viewName) {
+    return transform(expectOneRow(qe.query(maxDepthQuery(viewName))), r -> {
+      return r.getLong(0);
+    });
+  }
+
+  private static String trackIdQuery(String from, String filter) {
+    return format(TRACK_ID_QUERY, from, filter);
+  }
+
+  private static String phaseQuery(String filter) {
+    return format(PHASE_QUERY, filter);
+  }
+
+  private static String displayPhaseQuery(String filter) {
+    return format(DISPLAY_PHASE_QUERY, filter);
+  }
+
+  private static String maxDepthQuery(String viewName) {
+    return format(MAX_DEPTH_QUERY, viewName);
+  }
+
+  private static ListenableFuture<List<List<Event>>> createBuffers(QueryEngine qe,
+      List<List<Event>> buffers, List<String> layerNames, int idx) {
+    String l = layerNames.get(idx);
+    return transformAsync(qe.query(buffersQuery(layerTracksQuery(l))), res -> {
+      List<Event> currentLayerBuffers = Lists.newArrayList();
+      List<Long> trackIds = Lists.newArrayList();
+      List<String> trackNames = Lists.newArrayList();
+      res.forEachRow(($, row) -> {
+        trackIds.add(row.getLong(0));
+        trackNames.add(row.getString(1));
+      });
+      if (trackIds.isEmpty()) {
+        return Futures.immediateFuture(buffers);
+      }
+      return transformAsync(createBufferViews(qe, trackIds, trackNames,currentLayerBuffers, 0), $ -> {
+        buffers.add(currentLayerBuffers);
+        if (idx + 1 >= layerNames.size()) {
+          return Futures.immediateFuture(buffers);
+        }
+        // Create buffers for the next layer.
+        return createBuffers(qe, buffers, layerNames, idx + 1);
+      });
+    });
+  }
+
+  private static ListenableFuture<List<Event>> createBufferViews(QueryEngine qe, List<Long> trackIds,
+      List<String> names, List<Event> buffers, int idx) {
+    long trackId = trackIds.get(idx);
+    return transformAsync(qe.queries(
+        dropView("buffer_" + trackId),
+        createView("buffer_" + trackId, buffersViewQuery(trackId))), $ -> {
+          // Depth of instant events is always 1, the depth query can be avoided here.
+          buffers.add(new Event(names.get(idx), "buffer_" + trackId, 1));
+          if (idx + 1 >= trackIds.size()) {
+            return Futures.immediateFuture(buffers);
+          }
+          // Create view for the next buffer.
+          return createBufferViews(qe, trackIds, names, buffers, idx + 1);
+    });
+  }
+
+  private static String layerTracksQuery(String layerName) {
+    return format(LAYER_TRACKS_QUERY, layerName);
+  }
+
+  private static String buffersQuery(String from) {
+    return format(BUFFERS_QUERY, from);
+  }
+
+  private static String buffersViewQuery(long filter) {
+    return format(BUFFERS_VIEW_QUERY, filter);
+  }
+
+  public static class Layer {
+    public final String layerName;
+    private final List<Event> bufferEvents;
+    private final List<Event> phaseEvents;
+
+    public Layer(String layerName, List<Event> bufferEvents, List<Event> phaseEvents) {
+      this.layerName = layerName;
+      this.bufferEvents = bufferEvents;
+      this.phaseEvents = phaseEvents;
     }
 
-    public Buffer(QueryEngine.Row row) {
-      this(row.getLong(0), row.getString(1), row.getInt(3));
+    public boolean isBufferEventsEmpty() {
+      return bufferEvents.isEmpty();
+    }
+
+    public int bufferEventsCount() {
+      return bufferEvents.size();
+    }
+
+    public Iterable<Event> bufferEvents() {
+      return Iterables.unmodifiableIterable(bufferEvents);
+    }
+
+    public boolean isPhaseEventsEmpty() {
+      return phaseEvents.isEmpty();
+    }
+
+    public int phaseEventsCount() {
+      return phaseEvents.size();
+    }
+
+    public Iterable<Event> phaseEvents() {
+      return Iterables.unmodifiableIterable(phaseEvents);
+    }
+  }
+
+  public static class Event {
+    public final String name;
+    public final String viewName;
+    public final long maxDepth;
+    public final String tooltip;
+
+    public Event(String name, String viewName, long maxDepth, String tooltip) {
+      this.name = name;
+      this.viewName = viewName;
+      this.maxDepth = maxDepth;
+      this.tooltip = tooltip;
+    }
+
+    public Event(String name, String viewName, long maxDepth) {
+      this.name = name;
+      this.viewName = viewName;
+      this.maxDepth = maxDepth;
+      this.tooltip = name;
     }
 
     public String getDisplay() {

--- a/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
@@ -64,8 +64,6 @@ public class Tracks {
       enumerateCpu(data);
       enumerateCounters(data);
       enumerateGpu(data);
-      //enumerateFrame(data);
-      //enumerateFrame2(data);
       enumerateFrame(data);
       enumerateProcesses(data);
       enumerateVSync(data);

--- a/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
@@ -31,7 +31,7 @@ import com.google.gapid.perfetto.views.CounterPanel;
 import com.google.gapid.perfetto.views.CpuFrequencyPanel;
 import com.google.gapid.perfetto.views.CpuPanel;
 import com.google.gapid.perfetto.views.CpuSummaryPanel;
-import com.google.gapid.perfetto.views.FrameEventsSummaryPanel;
+import com.google.gapid.perfetto.views.FrameEventsPanel;
 import com.google.gapid.perfetto.views.GpuQueuePanel;
 import com.google.gapid.perfetto.views.ProcessSummaryPanel;
 import com.google.gapid.perfetto.views.ThreadPanel;
@@ -64,6 +64,8 @@ public class Tracks {
       enumerateCpu(data);
       enumerateCounters(data);
       enumerateGpu(data);
+      //enumerateFrame(data);
+      //enumerateFrame2(data);
       enumerateFrame(data);
       enumerateProcesses(data);
       enumerateVSync(data);
@@ -168,14 +170,27 @@ public class Tracks {
   }
 
   public static Perfetto.Data.Builder enumerateFrame(Perfetto.Data.Builder data) {
-    if (data.getFrame().bufferCount() > 0) {
-      data.tracks.addLabelGroup(null, "sf_events", "Surface Flinger Events",
-          group(state -> new TitlePanel("Surface Flinger Events"), true));
+    if (data.getFrame().layerCount() > 0) {
       String parent = "sf_events";
-      for (FrameInfo.Buffer buffer : data.getFrame().buffers()) {
-        FrameEventsTrack track = FrameEventsTrack.forBuffer(data.qe, buffer);
-        data.tracks.addTrack(parent, track.getId(), buffer.getDisplay(),
-            single(state -> new FrameEventsSummaryPanel(state, buffer, track), true, false));
+      data.tracks.addLabelGroup(null, parent, "Surface Flinger Events",
+          group(state -> new TitlePanel("Surface Flinger Events"), true));
+
+      for (FrameInfo.Layer layer : data.getFrame().layers()) {
+        data.tracks.addLabelGroup(parent, layer.layerName, layer.layerName,
+            group(state -> new TitlePanel(layer.layerName), true));
+        for (FrameInfo.Event phase : layer.phaseEvents()) {
+          FrameEventsTrack track = FrameEventsTrack.forFrameEvent(data.qe, layer.layerName, phase);
+          data.tracks.addTrack(layer.layerName, track.getId(), phase.getDisplay(),
+              single(state -> new FrameEventsPanel(state, phase, track), true, false));
+        }
+        String buffersGroup = "buffers_" + layer.layerName;
+        data.tracks.addLabelGroup(layer.layerName, buffersGroup, "Buffers",
+            group(state -> new TitlePanel("Buffers"), false));
+        for (FrameInfo.Event buffer : layer.bufferEvents()) {
+          FrameEventsTrack track = FrameEventsTrack.forFrameEvent(data.qe, layer.layerName, buffer);
+          data.tracks.addTrack(buffersGroup, track.getId(), buffer.getDisplay(),
+              single(state -> new FrameEventsPanel(state, buffer, track), true, false));
+        }
       }
     }
     return data;

--- a/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSelectionView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSelectionView.java
@@ -95,17 +95,17 @@ public class FrameEventsSelectionView extends Composite {
       Composite props = withLayoutData(createComposite(this, new GridLayout(2 * panels, false)),
           withIndents(new GridData(SWT.LEFT, SWT.TOP, false, false), PANEL_INDENT, 0));
       withLayoutData(createBoldLabel(props, "Properties:"),
-        withSpans(new GridData(), 2 * panels, 1));
+          withSpans(new GridData(), 2 * panels, 1));
 
-    for (int i = 0; i < keys.length && i < PROPERTIES_PER_PANEL; i++) {
-      int cols = (keys.length - i + PROPERTIES_PER_PANEL - 1) / PROPERTIES_PER_PANEL;
-      for (int c = 0; c < cols; c++) {
-        withLayoutData(createLabel(props, keys[i + c * PROPERTIES_PER_PANEL] + ":"),
-            withIndents(new GridData(), (c == 0) ? 0 : PANEL_INDENT, 0));
-        createLabel(props, String.valueOf(slice.argsets.get(0).get(keys[i + c * PROPERTIES_PER_PANEL])));
-      }
-      if (cols != panels) {
-        withLayoutData(createLabel(props, ""), withSpans(new GridData(), 2 * (panels - cols), 1));
+      for (int i = 0; i < keys.length && i < PROPERTIES_PER_PANEL; i++) {
+        int cols = (keys.length - i + PROPERTIES_PER_PANEL - 1) / PROPERTIES_PER_PANEL;
+        for (int c = 0; c < cols; c++) {
+          withLayoutData(createLabel(props, keys[i + c * PROPERTIES_PER_PANEL] + ":"),
+              withIndents(new GridData(), (c == 0) ? 0 : PANEL_INDENT, 0));
+          createLabel(props, String.valueOf(slice.argsets.get(0).get(keys[i + c * PROPERTIES_PER_PANEL])));
+        }
+        if (cols != panels) {
+          withLayoutData(createLabel(props, ""), withSpans(new GridData(), 2 * (panels - cols), 1));
         }
       }
     }
@@ -142,9 +142,13 @@ public class FrameEventsSelectionView extends Composite {
     viewer.setLabelProvider(new LabelProvider());
 
     createTreeColumn(viewer, "Name", e -> n(e).name);
+    createTreeColumn(viewer, "Frame Number", e -> Long.toString(n(e).frameNumber));
     createTreeColumn(viewer, "Self Time", e -> timeToString(n(e).self));
     createTreeColumn(viewer, "Event type", e -> n(e).eventName);
     createTreeColumn(viewer, "Layers", e -> n(e).layerName);
+    createTreeColumn(viewer, "Queue to Acquire Time", e -> timeToString(n(e).queueToAcquireTime));
+    createTreeColumn(viewer, "Acquire to Latch Time", e -> timeToString(n(e).acquireToLatchTime));
+    createTreeColumn(viewer, "Latch to Present Time", e -> timeToString(n(e).latchToPresentTime));
     viewer.setInput(slices);
     packColumns(viewer.getTree());
   }

--- a/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSelectionView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSelectionView.java
@@ -39,9 +39,6 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 
-import java.util.Arrays;
-import java.util.stream.Collectors;
-
 /**
  * Displays information about a selected Frame event.
  */
@@ -74,36 +71,23 @@ public class FrameEventsSelectionView extends Composite {
     createLabel(main, "Duration:");
     createLabel(main, timeToString(slice.durs.get(0)));
 
-    if (slice.frameStats.get(0) != null) {
       // If the selected event is a displayed frame slice, show the frame stats
-      Composite stats = withLayoutData(createComposite(this, new GridLayout(2, false)),
-          withIndents(new GridData(SWT.LEFT, SWT.TOP, false, false), PANEL_INDENT, 0));
-      withLayoutData(createBoldLabel(stats, "Frame Stats:"),
-          withSpans(new GridData(), 2, 1));
+    Composite stats = withLayoutData(createComposite(this, new GridLayout(2, false)),
+        withIndents(new GridData(SWT.LEFT, SWT.TOP, false, false), PANEL_INDENT, 0));
+    withLayoutData(createBoldLabel(stats, "Frame Stats:"),
+        withSpans(new GridData(), 2, 1));
 
-      slice.frameStats.get(0).forEach((k, v) -> {
-        withLayoutData(createBoldLabel(stats, k.toString()),
-            withSpans(new GridData(), 2, 1));
+    createLabel(stats, "Frame number: ");
+    createLabel(stats, Long.toString(slice.frameNumbers.get(0)));
 
-        createLabel(stats, "Frame number: ");
-        createLabel(stats, Long.toString(v.frameNumber));
+    createLabel(stats, "Queue to Acquire: ");
+    createLabel(stats, timeToString(slice.queueToAcquireTimes.get(0)));
 
-        createLabel(stats, "Queue to Acquire: ");
-        createLabel(stats, timeToString(v.queueToAcquireTime));
+    createLabel(stats, "Acquire to Latch: ");
+    createLabel(stats, timeToString(slice.acquireToLatchTimes.get(0)));
 
-        createLabel(stats, "Acquire to Latch: ");
-        createLabel(stats, timeToString(v.acquireToLatchTime));
-
-        createLabel(stats, "Latch to Present: ");
-        createLabel(stats, timeToString(v.latchToPresentTime));
-      });
-    } else {
-      // Show the frame number associated with the event
-      createLabel(main, "Frame Number:");
-      createLabel(main, Arrays.stream(slice.frameNumbers.get(0))
-          .map(l -> Long.toString(l))
-          .collect(Collectors.joining(", ")));
-    }
+    createLabel(stats, "Latch to Present: ");
+      createLabel(stats, timeToString(slice.latchToPresentTimes.get(0)));
 
     if (!slice.argsets.get(0).isEmpty()) {
       String[] keys = Iterables.toArray(slice.argsets.get(0).keys(), String.class);
@@ -111,17 +95,17 @@ public class FrameEventsSelectionView extends Composite {
       Composite props = withLayoutData(createComposite(this, new GridLayout(2 * panels, false)),
           withIndents(new GridData(SWT.LEFT, SWT.TOP, false, false), PANEL_INDENT, 0));
       withLayoutData(createBoldLabel(props, "Properties:"),
-          withSpans(new GridData(), 2 * panels, 1));
+        withSpans(new GridData(), 2 * panels, 1));
 
-      for (int i = 0; i < keys.length && i < PROPERTIES_PER_PANEL; i++) {
-        int cols = (keys.length - i + PROPERTIES_PER_PANEL - 1) / PROPERTIES_PER_PANEL;
-        for (int c = 0; c < cols; c++) {
-          withLayoutData(createLabel(props, keys[i + c * PROPERTIES_PER_PANEL] + ":"),
-              withIndents(new GridData(), (c == 0) ? 0 : PANEL_INDENT, 0));
-          createLabel(props, String.valueOf(slice.argsets.get(0).get(keys[i + c * PROPERTIES_PER_PANEL])));
-        }
-        if (cols != panels) {
-          withLayoutData(createLabel(props, ""), withSpans(new GridData(), 2 * (panels - cols), 1));
+    for (int i = 0; i < keys.length && i < PROPERTIES_PER_PANEL; i++) {
+      int cols = (keys.length - i + PROPERTIES_PER_PANEL - 1) / PROPERTIES_PER_PANEL;
+      for (int c = 0; c < cols; c++) {
+        withLayoutData(createLabel(props, keys[i + c * PROPERTIES_PER_PANEL] + ":"),
+            withIndents(new GridData(), (c == 0) ? 0 : PANEL_INDENT, 0));
+        createLabel(props, String.valueOf(slice.argsets.get(0).get(keys[i + c * PROPERTIES_PER_PANEL])));
+      }
+      if (cols != panels) {
+        withLayoutData(createLabel(props, ""), withSpans(new GridData(), 2 * (panels - cols), 1));
         }
       }
     }
@@ -159,7 +143,8 @@ public class FrameEventsSelectionView extends Composite {
 
     createTreeColumn(viewer, "Name", e -> n(e).name);
     createTreeColumn(viewer, "Self Time", e -> timeToString(n(e).self));
-    createTreeColumn(viewer, "Layers", e -> String.join(", ", n(e).layers));
+    createTreeColumn(viewer, "Event type", e -> n(e).eventName);
+    createTreeColumn(viewer, "Layers", e -> n(e).layerName);
     viewer.setInput(slices);
     packColumns(viewer.getTree());
   }

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -185,8 +185,8 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
         name = "perfetto",
         locals = locals,
         remote = "https://android.googlesource.com/platform/external/perfetto",
-        commit = "34b3e095fffc5bc4db1fb704528a8610687e1a9f",
-        shallow_since = "1587159225 +0000",
+        commit = "3d920083ed23e730aece1252ce18ef25bbe10256",
+        shallow_since = "1591207640 +0100",
     )
 
     maybe_repository(


### PR DESCRIPTION
We have decided to revamp the frame lifecycle UI to be friendly towards users who don't have the knowledge of SurfaceFlinger's events. This new change brings in an ownership view where the old events are taken and are shown as slices of DISPLAY (Present to Present), APP (Dequeue to Queue), Wait for GPU (Queue to Acquire), Composition (Latch to Present). The old buffer events will still be made available so as to not block experienced users.

This change also removes the old summary view as it is no longer relevant and there isn't a design yet to show some kind of a summary.

Design doc: go/sf-profiling-design
    
 Bug: 155242423