### PR TITLE
Fix the tree column rendering issues on OSX.

### DIFF
--- a/gapic/src/main/com/google/gapid/widgets/LinkifiedTree.java
+++ b/gapic/src/main/com/google/gapid/widgets/LinkifiedTree.java
@@ -377,10 +377,7 @@ public abstract class LinkifiedTree<T, F> extends Composite {
     protected void drawText(@SuppressWarnings("unused") T node, GC gc, Rectangle bounds,
         Label label, boolean ignoreColors) {
       updateLayout(label.string, ignoreColors);
-      Rectangle clip = gc.getClipping();
-      gc.setClipping(bounds);
       layout.draw(gc, bounds.x, bounds.y + (bounds.height - label.bounds.height) / 2);
-      gc.setClipping(clip);
     }
 
     private void drawFocus(Event event) {

--- a/gapic/src/main/com/google/gapid/widgets/LinkifiedTreeWithImages.java
+++ b/gapic/src/main/com/google/gapid/widgets/LinkifiedTreeWithImages.java
@@ -177,6 +177,7 @@ public abstract class LinkifiedTreeWithImages<T, F> extends LinkifiedTree<T, F> 
       }
 
       bounds.x += TEXT_START;
+      bounds.width -= TEXT_START;
       super.drawText(node, gc, bounds, label, ignoreColors);
     }
 


### PR DESCRIPTION
The clip was computed incorrectly, when an image was present. OSX allowed us to override the system clip, so rendering was done out of bounds. This change, 1) fixes the bounds computation, 2) gets rid of our own clip, as it's costly and not actually needed.