### PR TITLE
Add OpenGL on ANGLE tracing option

### DIFF
--- a/cmd/gapit/common.go
+++ b/cmd/gapit/common.go
@@ -68,6 +68,7 @@ func getGapis(ctx context.Context, gapisFlags GapisFlags, gapirFlags GapirFlags)
 	args = append(args, "--enable-local-files")
 
 	args = append(args, "--experimental-enable-vulkan-tracing")
+	args = append(args, "--experimental-enable-angle-tracing")
 	args = append(args, "--experimental-enable-frame-lifecycle")
 
 	if app.Flags.Analytics != "" {

--- a/core/app/flags/experimental.go
+++ b/core/app/flags/experimental.go
@@ -25,4 +25,5 @@ import (
 var (
 	EnableFrameLifecycle = flag.Bool("experimental-enable-frame-lifecycle", false, "Enable the experimental feature Frame Lifecycle.")
 	EnableVulkanTracing  = flag.Bool("experimental-enable-vulkan-tracing", false, "Enable the experimental feature Vulkan tracing.")
+	EnableAngleTracing   = flag.Bool("experimental-enable-angle-tracing", false, "Enable the experimental feature ANGLE tracing.")
 )

--- a/core/os/android/adb/device.go
+++ b/core/os/android/adb/device.go
@@ -217,6 +217,11 @@ func newDevice(ctx context.Context, serial string, status bind.Status) (*binding
 		d.To.Configuration.PerfettoCapability = perfettoCapability
 	}
 
+	// Query device ANGLE support
+	if anglePackage, err := d.QueryAnglePackageName(ctx); err == nil {
+		d.To.Configuration.AnglePackage = anglePackage
+	}
+
 	// If the VkRenderStagesProducer layer exist, we assume the render stages producer is
 	// implemented in the layer.
 	for _, l := range d.To.Configuration.GetDrivers().GetVulkan().GetLayers() {

--- a/core/os/device/bind/device.go
+++ b/core/os/device/bind/device.go
@@ -66,6 +66,8 @@ type Device interface {
 	CanTrace() bool
 	// SupportsPerfetto returns true if this device will work with perfetto
 	SupportsPerfetto(ctx context.Context) bool
+	// SupportsAngle returns true if this device will work with ANGLE
+	SupportsAngle(ctx context.Context) bool
 	// ConnectPerfetto connects to a Perfetto service running on this device
 	// and returns an open socket connection to the service.
 	ConnectPerfetto(ctx context.Context) (*perfetto.Client, error)

--- a/core/os/device/bind/simple_posix.go
+++ b/core/os/device/bind/simple_posix.go
@@ -79,6 +79,11 @@ func (b *Simple) SupportsPerfetto(ctx context.Context) bool {
 	return false
 }
 
+// SupportsAngle can only return true on Android currently.
+func (b *Simple) SupportsAngle(ctx context.Context) bool {
+	return false
+}
+
 // ConnectPerfetto connects to a Perfetto service running on this device
 // and returns an open socket connection to the service.
 func (b *Simple) ConnectPerfetto(ctx context.Context) (*perfetto.Client, error) {

--- a/core/os/device/bind/simple_windows.go
+++ b/core/os/device/bind/simple_windows.go
@@ -123,6 +123,11 @@ func (b *Simple) SupportsPerfetto(ctx context.Context) bool {
 	return false
 }
 
+// SupportsAngle can only return true on Android currently.
+func (b *Simple) SupportsAngle(ctx context.Context) bool {
+	return false
+}
+
 // ConnectPerfetto connects to a Perfetto service running on this device
 // and returns an open socket connection to the service.
 func (b *Simple) ConnectPerfetto(ctx context.Context) (*perfetto.Client, error) {

--- a/core/os/device/device.proto
+++ b/core/os/device/device.proto
@@ -173,6 +173,8 @@ message Configuration {
   Drivers drivers = 4;
   // Perfetto capability.
   PerfettoCapability perfetto_capability = 5;
+  // Angle package name
+  string angle_package = 6;
 }
 
 message VulkanProfilingLayers {

--- a/core/os/device/remotessh/commands.go
+++ b/core/os/device/remotessh/commands.go
@@ -365,6 +365,11 @@ func (b binding) SupportsPerfetto(ctx context.Context) bool {
 	return false
 }
 
+// SupportsAngle can only return true on Android currently.
+func (b binding) SupportsAngle(ctx context.Context) bool {
+	return false
+}
+
 // ConnectPerfetto connects to a Perfetto service running on this device
 // and returns an open socket connection to the service.
 func (b *binding) ConnectPerfetto(ctx context.Context) (*perfetto.Client, error) {

--- a/gapic/src/main/com/google/gapid/Main.java
+++ b/gapic/src/main/com/google/gapid/Main.java
@@ -208,6 +208,7 @@ public class Main {
     Experimental.enableAll,
     Experimental.enableFrameLifecycle,
     Experimental.enableVulkanTracing,
+    Experimental.enableAngleTracing,
     GapiPaths.gapidPath,
     GapiPaths.adbPath,
     GapisProcess.disableGapisTimeout,

--- a/gapic/src/main/com/google/gapid/util/Experimental.java
+++ b/gapic/src/main/com/google/gapid/util/Experimental.java
@@ -33,7 +33,10 @@ public class Experimental {
       false, "Enable the experimental feature Frame Lifecycle.");
 
   public static final Flag<Boolean> enableVulkanTracing = Flags.value("experimental-enable-vulkan-tracing",
-      false, "Enable the experimental feature Vulakn tracing.");
+      false, "Enable the experimental feature Vulkan tracing.");
+
+  public static final Flag<Boolean> enableAngleTracing = Flags.value("experimental-enable-angle-tracing",
+      false, "Enable the experimental feature Angle tracing.");
 
   public static List<String> getGapisFlags(boolean enableAllExperimentalFeatures) {
     List<String> args = Lists.newArrayList();
@@ -42,12 +45,16 @@ public class Experimental {
       // All --experimental-enable-<feature-name> flags must be added here.
       args.add("--experimental-enable-frame-lifecycle");
       args.add("--experimental-enable-vulkan-tracing");
+      args.add("--experimental-enable-angle-tracing");
     } else {
       if (Experimental.enableFrameLifecycle.get()) {
         args.add("--experimental-enable-frame-lifecycle");
       }
       if (Experimental.enableVulkanTracing.get()) {
         args.add("--experimental-enable-vulkan-tracing");
+      }
+      if (Experimental.enableAngleTracing.get()) {
+        args.add("--experimental-enable-angle-tracing");
       }
     }
     return args;

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -271,6 +271,7 @@ public class TracerDialog {
       private static final String DEFAULT_TRACE_FILE = "trace";
       private static final String TRACE_EXTENSION = ".gfxtrace";
       private static final String PERFETTO_EXTENSION = ".perfetto";
+      private static final String ANGLE_STRING = "_angle";
       private static final DateFormat TRACE_DATE_FORMAT = new SimpleDateFormat("_yyyyMMdd_HHmm");
       private static final String TARGET_LABEL = "Application";
       private static final String FRAMES_LABEL = "Stop After:";
@@ -844,7 +845,9 @@ public class TracerDialog {
       protected String formatTraceName(String name) {
         TraceTypeCapabilities config = getSelectedApi();
         String ext = config != null && isPerfetto(config) ? PERFETTO_EXTENSION : TRACE_EXTENSION;
-        return (name.isEmpty() ? DEFAULT_TRACE_FILE : name) + date + ext;
+        // For ANGLE captures include "_angle" in trace name
+        String angle = isAngle(config) ? ANGLE_STRING : "";
+        return (name.isEmpty() ? DEFAULT_TRACE_FILE : name) + angle + date + ext;
       }
 
       public boolean isReady() {
@@ -1006,6 +1009,10 @@ public class TracerDialog {
 
       private static boolean isPerfetto(TraceTypeCapabilities config) {
         return config != null && config.getType() == TraceType.Perfetto;
+      }
+
+      private static boolean isAngle(TraceTypeCapabilities config) {
+        return config != null && config.getApi().equalsIgnoreCase("OpenGL on ANGLE");
       }
     }
 

--- a/gapii/client/capture.go
+++ b/gapii/client/capture.go
@@ -69,6 +69,8 @@ type Options struct {
 	Flags Flags
 	// Additional flags to pass to am start
 	AdditionalFlags string
+	// Enable ANGLE for application prior to start
+	EnableAngle bool
 	// The name of the pipe to connect/listen to.
 	PipeName string
 }

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -283,6 +283,10 @@ func (t *androidTracer) TraceConfiguration(ctx context.Context) (*service.Device
 	*/
 	if len(t.b.Instance().GetConfiguration().GetDrivers().GetVulkan().GetPhysicalDevices()) > 0 && *flags.EnableVulkanTracing {
 		apis = append(apis, tracer.VulkanTraceOptions())
+		// If ANGLE is enabled and available, need to also append ANGLE trace mode
+		if *flags.EnableAngleTracing && t.b.SupportsAngle(ctx) {
+			apis = append(apis, tracer.AngleTraceOptions())
+		}
 	}
 	if t.b.SupportsPerfetto(ctx) {
 		apis = append(apis, tracer.PerfettoTraceOptions())

--- a/gapis/trace/tracer/default_api_trace_options.go
+++ b/gapis/trace/tracer/default_api_trace_options.go
@@ -29,6 +29,17 @@ func VulkanTraceOptions() *service.TraceTypeCapabilities {
 	}
 }
 
+// AngleTraceOptions returns the default trace options for Angle.
+func AngleTraceOptions() *service.TraceTypeCapabilities {
+	return &service.TraceTypeCapabilities{
+		Type:                           service.TraceType_Graphics,
+		Api:                            "OpenGL on ANGLE",
+		MidExecutionCaptureSupport:     service.FeatureStatus_Supported,
+		CanEnableUnsupportedExtensions: true,
+		RequiresApplication:            true,
+	}
+}
+
 // PerfettoTraceOptions returns the default trace options for Perfetto.
 func PerfettoTraceOptions() *service.TraceTypeCapabilities {
 	return &service.TraceTypeCapabilities{

--- a/gapis/trace/tracer/tracer.go
+++ b/gapis/trace/tracer/tracer.go
@@ -104,9 +104,14 @@ func LayersFromOptions(ctx context.Context, o *service.TraceOptions) []string {
 // GapiiOptions converts the given TraceOptions to gapii.Options.
 func GapiiOptions(o *service.TraceOptions) gapii.Options {
 	apis := uint32(0)
+	enableAngle := bool(false)
 	for _, api := range o.Apis {
 		if api == "Vulkan" {
 			apis |= gapii.VulkanAPI
+		}
+		if api == "OpenGL on ANGLE" {
+			apis |= gapii.VulkanAPI
+			enableAngle = true
 		}
 	}
 
@@ -135,6 +140,7 @@ func GapiiOptions(o *service.TraceOptions) gapii.Options {
 		apis,
 		flags,
 		o.AdditionalCommandLineArgs,
+		enableAngle,
 		o.PipeName,
 	}
 }


### PR DESCRIPTION
Add new tracing mode "OpenGL on ANGLE."
This is the Vulkan frame capture mode, but is intended to be used
on OpenGL apps and, prior to launching the app, ANGLE will be enabled
for the target app. AGI will then capture the Vulkan output from
ANGLE.

Here are the main components of the feature:
 * Enable feature w/ "--experimental-enable-angle-tracing" flags/experimental
 * This allows "OpenGL on Angle" tracing mode to appear
 * Detect ANGLE apk installed on device, favoring custom apk, then
 system ANGLE install
 * When Angle mode is selected, enable Angle for selected application
 * Frame capture proceeds as usual w/ Vulkan output of Angle
 * When complete, restore any original ANGLE settings to device

Bug: b/153447218