### PR TITLE
Treat textures as naturally flipped.

### DIFF
--- a/gapic/src/main/com/google/gapid/views/TextureView.java
+++ b/gapic/src/main/com/google/gapid/views/TextureView.java
@@ -131,7 +131,7 @@ public class TextureView extends Composite
 
     Composite imageAndToolbar = createComposite(splitter, new GridLayout(2, false));
     ToolBar toolBar = new ToolBar(imageAndToolbar, SWT.VERTICAL | SWT.FLAT);
-    imagePanel = new ImagePanel(imageAndToolbar, View.Textures, models.analytics, widgets, false);
+    imagePanel = new ImagePanel(imageAndToolbar, View.Textures, models.analytics, widgets, true);
 
     splitter.setWeights(models.settings.getSplitterWeights(Settings.SplitterWeights.Textures));
     addListener(SWT.Dispose, e ->


### PR DESCRIPTION
This essentially changes the the expectations of the GAPIS API. Textures are now expected to be represented in the up-side-down Vulkan format.

Bug: http://b/159900736