### PR TITLE
Add support for GPU profiling in BSP driver.

### DIFF
--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -437,7 +437,8 @@ type (
 
 	ValidateGpuProfilingFlags struct {
 		DeviceFlags
-		Gapis GapisFlags
+		Gapis          GapisFlags
+		UseSystemImage bool `help:"If true then validate against the GPU profiling libraries in the system image."`
 	}
 
 	PerfettoFlags struct {

--- a/cmd/gapit/validate_gpu_profiling.go
+++ b/cmd/gapit/validate_gpu_profiling.go
@@ -51,7 +51,7 @@ func (verb *validateGpuProfilingVerb) Run(ctx context.Context, flags flag.FlagSe
 	someDeviceFailed := false
 	for i, p := range devices {
 		fmt.Fprintf(stdout, "-- Device %v: %v --\n", i, p.ID.ID())
-		err = client.ValidateDevice(ctx, p)
+		err = client.ValidateDevice(ctx, p, verb.UseSystemImage)
 		if err != nil {
 			fmt.Fprintf(stdout, "%v\n", log.Err(ctx, err, "Failed to validate device"))
 			someDeviceFailed = true

--- a/cmd/launch_producer/BUILD.bazel
+++ b/cmd/launch_producer/BUILD.bazel
@@ -15,7 +15,7 @@
 load("//tools/build:rules.bzl", "android_native_binary")
 
 android_native_binary(
-    name = "launch_producer",
+    name = "agi_launch_producer",
     srcs = ["main.cpp"],
     linkopts = [
         "-llog",

--- a/cmd/launch_producer/main.cpp
+++ b/cmd/launch_producer/main.cpp
@@ -24,10 +24,9 @@
 
 #include <string>
 
-// TODO(b/148950543): Figure out why stdout is not captured.
 #define _LOG(lvl, name, msg, ...)                        \
   do {                                                   \
-    fprintf(stderr, name ": " msg "\n", ##__VA_ARGS__);  \
+    fprintf(stdout, name ": " msg "\n", ##__VA_ARGS__);  \
     __android_log_print(lvl, "AGI", msg, ##__VA_ARGS__); \
   } while (false)
 

--- a/cmd/vulkan_sample/main.cpp
+++ b/cmd/vulkan_sample/main.cpp
@@ -1571,6 +1571,7 @@ int main(int argc, const char** argv) {
                               swapchain_image_ready_semaphores[frame_parity],
                               VK_NULL_HANDLE, &next_image));
 
+    // Known issue b/158792228
     REQUIRE_SUCCESS(vkWaitForFences(device, 1, &ready_fences[frame_parity],
                                     false, static_cast<uint64_t>(-1)));
     REQUIRE_SUCCESS(vkResetFences(device, 1, &ready_fences[frame_parity]));

--- a/core/os/android/adb/bind.go
+++ b/core/os/android/adb/bind.go
@@ -38,6 +38,11 @@ type Device interface {
 	RemoveForward(ctx context.Context, local Port) error
 	// GraphicsDriver queries and returns info about the prerelease graphics driver.
 	GraphicsDriver(ctx context.Context) (Driver, error)
+	// HasGpuProfilingSupportInSystemImage returns whether system image has GPU profiling support.
+	HasGpuProfilingSupportInSystemImage(ctx context.Context) (bool, error)
+	// GetGpuProfilingLayerPackageName queries and returns the package name of the apk that contains
+	// the GPU profiling Vulkan layer.
+	GetGpuProfilingLayerPackageName(ctx context.Context) (string, error)
 }
 
 // Driver contains the information about a graphics driver.

--- a/core/os/android/adb/device_test.go
+++ b/core/os/android/adb/device_test.go
@@ -45,6 +45,10 @@ func TestParseDevices(t_ *testing.T) {
 				Name: "flame",
 			},
 			ABIs: []*device.ABI{device.AndroidARM64v8a},
+			PerfettoCapability: &device.PerfettoCapability{
+				SystemImageGpuProfiling: &device.GPUProfiling{},
+				GpuProfiling:            &device.GPUProfiling{},
+			},
 		},
 	}
 	expected.GenID()

--- a/core/os/device/device.proto
+++ b/core/os/device/device.proto
@@ -186,13 +186,15 @@ message PerfettoCapability {
   GPUProfiling gpu_profiling = 1;
   VulkanProfilingLayers vulkan_profile_layers = 2;
   bool can_specify_atrace_apps = 3;
+  bool hasFrameLifecycle = 4;
+  GPUProfiling system_image_gpu_profiling = 5;
 }
 
 message GPUProfiling {
   bool hasRenderStage = 1;
   // The GPU performance counters.
   GpuCounterDescriptor gpu_counter_descriptor = 2;
-  bool hasFrameLifecycle = 3;
+  reserved 3;
   bool has_render_stage_producer_layer = 4;
 }
 

--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
@@ -191,7 +191,7 @@ public class TraceConfigDialog extends DialogBase {
     Device.GPUProfiling gpuCaps = caps.getGpuProfiling();
     if (gpuCaps.getHasRenderStage() ||
         gpuCaps.getGpuCounterDescriptor().getSpecsCount() > 0 ||
-        gpuCaps.getHasFrameLifecycle()) {
+        caps.getHasFrameLifecycle()) {
       if (p.getGpuOrBuilder().getEnabled()) {
         enabled.add("GPU");
       }
@@ -284,7 +284,7 @@ public class TraceConfigDialog extends DialogBase {
                     .setCounterPeriodNs(MILLISECONDS.toNanos(gpu.getCounterRate()));
         counters.addAllCounterIds(gpu.getCounterIdsList());
       }
-      if (gpuCaps.getHasFrameLifecycle() && gpu.getSurfaceFlinger()) {
+      if (caps.getHasFrameLifecycle() && gpu.getSurfaceFlinger()) {
         config.addDataSourcesBuilder()
             .getConfigBuilder()
                 .setName("android.surfaceflinger.frame");
@@ -469,7 +469,7 @@ public class TraceConfigDialog extends DialogBase {
       Device.GPUProfiling gpuCaps = caps.getGpuProfiling();
       if (gpuCaps.getHasRenderStage() ||
           gpuCaps.getGpuCounterDescriptor().getSpecsCount() > 0 ||
-          gpuCaps.getHasFrameLifecycle()) {
+          caps.getHasFrameLifecycle()) {
         gpu = createCheckbox(this, "GPU", sGpu.getEnabled(), e -> updateGpu());
         Composite gpuGroup = withLayoutData(
             createComposite(this, withMargin(new GridLayout(1, false), 5, 0)),
@@ -515,7 +515,7 @@ public class TraceConfigDialog extends DialogBase {
           gpuCountersSelect = null;
         }
 
-        if (gpuCaps.getHasFrameLifecycle()) {
+        if (caps.getHasFrameLifecycle()) {
           gpuFrame = createCheckbox(
               gpuGroup, "Frame Lifecycle (experimental)", sGpu.getSurfaceFlinger(), e -> updateGpu());
         } else {

--- a/gapic/src/main/com/google/gapid/server/Client.java
+++ b/gapic/src/main/com/google/gapid/server/Client.java
@@ -251,6 +251,7 @@ public class Client {
         stack -> MoreFutures.transformAsync(
             client.validateDevice(Service.ValidateDeviceRequest.newBuilder()
                 .setDevice(device)
+                .setUseSystemImage(false)
                 .build()),
             in -> immediateFuture(in)));
   }

--- a/gapidapk/android/apk/BUILD.bazel
+++ b/gapidapk/android/apk/BUILD.bazel
@@ -27,7 +27,7 @@ _NATIVE_LIBRARIES = {
 }
 
 _NATIVE_BINARIES = {
-    "launch_producer": "//cmd/launch_producer",
+    "agi_launch_producer": "//cmd/launch_producer",
 }
 
 gapid_apk(

--- a/gapidapk/deviceinfo.go
+++ b/gapidapk/deviceinfo.go
@@ -15,18 +15,14 @@
 package gapidapk
 
 import (
-	"bufio"
 	"bytes"
 	"context"
-	"fmt"
-	"io"
 	"io/ioutil"
 	"strings"
 	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/gapid/core/app"
-	"github.com/google/gapid/core/app/crash"
 	"github.com/google/gapid/core/event/task"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/android"
@@ -36,14 +32,11 @@ import (
 )
 
 const (
-	sendDevInfoAction        = "com.google.android.gapid.action.SEND_DEV_INFO"
-	sendDevInfoService       = "com.google.android.gapid.DeviceInfoService"
-	sendDevInfoPort          = "gapid-devinfo"
-	startServiceAttempts     = 3
-	portListeningAttempts    = 5
-	perfettoProducerLauncher = "launch_producer"
-	launcherPath             = "/data/local/tmp/gapid_launch_producer"
-	launcherScript           = "nohup %[1]s &"
+	sendDevInfoAction     = "com.google.android.gapid.action.SEND_DEV_INFO"
+	sendDevInfoService    = "com.google.android.gapid.DeviceInfoService"
+	sendDevInfoPort       = "gapid-devinfo"
+	startServiceAttempts  = 3
+	portListeningAttempts = 5
 )
 
 func init() {
@@ -135,21 +128,6 @@ func fetchDeviceInfo(ctx context.Context, d adb.Device) error {
 	}
 	defer cleanup.Invoke(ctx)
 
-	if d.Instance().GetConfiguration().GetOS().GetAPIVersion() >= 29 {
-		startSignal, startFunc := task.NewSignal()
-		startFunc = task.Once(startFunc)
-		crash.Go(func() {
-			err := launchPerfettoProducerFromApk(ctx, d, startFunc)
-			if err != nil {
-				log.E(ctx, "[launchPerfettoProducerFromApk] error: %v", err)
-			}
-
-			// Ensure the start signal is fired on failure/immediate return.
-			startFunc(ctx)
-		})
-		startSignal.Wait(ctx)
-	}
-
 	// Make sure the device is available to query device info, this is to prevent
 	// Vulkan trace from happening at the same time than device info query.
 	m := flock.Lock(d.Instance().GetSerial())
@@ -177,89 +155,4 @@ func fetchDeviceInfo(ctx context.Context, d adb.Device) error {
 	}
 
 	return nil
-}
-
-func preparePerfettoProducerLauncherFromApk(ctx context.Context, d adb.Device) error {
-	packageName := PackageName(d.Instance().GetConfiguration().PreferredABI(nil))
-	res, err := d.Shell("pm", "path", packageName).Call(ctx)
-	if err != nil {
-		return log.Errf(ctx, err, "Failed to query path to apk %v", packageName)
-	}
-	packagePath := strings.Split(res, ":")[1]
-	d.Shell("rm", "-f", launcherPath).Call(ctx)
-	if _, err := d.Shell("unzip", "-o", packagePath, "assets/"+perfettoProducerLauncher, "-p", ">", launcherPath).Call(ctx); err != nil {
-		return log.Errf(ctx, err, "Failed to unzip %v from %v", perfettoProducerLauncher, packageName)
-	}
-
-	// Finally, make sure the binary is executable
-	d.Shell("chmod", "a+x", launcherPath).Call(ctx)
-	return nil
-}
-
-func launchPerfettoProducerFromApk(ctx context.Context, d adb.Device, startFunc task.Task) error {
-	driver, err := d.GraphicsDriver(ctx)
-	if err != nil {
-		return err
-	}
-
-	// Extract the producer launcher from the APK.
-	if err := preparePerfettoProducerLauncherFromApk(ctx, d); err != nil {
-		return err
-	}
-
-	// Construct IO pipe, shell command outputs to stdout, GAPID reads from
-	// reader for logging purpose.
-	reader, stdout := io.Pipe()
-	fail := make(chan error, 1)
-	crash.Go(func() {
-		buf := bufio.NewReader(reader)
-		for {
-			line, e := buf.ReadString('\n')
-			// As long as there's output, consider the binary starting running.
-			startFunc(ctx)
-			switch e {
-			default:
-				log.E(ctx, "[launch producer] Read error %v", e)
-				fail <- e
-				return
-			case io.EOF:
-				fail <- nil
-				return
-			case nil:
-				log.E(ctx, "[launch producer] %s", strings.TrimSuffix(adb.AnsiRegex.ReplaceAllString(line, ""), "\n"))
-			}
-		}
-	})
-
-	// Start the shell command to launch producer
-	script := fmt.Sprintf(launcherScript, launcherPath)
-	if driver.Package != "" {
-		abi := d.Instance().GetConfiguration().PreferredABI(nil)
-		script = "export LD_LIBRARY_PATH=\"" + driver.Path + "!/lib/" + abi.Name + "/\";" + script
-	}
-	process, err := d.Shell(script).
-		Capture(stdout, stdout).
-		Start(ctx)
-	if err != nil {
-		stdout.Close()
-		return err
-	}
-
-	wait := make(chan error, 1)
-	crash.Go(func() {
-		wait <- process.Wait(ctx)
-	})
-
-	// Wait until either an error or EOF is read, or shell command exits.
-	select {
-	case err = <-fail:
-		return err
-	case err = <-wait:
-		// Do nothing.
-	}
-	stdout.Close()
-	if err != nil {
-		return err
-	}
-	return <-fail
 }

--- a/gapis/client/client.go
+++ b/gapis/client/client.go
@@ -564,9 +564,10 @@ func (c *client) PerfettoQuery(ctx context.Context, capture *path.Capture, query
 	return res.GetResult(), nil
 }
 
-func (c *client) ValidateDevice(ctx context.Context, device *path.Device) error {
+func (c *client) ValidateDevice(ctx context.Context, device *path.Device, useSystemImage bool) error {
 	res, err := c.client.ValidateDevice(ctx, &service.ValidateDeviceRequest{
-		Device: device,
+		Device:         device,
+		UseSystemImage: useSystemImage,
 	})
 	if err != nil {
 		return err

--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -666,7 +666,7 @@ func (s *grpcServer) PerfettoQuery(ctx xctx.Context, req *service.PerfettoQueryR
 }
 
 func (s *grpcServer) ValidateDevice(ctx xctx.Context, req *service.ValidateDeviceRequest) (*service.ValidateDeviceResponse, error) {
-	err := s.handler.ValidateDevice(s.bindCtx(ctx), req.Device)
+	err := s.handler.ValidateDevice(s.bindCtx(ctx), req.Device, req.UseSystemImage)
 	if err := service.NewError(err); err != nil {
 		return &service.ValidateDeviceResponse{Error: err}, nil
 	}

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -950,9 +950,9 @@ func (s *server) PerfettoQuery(ctx context.Context, c *path.Capture, query strin
 	return res, nil
 }
 
-func (s *server) ValidateDevice(ctx context.Context, d *path.Device) error {
+func (s *server) ValidateDevice(ctx context.Context, d *path.Device, useSystemImage bool) error {
 	ctx = status.Start(ctx, "RPC ValidateDevice")
 	defer status.Finish(ctx)
 	ctx = log.Enter(ctx, "ValidateDevice")
-	return trace.Validate(ctx, d)
+	return trace.Validate(ctx, d, useSystemImage)
 }

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -182,7 +182,7 @@ type Service interface {
 
 	// ValidateDevice validates the GPU profiling capabilities of the given device and returns
 	// an error if validation failed or the GPU profiling data is invalid.
-	ValidateDevice(ctx context.Context, d *path.Device) error
+	ValidateDevice(ctx context.Context, d *path.Device, useSystemImage bool) error
 }
 
 type TraceHandler interface {

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -737,6 +737,7 @@ service Gapid {
 
 message ValidateDeviceRequest {
   path.Device device = 1;
+  bool use_system_image = 2;
 }
 
 message ValidateDeviceResponse {
@@ -1142,6 +1143,8 @@ message TraceOptions {
   bool disable_coherent_memory_tracker = 25;
   // The config to use if doing a Perfetto trace.
   perfetto.protos.TraceConfig perfetto_config = 24;
+  // Whether to use GPU profiling libraries from the system image.
+  bool use_system_image_gpu_profiling = 26;
 }
 
 enum TraceEvent {

--- a/gapis/trace/android/validate/validate.go
+++ b/gapis/trace/android/validate/validate.go
@@ -182,7 +182,7 @@ func ValidateGpuCounters(ctx context.Context, processor *perfetto.Processor, cou
 func GetTrackIDs(ctx context.Context, s Scope, processor *perfetto.Processor) ([]int64, error) {
 	queryResult, err := processor.Query(fmt.Sprintf(trackIDQuery, s))
 	if err != nil || queryResult.GetNumRecords() <= 0 {
-		return []int64{}, log.Err(ctx, err, "Failed to query GPU render stage track ids")
+		return []int64{}, log.Errf(ctx, err, "Failed to query track ids with scope: %v", s)
 	}
 	result := make([]int64, queryResult.GetNumRecords())
 	for i, v := range queryResult.GetColumns()[0].GetLongValues() {

--- a/gapis/trace/desktop/trace.go
+++ b/gapis/trace/desktop/trace.go
@@ -55,7 +55,7 @@ func (t *DesktopTracer) ProcessProfilingData(ctx context.Context, buffer *bytes.
 	return nil, log.Err(ctx, nil, "Desktop replay profiling is unsupported.")
 }
 
-func (t *DesktopTracer) Validate(ctx context.Context) error {
+func (t *DesktopTracer) Validate(ctx context.Context, useSystemImage bool) error {
 	return nil
 }
 

--- a/gapis/trace/trace.go
+++ b/gapis/trace/trace.go
@@ -115,12 +115,12 @@ func ProcessProfilingData(ctx context.Context, device *path.Device, capture *pat
 	return t.ProcessProfilingData(ctx, buffer, capture, handleMapping, syncData)
 }
 
-func Validate(ctx context.Context, device *path.Device) error {
+func Validate(ctx context.Context, device *path.Device, useSystemImage bool) error {
 	t, err := GetTracer(ctx, device)
 	if err != nil {
 		return err
 	}
-	return t.Validate(ctx)
+	return t.Validate(ctx, useSystemImage)
 }
 
 func GetTracer(ctx context.Context, device *path.Device) (tracer.Tracer, error) {

--- a/gapis/trace/tracer/tracer.go
+++ b/gapis/trace/tracer/tracer.go
@@ -77,7 +77,7 @@ type Tracer interface {
 	ProcessProfilingData(ctx context.Context, buffer *bytes.Buffer, capture *path.Capture, handleMapping *map[uint64][]service.VulkanHandleMappingItem, syncData *sync.Data) (*service.ProfilingData, error)
 	// Validate validates the GPU profiling capabilities of the given device and returns
 	// an error if validation failed or the GPU profiling data is invalid.
-	Validate(ctx context.Context) error
+	Validate(ctx context.Context, useSystemImage bool) error
 }
 
 // LayersFromOptions Parses the perfetto options, and returns the required layers


### PR DESCRIPTION
Add support to use GPU profiling libraries in system image.

Previously GPU profiling libraries are shipped as part of developer driver. In
Android 11, now vendors have the choice to ship them as part of BSP. This patch
below supports:

1) Load libgpudataproducer.so from BSP;
2) Add another field to store native GPU profiling libraries;
3) Allow to capture a trace with BSP GPU profiling libraries;
4) Allow to run gapit validation command against the BSP.

Minor: Move frame lifecycle out of GPU profiling capability to Perfetto
capability because it's technically not updatable and bound to the system
image.

Bug: b/148970509, b/148950543
Test: Verified with  Pixel 4 and Note 10.
Test: bazel run gapit -- validate_gpu_profiling --os android
Test: bazel run gapit -- validate_gpu_profiling --os android --usesystemimage