### PR TITLE
Harden GAPIR error reporting

### DIFF
--- a/gapir/cc/server.h
+++ b/gapir/cc/server.h
@@ -26,10 +26,16 @@
 #include <grpc++/grpc++.h>
 
 #include <atomic>
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <string>
 #include <thread>
+
+namespace {
+// Duration for which pending RPC can cleanly terminate upon a shutdown.
+const std::chrono::seconds kShutdownTimeout(1);
+}  // namespace
 
 namespace gapir {
 
@@ -116,10 +122,14 @@ class Server {
   // Wait blocks until the server shuts down.
   void wait() { mGrpcServer->Wait(); }
 
-  // Shuts down the server, it waits for all RPC processing to finish.
+  // Shuts down the server, give it a little time to finish RPC processing.
   void shutdown() {
     if (!mShuttingDown.exchange(true)) {
-      std::thread([this] { this->mGrpcServer->Shutdown(); }).detach();
+      std::thread([this] {
+        auto deadline = std::chrono::system_clock::now() + kShutdownTimeout;
+        this->mGrpcServer->Shutdown(deadline);
+      })
+          .detach();
     }
   }
 


### PR DESCRIPTION
Avoid early returns upon errors in the ReplayHandler. These early
returns would lead to a hang. The ReplayHandler executes while the
main replayer logic waits on server->wait(), which effectively waits
on the gRPC connection to terminate. When the ReplayHandler handles an
error via an early return, this leads to the main thread waiting on
the connection to terminate, which will never happen: GAPIS is waiting
for a replay response and will not close the connection, the replayer
is waiting for the connection to terminate, no one will make progress.

Also, set a deadline in gRPC Shutdown(), to bound the termination of
in-flight RPCs.

Bug: b/158316277
Test: Lots of manual tests by hard-coding fake errors in e.g. state
priming.