### PR TITLE
Match replay device vulkan driver version with trace

### DIFF
--- a/gapic/src/main/com/google/gapid/models/Devices.java
+++ b/gapic/src/main/com/google/gapid/models/Devices.java
@@ -250,7 +250,7 @@ public class Devices {
   public static String getVulkanDriverVersions(Device.Instance dev) {
     StringBuilder version = new StringBuilder("N/A");
     VulkanDriver vkDriver = dev.getConfiguration().getDrivers().getVulkan();
-    Boolean first = true;
+    boolean first = true;
     for (int i = 0; i < vkDriver.getPhysicalDevicesCount(); i++) {
       if (first) {
         version.setLength(0);

--- a/gapic/src/main/com/google/gapid/models/Devices.java
+++ b/gapic/src/main/com/google/gapid/models/Devices.java
@@ -29,6 +29,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gapid.proto.SettingsProto;
 import com.google.gapid.proto.device.Device;
 import com.google.gapid.proto.device.Device.Instance;
+import com.google.gapid.proto.device.Device.VulkanDriver;
 import com.google.gapid.proto.service.Service;
 import com.google.gapid.proto.service.Service.Value;
 import com.google.gapid.proto.service.path.Path;
@@ -244,6 +245,15 @@ public class Devices {
 
   public void removeListener(Listener listener) {
     listeners.removeListener(listener);
+  }
+
+  public static String getVulkanDriverVersion(Device.Instance dev) {
+    String version = "N/A";
+    VulkanDriver vkDriver = dev.getConfiguration().getDrivers().getVulkan();
+    if (vkDriver.getPhysicalDevicesCount() > 0) {
+      version = Integer.toUnsignedString(vkDriver.getPhysicalDevices(0).getDriverVersion());
+    }
+    return version;
   }
 
   public static String getLabel(Device.Instance dev) {

--- a/gapic/src/main/com/google/gapid/models/Devices.java
+++ b/gapic/src/main/com/google/gapid/models/Devices.java
@@ -247,13 +247,20 @@ public class Devices {
     listeners.removeListener(listener);
   }
 
-  public static String getVulkanDriverVersion(Device.Instance dev) {
-    String version = "N/A";
+  public static String getVulkanDriverVersions(Device.Instance dev) {
+    StringBuilder version = new StringBuilder("N/A");
     VulkanDriver vkDriver = dev.getConfiguration().getDrivers().getVulkan();
-    if (vkDriver.getPhysicalDevicesCount() > 0) {
-      version = Integer.toUnsignedString(vkDriver.getPhysicalDevices(0).getDriverVersion());
+    Boolean first = true;
+    for (int i = 0; i < vkDriver.getPhysicalDevicesCount(); i++) {
+      if (first) {
+        version.setLength(0);
+        first = false;
+      } else {
+        version.append(", ");
+      }
+      version.append(Integer.toUnsignedString(vkDriver.getPhysicalDevices(0).getDriverVersion()));
     }
-    return version;
+    return version.toString();
   }
 
   public static String getLabel(Device.Instance dev) {

--- a/gapic/src/main/com/google/gapid/views/DeviceDialog.java
+++ b/gapic/src/main/com/google/gapid/views/DeviceDialog.java
@@ -175,7 +175,7 @@ public class DeviceDialog implements Devices.Listener, Capture.Listener {
       createLabel(composite, "Capture name: " + models.capture.getName());
       Instance dev = models.capture.getData().capture.getDevice();
       createLabel(composite,
-          "Capture device: " + Devices.getLabel(dev) + " (Vulkan driver version: " + Devices.getVulkanDriverVersion(dev) + ")");
+          "Capture device: " + Devices.getLabel(dev) + " (Vulkan driver version: " + Devices.getVulkanDriverVersions(dev) + ")");
 
       // Warning when no compatible device found
       noCompatibleDeviceFound = createLabel(composite, Messages.SELECT_DEVICE_NO_COMPATIBLE_FOUND);

--- a/gapic/src/main/com/google/gapid/views/DeviceDialog.java
+++ b/gapic/src/main/com/google/gapid/views/DeviceDialog.java
@@ -31,6 +31,7 @@ import com.google.gapid.models.Devices;
 import com.google.gapid.models.Devices.DeviceValidationResult;
 import com.google.gapid.models.Models;
 import com.google.gapid.proto.device.Device;
+import com.google.gapid.proto.device.Device.Instance;
 import com.google.gapid.rpc.Rpc;
 import com.google.gapid.rpc.RpcException;
 import com.google.gapid.rpc.SingleInFlight;
@@ -172,8 +173,9 @@ public class DeviceDialog implements Devices.Listener, Capture.Listener {
 
       // Recap capture info
       createLabel(composite, "Capture name: " + models.capture.getName());
+      Instance dev = models.capture.getData().capture.getDevice();
       createLabel(composite,
-          "Capture device: " + Devices.getLabel(models.capture.getData().capture.getDevice()));
+          "Capture device: " + Devices.getLabel(dev) + " (Vulkan driver version: " + Devices.getVulkanDriverVersion(dev) + ")");
 
       // Warning when no compatible device found
       noCompatibleDeviceFound = createLabel(composite, Messages.SELECT_DEVICE_NO_COMPATIBLE_FOUND);

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -80,7 +80,7 @@ func (a API) GetReplayPriority(ctx context.Context, i *device.Instance, h *captu
 		if len(traceVkDriver.GetPhysicalDevices()) == 0 {
 			return 1
 		}
-		// Requires same vendor, device and version of API.
+		// Requires same vendor, device, driver version and API version.
 		for _, devPhyInfo := range devVkDriver.GetPhysicalDevices() {
 			for _, tracePhyInfo := range traceVkDriver.GetPhysicalDevices() {
 				// TODO: More sophisticated rules
@@ -88,6 +88,9 @@ func (a API) GetReplayPriority(ctx context.Context, i *device.Instance, h *captu
 					continue
 				}
 				if devPhyInfo.GetDeviceId() != tracePhyInfo.GetDeviceId() {
+					continue
+				}
+				if devPhyInfo.GetDriverVersion() != tracePhyInfo.GetDriverVersion() {
 					continue
 				}
 				// Ignore the API patch level (bottom 12 bits) when comparing the API version.


### PR DESCRIPTION
Do not allow to replay on a device which reports a different Vulkan
driver version. Also, show the driver version in the replay device
selection dialog.

Bug: b/148563197