### PR TITLE
Migrate LUCI tools from lucy-py to luci-go

### DIFF
--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -114,8 +114,8 @@ export PATH="`pwd`/depot_tools:$PATH"
 # Note that the '${platform}' must appear as-is in the ensure file,
 # hence the single quotes.
 (
-  echo 'infra/tools/luci/isolate/${platform} git_revision:227ed2302d4b77f5a9823c223d5c1571b45dafd4'
-  echo 'infra/tools/luci/swarming/${platform} git_revision:227ed2302d4b77f5a9823c223d5c1571b45dafd4'
+  echo 'infra/tools/luci/isolate/${platform} git_revision:fe882fb29f1eaa8d1a4cfc77af4d11bcf7d59318'
+  echo 'infra/tools/luci/swarming/${platform} git_revision:fe882fb29f1eaa8d1a4cfc77af4d11bcf7d59318'
 ) > ${LUCI_ROOT}/ensure_file.txt
 cipd ensure -ensure-file ${LUCI_ROOT}/ensure_file.txt -root ${LUCI_ROOT}
 

--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -101,12 +101,23 @@ $SRC/kokoro/linux/package.sh $BUILD_ROOT/out
 ## Swarming tests, see test/swarming/README.md
 ##
 
-# Install LUCI
-curl -fsSL -o luci-py.tar.gz https://chromium.googlesource.com/infra/luci/luci-py.git/+archive/2128d8d9c36a0e2839afa200cf3da5e6f6ea845a.tar.gz
-mkdir luci-py
-tar xzf luci-py.tar.gz --directory luci-py
-export LUCI_CLIENT_ROOT="$PWD/luci-py/client"
+# "Swarming" is a tool from Chromium LUCI, install using the recommended CIPD
+# from depot_tool
+export LUCI_ROOT="`pwd`/luci"
+mkdir -p ${LUCI_ROOT}
 
+git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+export PATH="`pwd`/depot_tools:$PATH"
+
+# You can get valid git revision by looking up infra/tools/... at:
+# https://chrome-infra-packages.appspot.com/
+# Note that the '${platform}' must appear as-is in the ensure file,
+# hence the single quotes.
+(
+  echo 'infra/tools/luci/isolate/${platform} git_revision:227ed2302d4b77f5a9823c223d5c1571b45dafd4'
+  echo 'infra/tools/luci/swarming/${platform} git_revision:227ed2302d4b77f5a9823c223d5c1571b45dafd4'
+) > ${LUCI_ROOT}/ensure_file.txt
+cipd ensure -ensure-file ${LUCI_ROOT}/ensure_file.txt -root ${LUCI_ROOT}
 
 # Initialize some environment variables, unless they have already been set
 # (e.g. by build-nightly.sh)
@@ -118,7 +129,7 @@ if [ -z "${SWARMING_TASK_PREFIX}" ] ; then
   export SWARMING_TASK_PREFIX="Kokoro_PR${KOKORO_GITHUB_PULL_REQUEST_NUMBER}"
 fi
 
-export SWARMING_AUTH_FLAG="--auth-service-account-json=${KOKORO_KEYSTORE_DIR}/74894_kokoro_swarming_access_key"
+export SWARMING_AUTH_FLAG="--service-account-json=${KOKORO_KEYSTORE_DIR}/74894_kokoro_swarming_access_key"
 
 # Prepare Swarming files
 SWARMING_DIR=${SRC}/test/swarming

--- a/test/swarming/README.md
+++ b/test/swarming/README.md
@@ -31,10 +31,13 @@ running order is:
 
 Requirements:
 
-- LUCI tools installed, and the `LUCI_CLIENT_ROOT` environment variable set
-  accordingly.
+- LUCI `isolate` and `swarming` tools installed in a directory pointed at with
+the `LUCI_ROOT` environment variable. Search for "cipd" in
+`kokoro/linux/build.sh` to check how to install these tools using chromium's
+[CIPD](https://chromium.googlesource.com/chromium/src.git/+/master/docs/cipd.md).
 
-- valid Swarming/Isolate credentials.
+- valid Swarming/Isolate credentials: run `${LUCI_ROOT}/isolate login` to login,
+and `${LUCI_ROOT}/isolate whoami` to check your local credentials.
 
 You can trigger a Swarming test manually with:
 

--- a/test/swarming/trigger.py
+++ b/test/swarming/trigger.py
@@ -30,7 +30,7 @@ def main():
     args = parser.parse_args()
 
     #### Early checks and sanitization
-    assert 'LUCI_CLIENT_ROOT' in os.environ.keys()
+    assert 'LUCI_ROOT' in os.environ.keys()
     assert os.path.isdir(args.test_dir)
     test_dir = os.path.normpath(args.test_dir)
     prefix = ''
@@ -83,7 +83,7 @@ def main():
     if os.path.exists(isolated_file):
         os.remove(isolated_file)
     cmd = [
-        os.path.join(os.environ['LUCI_CLIENT_ROOT'], 'isolate.py'),
+        os.path.join(os.environ['LUCI_ROOT'], 'isolate'),
         'archive',
         '--isolate-server=https://chrome-isolated.appspot.com',
         '--isolate', isolate_file,
@@ -111,15 +111,15 @@ def main():
         if os.path.exists(task_json):
             os.remove(task_json)
         cmd = [
-            os.path.join(os.environ['LUCI_CLIENT_ROOT'], 'swarming.py'),
+            os.path.join(os.environ['LUCI_ROOT'], 'swarming'),
             'trigger',
-            '--swarming=https://chrome-swarming.appspot.com',
+            '--server=https://chrome-swarming.appspot.com',
             '--isolate-server=https://chrome-isolated.appspot.com',
             '--isolated', isolated_sha,
             '--task-name', swarming_params['task_name'],
             '--dump-json', task_json,
-            '--dimension', 'pool', 'SkiaInternal',
-            '--dimension', 'device_type', device,
+            '--dimension', 'pool=SkiaInternal',
+            '--dimension', 'device_type=' + device,
             '--priority', swarming_params['priority'],
             '--expiration', swarming_params['expiration'],
             '--hard-timeout', swarming_params['timeout'],


### PR DESCRIPTION
LUCI tools have been reimplemented in Go, and now only the Go version
is recommended. This update follows a request from the LUCI team.

Fetch the luci-go tools using CIPD, as recommended, and update various
flags to match the new tools.

Bug: b/159313821
Test: test/swarming/manual-run.sh