### PR TITLE
Use GCC 8 on Windows builds

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -55,9 +55,9 @@ Using the msys64 shell (installed by choco at `C:\tools\msys64\mingw64`):
 1. Update MSYS with: `pacman -Syu`.
 2. If the update ends with “close the window and run it again”, close and reopen the window and repeat 1.
 3. Fetch required tools with: `pacman -S curl git zip unzip patch`
-4. Download gcc with: `curl -O http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-9.2.0-2-any.pkg.tar.xz`
-5. Download gcc-libs with: `curl -O http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-9.2.0-2-any.pkg.tar.xz`
-6. Install gcc with: `pacman -U mingw-w64-x86_64-gcc*-9.2.0-2-any.pkg.tar.xz`
+4. Download gcc with: `curl -O http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-8.3.0-2-any.pkg.tar.xz`
+5. Download gcc-libs with: `curl -O http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-8.3.0-2-any.pkg.tar.xz`
+6. Install gcc with: `pacman -U mingw-w64-x86_64-gcc*-8.3.0-2-any.pkg.tar.xz`
 7. Close the MSYS terminal
 
 ### Install Java Development Kit 11
@@ -153,6 +153,8 @@ tools/bin/sdkmanager platform-tools
 
 ### Install the XCode command line tools
 
+> AGI is known to compile with Xcode 11.3, which is the version used in our continuous integration.
+
 After installing, ensure the XCode license is signed with:
 
 ```
@@ -226,6 +228,8 @@ tools/bin/sdkmanager platform-tools
 sudo apt-get update
 sudo apt-get install mesa-common-dev libncurses5-dev libgl1-mesa-dev zlib1g-dev
 ```
+
+> C++ compiler: AGI is known to compile with gcc-8, which is the version used in our continuous integration.
 
 ### Configure the environment
 

--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -27,7 +27,7 @@ bash bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh --prefix=$PWD/bazel
 
 # Get GCC 8
 # We stick with GCC version 8 for now, as later version triggers a dependency on
-# a more recent GLIBC that is not present on e.g. Swarming bots.
+# GLIBCXX_3.4.26 or higher, which are not available on not-too-recent Linux (e.g. Swarming bots).
 # Make sure to reflect changes here in BUILDING.md documentation.
 sudo rm /etc/apt/sources.list.d/cuda.list*
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -26,6 +26,8 @@ mkdir bazel
 bash bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh --prefix=$PWD/bazel
 
 # Get GCC 8
+# We stick with GCC version 8 for now, as later version triggers a dependency on
+# a more recent GLIBC that is not present on e.g. Swarming bots.
 sudo rm /etc/apt/sources.list.d/cuda.list*
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get -q update

--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -28,6 +28,7 @@ bash bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh --prefix=$PWD/bazel
 # Get GCC 8
 # We stick with GCC version 8 for now, as later version triggers a dependency on
 # a more recent GLIBC that is not present on e.g. Swarming bots.
+# Make sure to reflect changes here in BUILDING.md documentation.
 sudo rm /etc/apt/sources.list.d/cuda.list*
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get -q update

--- a/kokoro/macos/build.sh
+++ b/kokoro/macos/build.sh
@@ -51,6 +51,7 @@ mkdir bazel
 sh bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh --prefix=$PWD/bazel
 
 # Specify the version of XCode
+# Make sure to reflect changes here in BUILDING.md documentation.
 export DEVELOPER_DIR=/Applications/Xcode_11.3.app/Contents/Developer
 
 cd $SRC

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -56,9 +56,9 @@ wget -q http://repo.msys2.org/msys/x86_64/patch-2.7.5-1-x86_64.pkg.tar.xz
 c:\tools\msys64\usr\bin\bash --login -c "pacman -v -U --noconfirm  /t/src/patch-2.7.5-1-x86_64.pkg.tar.xz"
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-binutils-2.33.1-1-any.pkg.tar.xz
 c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-binutils-2.33.1-1-any.pkg.tar.xz"
-wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-9.2.0-2-any.pkg.tar.xz
-wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-9.2.0-2-any.pkg.tar.xz
-c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-gcc-9.2.0-2-any.pkg.tar.xz /t/src/mingw-w64-x86_64-gcc-libs-9.2.0-2-any.pkg.tar.xz"
+wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-8.3.0-2-any.pkg.tar.xz
+wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-8.3.0-2-any.pkg.tar.xz
+c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-gcc-8.3.0-2-any.pkg.tar.xz /t/src/mingw-w64-x86_64-gcc-libs-8.3.0-2-any.pkg.tar.xz"
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-crt-git-8.0.0.5647.1fe2e62e-1-any.pkg.tar.xz
 c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-crt-git-8.0.0.5647.1fe2e62e-1-any.pkg.tar.xz"
 set PATH=c:\tools\msys64\mingw64\bin;c:\tools\msys64\usr\bin;%PATH%

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -57,6 +57,7 @@ c:\tools\msys64\usr\bin\bash --login -c "pacman -v -U --noconfirm  /t/src/patch-
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-binutils-2.33.1-1-any.pkg.tar.xz
 c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-binutils-2.33.1-1-any.pkg.tar.xz"
 REM Keep GCC major version in sync with one used in Linux builds, to minimize differences between platforms.
+REM Make sure to reflect changes here in BUILDING.md documentation.
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-8.3.0-2-any.pkg.tar.xz
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-8.3.0-2-any.pkg.tar.xz
 c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-gcc-8.3.0-2-any.pkg.tar.xz /t/src/mingw-w64-x86_64-gcc-libs-8.3.0-2-any.pkg.tar.xz"

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -56,6 +56,7 @@ wget -q http://repo.msys2.org/msys/x86_64/patch-2.7.5-1-x86_64.pkg.tar.xz
 c:\tools\msys64\usr\bin\bash --login -c "pacman -v -U --noconfirm  /t/src/patch-2.7.5-1-x86_64.pkg.tar.xz"
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-binutils-2.33.1-1-any.pkg.tar.xz
 c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-binutils-2.33.1-1-any.pkg.tar.xz"
+REM Keep GCC major version in sync with one used in Linux builds, to minimize differences between platforms.
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-8.3.0-2-any.pkg.tar.xz
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-8.3.0-2-any.pkg.tar.xz
 c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-gcc-8.3.0-2-any.pkg.tar.xz /t/src/mingw-w64-x86_64-gcc-libs-8.3.0-2-any.pkg.tar.xz"


### PR DESCRIPTION
This is to stay in sync with the version used in Linux builds.

Bug: b/157873397