### PR TITLE
Check NDK version in Bazel

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -74,16 +74,19 @@ To fetch the required packages, using a console type:
 
 ```
 cd <sdk-path>
-tools\bin\sdkmanager.bat "platforms;android-26" "build-tools;29.0.2" ndk-bundle
+tools\bin\sdkmanager.bat "platforms;android-26" "build-tools;29.0.2"
 ```
-
-Note: this will install the latest NDK in `<sdk-path>\ndk-bundle`. The recommended version of the NDK is **r21**.
 
 If you do not have adb installed you can do so with:
 ```
 cd <sdk-path>
 tools\bin\sdkmanager.bat platform-tools
 ```
+
+Unzip the
+[Android NDK **r21**](https://dl.google.com/android/repository/android-ndk-r21-windows-x86_64.zip)
+into a directory of your choosing, and set the `ANDROID_NDK_HOME` environment
+variable to point to this directory.
 
 ### Configure the environment
 
@@ -132,15 +135,22 @@ To fetch the required packages, using a console type:
 
 ```
 cd <sdk-path>
-tools/bin/sdkmanager "platforms;android-26" "build-tools;29.0.2" ndk-bundle
+tools/bin/sdkmanager "platforms;android-26" "build-tools;29.0.2"
 ```
-
-Note: this will install the latest NDK in `<sdk-path>/ndk-bundle`. The recommended version of the NDK is **r21**.
 
 If you do not have adb installed you can do so with:
 ```
 cd <sdk-path>
 tools/bin/sdkmanager platform-tools
+```
+
+Unzip the
+[Android NDK **r21**](https://dl.google.com/android/repository/android-ndk-r21-darwin-x86_64.zip)
+into a directory of your choosing, and set the `ANDROID_NDK_HOME` environment
+variable to point to this directory:
+
+```
+export ANDROID_NDK_HOME=<ndk-path>
 ```
 
 ### Install the XCode command line tools
@@ -199,15 +209,22 @@ To fetch the required packages, using a console type:
 
 ```
 cd <sdk-path>
-tools/bin/sdkmanager "platforms;android-26" "build-tools;29.0.2" ndk-bundle
+tools/bin/sdkmanager "platforms;android-26" "build-tools;29.0.2"
 ```
-
-Note: this will install the latest NDK in `<sdk-path>/ndk-bundle`. The recommended version of the NDK is **r21**.
 
 If you do not have adb installed you can do so with:
 ```
 cd <sdk-path>
 tools/bin/sdkmanager platform-tools
+```
+
+Unzip the
+[Android NDK **r21**](https://dl.google.com/android/repository/android-ndk-r21-linux-x86_64.zip)
+into a directory of your choosing, and set the `ANDROID_NDK_HOME` environment
+variable to point to this directory:
+
+```
+export ANDROID_NDK_HOME=<ndk-path>
 ```
 
 ### Install other libraries

--- a/gapidapk/android/apk/rules.bzl
+++ b/gapidapk/android/apk/rules.bzl
@@ -110,7 +110,7 @@ def gapid_apk(name = "", abi = "", pkg = "", libs = {}, bins = {}):
             "//conditions:default": [],
         }),
         deps = select({
-            "//tools/build:android-" + name: ["@ndk_vk_validation_layer//:" + abi],
+            "//tools/build:android-" + name: ["@ndk_version_check//:ndk_version_check", "@ndk_vk_validation_layer//:" + abi],
             "//conditions:default": [],
         }),
     )

--- a/gapidapk/android/apk/rules.bzl
+++ b/gapidapk/android/apk/rules.bzl
@@ -110,7 +110,7 @@ def gapid_apk(name = "", abi = "", pkg = "", libs = {}, bins = {}):
             "//conditions:default": [],
         }),
         deps = select({
-            "//tools/build:android-" + name: ["@ndk_version_check//:ndk_version_check", "@ndk_vk_validation_layer//:" + abi],
+            "//tools/build:android-" + name: ["@ndk_vk_validation_layer//:" + abi],
             "//conditions:default": [],
         }),
     )
@@ -124,6 +124,7 @@ def gapid_apk(name = "", abi = "", pkg = "", libs = {}, bins = {}):
         assets = assets,
         assets_dir = abi,
         deps = [
+            "@ndk_version_check//:version_check",
             "//gapidapk/android/app/src/main:gapid",
             ":" + name + "_native",
         ],

--- a/kokoro/presubmit/build.sh
+++ b/kokoro/presubmit/build.sh
@@ -38,12 +38,13 @@ curl -L -k -s https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install -y clang-format-6.0
 
-# Mock the correct NDK version.
-# Our Bazel scripts check that the correct NDK version is installed: rather
-# than downloading the 1+GB NDK just to have a matching version to pass this
-# presubmit test, we "mock" the version by overwriting it manually.
-export ANDROID_NDK_HOME=/opt/android-ndk-r16b
-cat > $ANDROID_NDK_HOME/source.properties <<EOF
+# Fake NDK with the expected version.
+# Our Bazel scripts check that a specific NDK version is installed: rather
+# than downloading the 1GB+ NDK just to have a matching version, we manually
+# create a fake NDK with only a version file.
+export ANDROID_NDK_HOME=${PWD}/android-ndk-fake
+mkdir -p ${ANDROID_NDK_HOME}
+cat > ${ANDROID_NDK_HOME}/source.properties <<EOF
 Pkg.Desc = Android NDK
 Pkg.Revision = 21.0.6113669
 EOF

--- a/kokoro/presubmit/build.sh
+++ b/kokoro/presubmit/build.sh
@@ -38,8 +38,17 @@ curl -L -k -s https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install -y clang-format-6.0
 
-# Setup environment.
+# Mock the correct NDK version.
+# Our Bazel scripts check that the correct NDK version is installed: rather
+# than downloading the 1+GB NDK just to have a matching version to pass this
+# presubmit test, we "mock" the version by overwriting it manually.
 export ANDROID_NDK_HOME=/opt/android-ndk-r16b
+cat > $ANDROID_NDK_HOME/source.properties <<EOF
+Pkg.Desc = Android NDK
+Pkg.Revision = 21.0.6113669
+EOF
+
+# Setup environment.
 export BAZEL=$BUILD_ROOT/bazel/bin/bazel
 export BUILDIFIER=$BUILD_ROOT/tools/bin/buildifier
 export BUILDOZER=$BUILD_ROOT/tools/bin/buildozer

--- a/kokoro/presubmit/build.sh
+++ b/kokoro/presubmit/build.sh
@@ -38,18 +38,8 @@ curl -L -k -s https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install -y clang-format-6.0
 
-# Fake NDK with the expected version.
-# Our Bazel scripts check that a specific NDK version is installed: rather
-# than downloading the 1GB+ NDK just to have a matching version, we manually
-# create a fake NDK with only a version file.
-export ANDROID_NDK_HOME=${PWD}/android-ndk-fake
-mkdir -p ${ANDROID_NDK_HOME}
-cat > ${ANDROID_NDK_HOME}/source.properties <<EOF
-Pkg.Desc = Android NDK
-Pkg.Revision = 21.0.6113669
-EOF
-
 # Setup environment.
+export ANDROID_NDK_HOME=/opt/android-ndk-r16b
 export BAZEL=$BUILD_ROOT/bazel/bin/bazel
 export BUILDIFIER=$BUILD_ROOT/tools/bin/buildifier
 export BUILDOZER=$BUILD_ROOT/tools/bin/buildozer

--- a/tools/build/rules/android.bzl
+++ b/tools/build/rules/android.bzl
@@ -135,3 +135,30 @@ ndk_vk_validation_layer = repository_rule(
         "ANDROID_NDK_HOME",
     ],
 )
+
+# Enforce NDK version by checking $ANDROID_NDK_HOME/source.properties
+def _ndk_version_check(repository_ctx):
+    # This should be updated in sync with BUILDING.md documentation
+    version = "21.0.6113669"
+    sourcePropFile = repository_ctx.os.environ["ANDROID_NDK_HOME"] + "/source.properties"
+    sourceProp = repository_ctx.read(sourcePropFile)
+    if not ("Pkg.Revision = " + version) in sourceProp:
+        fail("NDK version mismatch: expected version " + version + " in file " + sourcePropFile)
+
+    build = """
+# Dummy rule
+cc_import(
+    name = "ndk_version_check",
+    visibility = ["//visibility:public"],
+)
+"""
+
+    repository_ctx.file("BUILD", build)
+
+ndk_version_check = repository_rule(
+    implementation = _ndk_version_check,
+    local = True,
+    environ = [
+        "ANDROID_NDK_HOME",
+    ]
+)

--- a/tools/build/rules/android.bzl
+++ b/tools/build/rules/android.bzl
@@ -139,20 +139,41 @@ ndk_vk_validation_layer = repository_rule(
 # Enforce NDK version by checking $ANDROID_NDK_HOME/source.properties
 def _ndk_version_check(repository_ctx):
     # This should be updated in sync with BUILDING.md documentation
-    version = "21.0.6113669"
+    expectedVersion = "21.0.6113669"
+
+    # Extract NDK version string from $ANDROID_NDK_HOME/source.properties,
+    # which has the following format:
+    #   Pkg.Desc = Android NDK
+    #   Pkg.Revision = 21.0.6113669
     sourcePropFile = repository_ctx.os.environ["ANDROID_NDK_HOME"] + "/source.properties"
     sourceProp = repository_ctx.read(sourcePropFile)
-    if not ("Pkg.Revision = " + version) in sourceProp:
-        fail("NDK version mismatch: expected version " + version + " in file " + sourcePropFile)
+    secondLine = sourceProp.split("\n")[1]
+    ndkVersion = secondLine.split(" ")[2]
 
+    # We want to fail only when Bazel tries to actually build a native target
+    # on Android, such that e.g. the presubmit check can pass without having
+    # to install the expected NDK version. To this aim, we create a rule to be
+    # used as a dependency in android_binary() rules. This rule fails when our
+    # check fails, and otherwise returns a CcInfo provider needed to be a
+    # valid dependency of android_binary().
+    ruleBody = "def _version_check(ctx):\n"
+    if ndkVersion != expectedVersion:
+        ruleBody += "    fail(\"Wrong NDK version: expected " + expectedVersion + ", got " + ndkVersion + "\")\n"
+    else:
+        ruleBody += "    return [CcInfo()]\n"
+    ruleBody += "\n"
+    ruleBody += "version_check = rule(implementation = _version_check)\n"
+    repository_ctx.file("version.bzl", ruleBody)
+
+    # Create a BUILD file to instanciate the rule.
     build = """
-# Dummy rule
-cc_import(
-    name = "ndk_version_check",
+load("//:version.bzl", "version_check")
+
+version_check(
+    name = "version_check",
     visibility = ["//visibility:public"],
 )
 """
-
     repository_ctx.file("BUILD", build)
 
 ndk_version_check = repository_rule(

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -16,7 +16,7 @@
 # dependencies and toolchains.
 
 load("@gapid//tools/build:cc_toolchain.bzl", "cc_configure")
-load("@gapid//tools/build/rules:android.bzl", "android_native_app_glue", "ndk_vk_validation_layer")
+load("@gapid//tools/build/rules:android.bzl", "android_native_app_glue", "ndk_vk_validation_layer", "ndk_version_check")
 load("@gapid//tools/build/rules:repository.bzl", "github_repository", "maybe_repository")
 load("@gapid//tools/build/third_party:breakpad.bzl", "breakpad")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
@@ -321,6 +321,12 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
         maybe_repository(
             ndk_vk_validation_layer,
             name = "ndk_vk_validation_layer",
+            locals = locals,
+        )
+
+        maybe_repository(
+            ndk_version_check,
+            name = "ndk_version_check",
             locals = locals,
         )
 


### PR DESCRIPTION
This makes sure we refuse to build with an invalid NDK version.

Bug: b/158669059