### PR TITLE
Fix two draw command grouping bugs.

### DIFF
--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -238,6 +238,36 @@ func (API) ResolveSynchronization(ctx context.Context, d *sync.Data, c *path.Cap
 			d.SubcommandLookup.SetValue(nv, ref)
 			refs = append(refs, ref)
 
+			// Handle draw commands grouping.
+			cmdName := cb.CommandReferences().Get(uint32(i)).Type().String()
+			isDrawCmd := strings.HasPrefix(cmdName, "cmd_vkCmdDraw") || strings.HasPrefix(cmdName, "cmd_vkCmdDispatch")
+			isStateSettingCmd := (strings.HasPrefix(cmdName, "cmd_vkCmdSet") || strings.HasPrefix(cmdName, "cmd_vkCmdPush") ||
+				strings.HasPrefix(cmdName, "cmd_vkCmdBind")) && !strings.HasPrefix(cmdName, "cmd_vkCmdSetEvent")
+			if isStateSettingCmd && canStartDrawGrouping {
+				markerStack = append(markerStack,
+					&markerInfo{
+						name:   "State Setting Group",
+						ty:     DrawGroupMarker,
+						start:  uint64(i),
+						end:    uint64(i),
+						parent: append(api.SubCmdIdx{}, idx...),
+					})
+				canStartDrawGrouping = false
+			} else if isDrawCmd {
+				// When a group is complete with state setting cmds following a draw command, override the group name.
+				groupName := cmdName
+				if strings.HasPrefix(groupName, "cmd_vkCmd") { // Remove "cmd_vkCmd".
+					groupName = groupName[9:len(groupName)]
+				}
+				popMarkerWithNewGroupName(DrawGroupMarker, uint64(i), groupName)
+				canStartDrawGrouping = true
+			} else if !isStateSettingCmd && !isDrawCmd && !canStartDrawGrouping {
+				// Handle an edge case where a group of state setting commands are
+				// followed by something other than a drawing command.
+				popMarker(DrawGroupMarker, uint64(i-1), nCommands)
+				canStartDrawGrouping = true
+			}
+
 			// Handle extra command buffer reference, render pass grouping and debug marker grouping.
 			switch args := GetCommandArgs(ctx, cb.CommandReferences().Get(uint32(i)), st).(type) {
 			case VkCmdExecuteCommandsArgsʳ:
@@ -328,36 +358,6 @@ func (API) ResolveSynchronization(ctx context.Context, d *sync.Data, c *path.Cap
 				popMarker(DebugMarker, uint64(i), nCommands)
 			case VkCmdDebugMarkerEndEXTArgsʳ:
 				popMarker(DebugMarker, uint64(i), nCommands)
-			}
-
-			// Handle draw commands grouping.
-			cmdName := cb.CommandReferences().Get(uint32(i)).Type().String()
-			isDrawCmd := strings.HasPrefix(cmdName, "cmd_vkCmdDraw") || strings.HasPrefix(cmdName, "cmd_vkCmdDispatch")
-			isStateSettingCmd := (strings.HasPrefix(cmdName, "cmd_vkCmdSet") || strings.HasPrefix(cmdName, "cmd_vkCmdPush") ||
-				strings.HasPrefix(cmdName, "cmd_vkCmdBind")) && !strings.HasPrefix(cmdName, "cmd_vkCmdSetEvent")
-			if isStateSettingCmd && canStartDrawGrouping {
-				markerStack = append(markerStack,
-					&markerInfo{
-						name:   "State Setting Group",
-						ty:     DrawGroupMarker,
-						start:  uint64(i),
-						end:    uint64(i),
-						parent: append(api.SubCmdIdx{}, idx...),
-					})
-				canStartDrawGrouping = false
-			} else if isDrawCmd {
-				// When a group is complete with state setting cmds following a draw command, override the group name.
-				groupName := cmdName
-				if strings.HasPrefix(groupName, "cmd_vkCmd") { // Remove "cmd_vkCmd".
-					groupName = groupName[9:len(groupName)]
-				}
-				popMarkerWithNewGroupName(DrawGroupMarker, uint64(i), groupName)
-				canStartDrawGrouping = true
-			} else if !isStateSettingCmd && !isDrawCmd && !canStartDrawGrouping {
-				// Handle an edge case where a group of state setting commands are
-				// followed by something other than a drawing command.
-				popMarker(DrawGroupMarker, uint64(i), nCommands)
-				canStartDrawGrouping = true
 			}
 		}
 

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -253,7 +253,7 @@ func (API) ResolveSynchronization(ctx context.Context, d *sync.Data, c *path.Cap
 						parent: append(api.SubCmdIdx{}, idx...),
 					})
 				canStartDrawGrouping = false
-			} else if isDrawCmd {
+			} else if isDrawCmd && !canStartDrawGrouping {
 				// When a group is complete with state setting cmds following a draw command, override the group name.
 				groupName := cmdName
 				if strings.HasPrefix(groupName, "cmd_vkCmd") { // Remove "cmd_vkCmd".


### PR DESCRIPTION
- Fix wrong cmd nesting relationship between state setting cmds 
and renderpass cmds, when draw grouping get interrupted by 
renderpass/debugmarker grouping.
- Fix wrong cmd nesting for continuous draw commands scenario, 
which is resulted from extra stack popping.
- Bug: b/159466831.