### PR TITLE
Remove Graphics driver override.

### DIFF
--- a/core/os/android/adb/bind.go
+++ b/core/os/android/adb/bind.go
@@ -36,10 +36,8 @@ type Device interface {
 	Forward(ctx context.Context, local, device Port) error
 	// RemoveForward removes a port forward made by Forward.
 	RemoveForward(ctx context.Context, local Port) error
-	// GraphicsDriver queries and returns info on the preview graphics driver.
+	// GraphicsDriver queries and returns info about the prerelease graphics driver.
 	GraphicsDriver(ctx context.Context) (Driver, error)
-	// PrereleaseGraphicsDriver queries and returns info on the prerelease graphics driver.
-	PrereleaseGraphicsDriver(ctx context.Context) (Driver, error)
 }
 
 // Driver contains the information about a graphics driver.

--- a/gapii/client/adb.go
+++ b/gapii/client/adb.go
@@ -72,7 +72,7 @@ func Start(ctx context.Context, p *android.InstalledPackage, a *android.Activity
 		abi = p.Device.Instance().GetConfiguration().PreferredABI(nil)
 	}
 
-	driver, err := d.PrereleaseGraphicsDriver(ctx)
+	driver, err := d.GraphicsDriver(ctx)
 	if err != nil {
 		return nil, nil, log.Err(ctx, err, "Failed to locate pre-release driver package")
 	}


### PR DESCRIPTION
Previously we added an override to allow fast development and iteration
with partners, now that the integration is done, remove this hack.
Rationale: Graphics driver has special permission than other components,
for example application apk. Having a way to override this exposes some
security concerns and we will trap ourselves by having to do hacks in
order to make the namespace work properly.

Minor: Do not return the prerelease driver if it's preinstalled, because
it is empty.

Bug: b/148970509