### PR TITLE
Set waitAll to true in vkWaitForFences.

### DIFF
--- a/cmd/vulkan_sample/main.cpp
+++ b/cmd/vulkan_sample/main.cpp
@@ -1572,7 +1572,7 @@ int main(int argc, const char** argv) {
                               VK_NULL_HANDLE, &next_image));
 
     REQUIRE_SUCCESS(vkWaitForFences(device, 1, &ready_fences[frame_parity],
-                                    false, static_cast<uint64_t>(-1)));
+                                    true, static_cast<uint64_t>(-1)));
     REQUIRE_SUCCESS(vkResetFences(device, 1, &ready_fences[frame_parity]));
 
     VkCommandBufferBeginInfo begin_info{


### PR DESCRIPTION
The current vulkan sample only waits for one fence at a time, hence it won't
make a difference to set waitAll to be true.

Bug: b/158633304
Test: bazel run gapit -- validate_gpu_profiling --os android