### PR TITLE
Fix wrong measurement of labels in CounterPanel.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
@@ -256,10 +256,10 @@ public class CounterPanel extends TrackPanel<CounterPanel> implements Selectable
 
       double leftLabel = Math.max(
           tm.measure(Fonts.Style.Normal, "Value:").w,
-          tm.measure(Fonts.Style.Normal, "Min:").w) + HOVER_PADDING;
-      double rightLabel = Math.max(
-          tm.measure(Fonts.Style.Normal, "Max:").w,
           tm.measure(Fonts.Style.Normal, "Avg:").w) + HOVER_PADDING;
+      double rightLabel = Math.max(
+          tm.measure(Fonts.Style.Normal, "Min:").w,
+          tm.measure(Fonts.Style.Normal, "Max:").w) + HOVER_PADDING;
       this.leftWidth = leftLabel + Math.max(valueSize.w, avgSize.w);
       this.size = new Size(leftWidth + HOVER_PADDING + rightLabel + Math.max(minSize.w, maxSize.w),
           Math.max(valueSize.h + avgSize.h, minSize.h + maxSize.h) + HOVER_PADDING);


### PR DESCRIPTION
The left labels of the CounterPanel hovered card are "Values:" and "Avg:", the
right labels are "Min:" and "Max:".

Bug: N/A