### PR TITLE
WIP:Add testing for ANGLE tracing

### DIFF
--- a/cmd/gapit/benchmark.go
+++ b/cmd/gapit/benchmark.go
@@ -792,7 +792,7 @@ func (verb *benchmarkVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 }
 
 // This intentionally duplicates a lot of the gapit trace logic
-// so that we can independently chnage how what we do to benchmark
+// so that we can independently change what we do to benchmark
 // everything.
 func (verb *benchmarkVerb) doTrace(ctx context.Context, client client.Client, traceURI string) error {
 	ctx = status.Start(ctx, "Record Trace for %+v frames", verb.NumFrames)

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -318,7 +318,7 @@ type (
 		No struct {
 			Buffer bool `help:"Do not buffer the output, this helps if the application crashes"`
 		}
-		API   string `help:"only capture the given API valid options are vulkan and perfetto"`
+		API   string `help:"only capture the given API valid options are vulkan, angle and perfetto"`
 		Local struct {
 			Port int `help:"connect to an application already running on the server using this port"`
 		}

--- a/cmd/gapit/trace.go
+++ b/cmd/gapit/trace.go
@@ -327,6 +327,12 @@ type apiAndType struct {
 
 func (verb *traceVerb) apiAndType() (apiAndType, error) {
 	switch verb.API {
+	case "angle":
+		return apiAndType{
+			service.TraceType_Graphics,
+			[]string{"OpenGL on ANGLE"},
+			".gfxtrace",
+		}, nil
 	case "vulkan":
 		return apiAndType{
 			service.TraceType_Graphics,

--- a/test/swarming/bot-scripts/video.py
+++ b/test/swarming/bot-scripts/video.py
@@ -42,6 +42,7 @@ def main():
         'startframe': '100',
         'numframes': '5',
         'observe_frames': '1',
+        'api': 'vulkan',
     }
     required_keys = ['apk', 'package', 'activity']
     botutil.load_params(test_params, required_keys=required_keys)
@@ -54,7 +55,7 @@ def main():
     gfxtrace = os.path.join(out_dir, test_params['package'] + '.gfxtrace')
     cmd = [
         gapit, 'trace',
-        '-api', 'vulkan',
+        '-api', test_params['api'],
         '-start-at-frame', test_params['startframe'],
         '-capture-frames', test_params['numframes'],
         '-observe-frames', test_params['observe_frames'],


### PR DESCRIPTION
Some code and comments related to updating test framework
to handle ANGLE testing.
This should just be a frame capture test where API is set
to "OpenGL on ANGLE." Flagged some key code areas and I'm
hopeful that there's a simple way to just set verb.API to
"angle" for an ANGLE test and that will handle ANGLE test
as a custom frame capture variation.