### PR TITLE
Default trace dialog title to system profile

### DIFF
--- a/gapic/src/main/com/google/gapid/util/Messages.java
+++ b/gapic/src/main/com/google/gapid/util/Messages.java
@@ -48,6 +48,7 @@ public interface Messages {
   public static final String MEMORY_STRUCT_TAB_TEXT = "Struct";
   public static final String CAPTURE_TRACE_GRAPHICS = "Capture Graphics Trace";
   public static final String CAPTURE_TRACE_PERFETTO = "Capture System Profile";
+  public static final String CAPTURE_TRACE_SELECT = "Capture: Select Trace Type";
   public static final String CAPTURING_TRACE = "Capturing...";
   public static final String CAPTURE_DIRECTORY = "Capture output directory...";
   public static final String CAPTURE_EXECUTABLE = "Executable to trace...";

--- a/gapic/src/main/com/google/gapid/util/Messages.java
+++ b/gapic/src/main/com/google/gapid/util/Messages.java
@@ -48,7 +48,7 @@ public interface Messages {
   public static final String MEMORY_STRUCT_TAB_TEXT = "Struct";
   public static final String CAPTURE_TRACE_GRAPHICS = "Capture Graphics Trace";
   public static final String CAPTURE_TRACE_PERFETTO = "Capture System Profile";
-  public static final String CAPTURE_TRACE_SELECT = "Capture: Select Trace Type";
+  public static final String CAPTURE_TRACE_DEFAULT = "Capture Trace";
   public static final String CAPTURING_TRACE = "Capturing...";
   public static final String CAPTURE_DIRECTORY = "Capture output directory...";
   public static final String CAPTURE_EXECUTABLE = "Executable to trace...";

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -228,7 +228,7 @@ public class TracerDialog {
 
     @Override
     public String getTitle() {
-      return Messages.CAPTURE_TRACE_GRAPHICS;
+      return Messages.CAPTURE_TRACE_PERFETTO;
     }
 
     @Override

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -228,7 +228,7 @@ public class TracerDialog {
 
     @Override
     public String getTitle() {
-      return Messages.CAPTURE_TRACE_SELECT;
+      return Messages.CAPTURE_TRACE_DEFAULT;
     }
 
     @Override

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -228,7 +228,7 @@ public class TracerDialog {
 
     @Override
     public String getTitle() {
-      return Messages.CAPTURE_TRACE_PERFETTO;
+      return Messages.CAPTURE_TRACE_SELECT;
     }
 
     @Override


### PR DESCRIPTION
As graphics capture are currently experimental, default to "System
Profile" in the trace dialog window title.

Related: see screenshot of bug in #340

Bug: b/159096531