### PR TITLE
Move the hover card position to the left of the hover point.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/views/BatterySummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/BatterySummaryPanel.java
@@ -135,7 +135,10 @@ public class BatterySummaryPanel extends TrackPanel<BatterySummaryPanel> impleme
       // Draw hovered card.
       if (hovered != null) {
         double cardW = hovered.allSize.w + 3 * HOVER_PADDING + LEGEND_SIZE;
-        double cardX = Math.min(mouseXpos + HOVER_MARGIN, w - cardW);
+        double cardX = mouseXpos + CURSOR_SIZE / 2 + HOVER_MARGIN;
+        if (cardX >= w - cardW) {
+          cardX = mouseXpos - CURSOR_SIZE / 2 - HOVER_MARGIN - cardW;
+        }
         ctx.setBackgroundColor(colors().hoverBackground);
         ctx.fillRect(cardX, mouseYpos, cardW, hovered.allSize.h);
 
@@ -187,7 +190,18 @@ public class BatterySummaryPanel extends TrackPanel<BatterySummaryPanel> impleme
       @Override
       public Area getRedraw() {
         double redrawW = CURSOR_SIZE + HOVER_MARGIN + hovered.allSize.w + 3 * HOVER_PADDING + LEGEND_SIZE;
-        double redrawX = Math.min(mouseXpos - CURSOR_SIZE, state.getWidth() - redrawW);
+        double redrawX = mouseXpos - CURSOR_SIZE / 2;
+        if (redrawX >= state.getWidth() - redrawW) {
+          redrawX = mouseXpos + CURSOR_SIZE / 2.0 - redrawW;
+
+          // If the hover card is drawn on the left side of the hover point, when moving the mouse
+          // from left to right, the right edge of the cursor doesn't seem to get redrawn all the
+          // time, this looks like a precision issue. This also happens when cursor is now on the
+          // right side of the hover card, and the mouse moving from right to left there seems to
+          // be a precision issue on the right edge of the cursor, hence extend the redraw with by
+          // plusing the radius of the cursor.
+          redrawW += CURSOR_SIZE / 2;
+        }
         return new Area(redrawX, -TRACK_MARGIN, redrawW, HEIGHT + 2 * TRACK_MARGIN);
       }
 

--- a/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
@@ -138,7 +138,10 @@ public class CpuPanel extends TrackPanel<CpuPanel> implements Selectable {
       double mouseX = state.timeToPx(tStart + hovered.bucket * data.bucketSize + data.bucketSize / 2);
       double dx = HOVER_PADDING + hovered.size.w + HOVER_PADDING;
       double dy = HOVER_PADDING + hovered.size.h + HOVER_PADDING;
-      double cardX = Math.min(mouseX + HOVER_MARGIN, w - dx);
+      double cardX = mouseX + CURSOR_SIZE / 2 + HOVER_MARGIN;
+      if (cardX >= w - dx) {
+        cardX = mouseX - CURSOR_SIZE / 2 - HOVER_MARGIN - dx;
+      }
       ctx.setBackgroundColor(colors().hoverBackground);
       ctx.fillRect(cardX, h - HOVER_PADDING - dy, dx, dy);
       ctx.setForegroundColor(colors().textMain);
@@ -195,7 +198,10 @@ public class CpuPanel extends TrackPanel<CpuPanel> implements Selectable {
     }
 
     if (hoveredThread != null) {
-      double cardX = Math.min(mouseXpos + HOVER_MARGIN, w - (hoveredWidth + 2 * HOVER_PADDING));
+      double cardX = mouseXpos + HOVER_MARGIN;
+      if (cardX >= w - (hoveredWidth + 2 * HOVER_PADDING)) {
+        cardX = mouseXpos - HOVER_MARGIN - hoveredWidth - 2 * HOVER_PADDING;
+      }
       ctx.setBackgroundColor(colors().hoverBackground);
       ctx.fillRect(cardX, 0, hoveredWidth + 2 * HOVER_PADDING, h);
 
@@ -240,8 +246,11 @@ public class CpuPanel extends TrackPanel<CpuPanel> implements Selectable {
         return new Hover() {
           @Override
           public Area getRedraw() {
-            double redrawW = hoveredWidth + 2 * HOVER_PADDING;
-            double redrawX = Math.min(x + HOVER_MARGIN, state.getWidth() - redrawW);
+            double redrawW = HOVER_MARGIN + hoveredWidth + 2 * HOVER_PADDING;
+            double redrawX = x;
+            if (redrawX >= state.getWidth() - redrawW) {
+              redrawX = x - redrawW;
+            }
             return new Area(redrawX, 0, redrawW, HEIGHT);
           }
 
@@ -295,8 +304,12 @@ public class CpuPanel extends TrackPanel<CpuPanel> implements Selectable {
       @Override
       public Area getRedraw() {
         double redrawW = CURSOR_SIZE + HOVER_MARGIN + dx;
-        double redrawX = Math.min(mouseX - CURSOR_SIZE, state.getWidth() - redrawW);
-        return new Area(redrawX, -TRACK_MARGIN, CURSOR_SIZE + HOVER_MARGIN + dx, dy);
+        double redrawX = mouseX - CURSOR_SIZE / 2;
+        if (redrawX >= state.getWidth() - redrawW) {
+          redrawX = mouseX + CURSOR_SIZE / 2 - redrawW;
+          redrawW += CURSOR_SIZE / 2;
+        }
+        return new Area(redrawX, -TRACK_MARGIN, redrawW, dy);
       }
 
       @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/CpuSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CpuSummaryPanel.java
@@ -106,11 +106,14 @@ public class CpuSummaryPanel extends TrackPanel<CpuSummaryPanel> implements Sele
         double mouseX = state.timeToPx(tStart + hovered.bucket * data.bucketSize + data.bucketSize / 2);
         double dx = HOVER_PADDING + hovered.size.w + HOVER_PADDING;
         double dy = HOVER_PADDING + hovered.size.h + HOVER_PADDING;
-        double cardX = Math.min(mouseX, w - dx);
+        double cardX = mouseX + CURSOR_SIZE / 2 + HOVER_MARGIN;
+        if (cardX >= w - dx) {
+          cardX = mouseX - CURSOR_SIZE / 2 - HOVER_MARGIN - dx;
+        }
         ctx.setBackgroundColor(colors().hoverBackground);
-        ctx.fillRect(cardX + HOVER_MARGIN, h - HOVER_PADDING - dy, dx, dy);
+        ctx.fillRect(cardX, h - HOVER_PADDING - dy, dx, dy);
         ctx.setForegroundColor(colors().textMain);
-        ctx.drawText(Fonts.Style.Normal, hovered.text, cardX + HOVER_MARGIN + HOVER_PADDING, h - dy);
+        ctx.drawText(Fonts.Style.Normal, hovered.text, cardX + HOVER_PADDING, h - dy);
 
         ctx.setForegroundColor(colors().textMain);
         ctx.drawCircle(mouseX, h * (1 - hovered.utilization), CURSOR_SIZE / 2);
@@ -143,8 +146,16 @@ public class CpuSummaryPanel extends TrackPanel<CpuSummaryPanel> implements Sele
     return new Hover() {
       @Override
       public Area getRedraw() {
-        double redrawX = Math.min(mouseX - CURSOR_SIZE, state.getWidth() - dx);
-        return new Area(redrawX, -TRACK_MARGIN, CURSOR_SIZE + HOVER_MARGIN + dx, dy);
+        double redrawW = CURSOR_SIZE + HOVER_MARGIN + dx;
+        double redrawX = mouseX - CURSOR_SIZE / 2;
+        if (redrawX >= state.getWidth() - redrawW) {
+          redrawX = mouseX + CURSOR_SIZE / 2 - redrawW;
+          // If the hover card is drawn on the left side of the hover point, when moving the mouse
+          // from left to right, the right edge of the cursor doesn't seem to get redrawn all the
+          // time, this looks like a precision issue. Plus the radius of cursor here to avoid it.
+          redrawW += CURSOR_SIZE / 2;
+        }
+        return new Area(redrawX, -TRACK_MARGIN, redrawW, dy);
       }
 
       @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsPanel.java
@@ -157,7 +157,10 @@ public class FrameEventsPanel extends TrackPanel<FrameEventsPanel>
     }
 
     if (hoveredTitle != null) {
-      double cardX = Math.min(mouseXpos + HOVER_MARGIN, w - (hoveredSize.w + 2 * HOVER_PADDING));
+      double cardX = mouseXpos + HOVER_MARGIN;
+      if (cardX >= w - (hoveredSize.w + 2 * HOVER_PADDING)) {
+        cardX = mouseXpos - HOVER_MARGIN - hoveredSize.w - 2 * HOVER_PADDING;
+      }
       ctx.setBackgroundColor(colors().hoverBackground);
       ctx.fillRect(cardX, mouseYpos, hoveredSize.w + 2 * HOVER_PADDING, hoveredSize.h);
 
@@ -221,8 +224,11 @@ public class FrameEventsPanel extends TrackPanel<FrameEventsPanel>
         return new Hover() {
           @Override
           public Area getRedraw() {
-            double redrawW = hoveredSize.w + 2 * HOVER_PADDING;
-            double redrawX = Math.min(x + HOVER_MARGIN, state.getWidth() - redrawW);
+            double redrawW = HOVER_MARGIN + hoveredSize.w + 2 * HOVER_PADDING;
+            double redrawX = x;
+            if (redrawX >= state.getWidth() - redrawW) {
+              redrawX = x - redrawW;
+            }
             return new Area(redrawX, mouseYpos, redrawW, hoveredSize.h);
           }
 

--- a/gapic/src/main/com/google/gapid/perfetto/views/GpuQueuePanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/GpuQueuePanel.java
@@ -153,7 +153,10 @@ public class GpuQueuePanel extends TrackPanel<GpuQueuePanel> implements Selectab
 
       if (hoveredTitle != null) {
         double cardW = hoveredSize.w + 2 * HOVER_PADDING;
-        double cardX = Math.min(mouseXpos + HOVER_MARGIN, w - cardW);
+        double cardX = mouseXpos + HOVER_MARGIN;
+        if (cardX >= w - cardW) {
+          cardX = mouseXpos - HOVER_MARGIN - cardW;
+        }
         ctx.setBackgroundColor(colors().hoverBackground);
         ctx.fillRect(cardX, mouseYpos, cardW, hoveredSize.h);
 
@@ -214,9 +217,12 @@ public class GpuQueuePanel extends TrackPanel<GpuQueuePanel> implements Selectab
         return new Hover() {
           @Override
           public Area getRedraw() {
-            double redrawW = hoveredSize.w + 2 * HOVER_PADDING;
-            double redrawX = Math.min(x + HOVER_MARGIN, state.getWidth() - redrawW);
-            return new Area(redrawX, mouseYpos, hoveredSize.w + 2 * HOVER_PADDING, hoveredSize.h);
+            double redrawW = HOVER_MARGIN + hoveredSize.w + 2 * HOVER_PADDING;
+            double redrawX = x;
+            if (redrawX >= state.getWidth() - redrawW) {
+              redrawX = x - redrawW;
+            }
+            return new Area(redrawX, mouseYpos, redrawW, hoveredSize.h);
           }
 
           @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/MemorySummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/MemorySummaryPanel.java
@@ -143,7 +143,10 @@ public class MemorySummaryPanel extends TrackPanel<MemorySummaryPanel> implement
 
       if (hovered != null) {
         double cardW = hovered.allSize.w + 3 * HOVER_PADDING + LEGEND_SIZE;
-        double cardX = Math.min(mouseXpos + HOVER_MARGIN, w - cardW);
+        double cardX = mouseXpos + CURSOR_SIZE / 2 + HOVER_MARGIN;
+        if (cardX >= w - cardW) {
+          cardX = mouseXpos - CURSOR_SIZE / 2 - HOVER_MARGIN - cardW;
+        }
         ctx.setBackgroundColor(colors().hoverBackground);
         ctx.fillRect(cardX, mouseYpos, cardW, hovered.allSize.h);
 
@@ -201,7 +204,17 @@ public class MemorySummaryPanel extends TrackPanel<MemorySummaryPanel> implement
       @Override
       public Area getRedraw() {
         double redrawW = CURSOR_SIZE + HOVER_MARGIN + hovered.allSize.w + 3 * HOVER_PADDING + LEGEND_SIZE;
-        double redrawX = Math.min(mouseXpos - CURSOR_SIZE, state.getWidth() - redrawW);
+        double redrawX = mouseXpos - CURSOR_SIZE / 2;
+        if (redrawX >= state.getWidth() - redrawW) {
+          redrawX = mouseXpos + CURSOR_SIZE / 2 - redrawW;
+          // If the hover card is drawn on the left side of the hover point, when moving the mouse
+          // from left to right, the right edge of the cursor doesn't seem to get redrawn all the
+          // time, this looks like a precision issue. This also happens when cursor is now on the
+          // right side of the hover card, and the mouse moving from right to left there seems to
+          // be a precision issue on the right edge of the cursor, hence extend the redraw with by
+          // plusing the radius of the cursor.
+          redrawW += CURSOR_SIZE / 2;
+        }
         return new Area(redrawX, -TRACK_MARGIN, redrawW, HEIGHT + 2 * TRACK_MARGIN);
       }
 

--- a/gapic/src/main/com/google/gapid/perfetto/views/ProcessMemoryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/ProcessMemoryPanel.java
@@ -174,7 +174,10 @@ public class ProcessMemoryPanel extends TrackPanel<ProcessMemoryPanel> implement
 
       if (hovered != null) {
         double cardW = hovered.allSize.w + 3 * HOVER_PADDING + LEGEND_SIZE;
-        double cardX = Math.min(mouseXpos + HOVER_MARGIN, w - cardW);
+        double cardX = mouseXpos + CURSOR_SIZE / 2 + HOVER_MARGIN;
+        if (cardX >= w - cardW) {
+          cardX = mouseXpos - CURSOR_SIZE / 2 - HOVER_MARGIN - cardW;
+        }
         ctx.setBackgroundColor(colors().hoverBackground);
         ctx.fillRect(cardX, mouseYpos, cardW, hovered.allSize.h);
 
@@ -238,7 +241,17 @@ public class ProcessMemoryPanel extends TrackPanel<ProcessMemoryPanel> implement
       @Override
       public Area getRedraw() {
         double redrawW = CURSOR_SIZE + HOVER_MARGIN + hovered.allSize.w + 3 * HOVER_PADDING + LEGEND_SIZE;
-        double redrawX = Math.min(mouseXpos - CURSOR_SIZE, state.getWidth() - redrawW);
+        double redrawX = mouseXpos - CURSOR_SIZE / 2;
+        if (redrawX >= state.getWidth() - redrawW) {
+          redrawX = mouseXpos + CURSOR_SIZE / 2 - redrawW;
+          // If the hover card is drawn on the left side of the hover point, when moving the mouse
+          // from left to right, the right edge of the cursor doesn't seem to get redrawn all the
+          // time, this looks like a precision issue. This also happens when cursor is now on the
+          // right side of the hover card, and the mouse moving from right to left there seems to
+          // be a precision issue on the right edge of the cursor, hence extend the redraw with by
+          // plusing the radius of the cursor.
+          redrawW += CURSOR_SIZE / 2;
+        }
         return new Area(redrawX, -TRACK_MARGIN, redrawW, HEIGHT + 2 * TRACK_MARGIN);
       }
 

--- a/gapic/src/main/com/google/gapid/perfetto/views/ProcessSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/ProcessSummaryPanel.java
@@ -153,7 +153,10 @@ public class ProcessSummaryPanel extends TrackPanel<ProcessSummaryPanel> impleme
       double x = state.timeToPx(tStart + hovered.bucket * data.bucketSize + data.bucketSize / 2);
       double dx = HOVER_PADDING + hovered.size.w + HOVER_PADDING;
       double dy = HOVER_PADDING + hovered.size.h + HOVER_PADDING;
-      double cardX = Math.min(x + HOVER_MARGIN, w - dx);
+      double cardX = x + CURSOR_SIZE / 2 + HOVER_MARGIN;
+      if (cardX >= w - dx) {
+        cardX = x - CURSOR_SIZE / 2 - HOVER_MARGIN - dx;
+      }
       ctx.setBackgroundColor(colors().hoverBackground);
       ctx.fillRect(cardX, h - HOVER_PADDING - dy, dx, dy);
       ctx.setForegroundColor(colors().textMain);
@@ -199,7 +202,10 @@ public class ProcessSummaryPanel extends TrackPanel<ProcessSummaryPanel> impleme
     }
 
     if (hoveredThread != null) {
-      double cardX = Math.min(mouseXpos + HOVER_MARGIN, w - (hoveredWidth + 2 * HOVER_PADDING));
+      double cardX = mouseXpos + HOVER_MARGIN;
+      if (cardX >= w - (hoveredWidth + 2 * HOVER_PADDING)) {
+        cardX = mouseXpos - HOVER_MARGIN - hoveredWidth - 2 * HOVER_PADDING;
+      }
       ctx.setBackgroundColor(colors().hoverBackground);
       ctx.fillRect(cardX, 0, hoveredWidth + 2 * HOVER_PADDING, h);
 
@@ -252,8 +258,12 @@ public class ProcessSummaryPanel extends TrackPanel<ProcessSummaryPanel> impleme
         return new Hover() {
           @Override
           public Area getRedraw() {
-            double redrawW = hoveredWidth + 2 * HOVER_PADDING;
-            double redrawX = Math.min(x + HOVER_MARGIN, state.getWidth() - redrawW);
+            double redrawW = HOVER_MARGIN + hoveredWidth + 2 * HOVER_PADDING;
+            double redrawX = x;
+            if (redrawX >= state.getWidth() - redrawW) {
+              redrawX = x - redrawW;
+              // redrawW *= 2;
+            }
             return new Area(redrawX, 0, redrawW, HEIGHT);
           }
 
@@ -307,7 +317,18 @@ public class ProcessSummaryPanel extends TrackPanel<ProcessSummaryPanel> impleme
       @Override
       public Area getRedraw() {
         double redrawW = CURSOR_SIZE + HOVER_MARGIN + dx;
-        double redrawX = Math.min(mouseX - CURSOR_SIZE, state.getWidth() - redrawW);
+        double redrawX = mouseX - CURSOR_SIZE / 2;
+        if (redrawX >= state.getWidth() - redrawW) {
+          redrawX = mouseX + CURSOR_SIZE / 2 - redrawW;
+
+          // If the hover card is drawn on the left side of the hover point, when moving the mouse
+          // from left to right, the right edge of the cursor doesn't seem to get redrawn all the
+          // time, this looks like a precision issue. This also happens when cursor is now on the
+          // right side of the hover card, and the mouse moving from right to left there seems to
+          // be a precision issue on the right edge of the cursor, hence extend the redraw with by
+          // plusing the radius of the cursor.
+          redrawW += CURSOR_SIZE / 2;
+        }
         return new Area(redrawX, -TRACK_MARGIN, redrawW, dy);
       }
 

--- a/gapic/src/main/com/google/gapid/perfetto/views/ThreadPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/ThreadPanel.java
@@ -241,9 +241,12 @@ public class ThreadPanel extends TrackPanel<ThreadPanel> implements Selectable {
 
       if (hoveredTitle != null) {
         double cardW = hoveredSize.w + 2 * HOVER_PADDING;
-        double cardX = Math.min(mouseXpos + HOVER_MARGIN, w - cardW);
+        double cardX = mouseXpos + HOVER_MARGIN;
+        if (cardX >= w - cardW) {
+          cardX = mouseXpos - HOVER_MARGIN - cardW;
+        }
         ctx.setBackgroundColor(colors().hoverBackground);
-        ctx.fillRect(cardX, mouseYpos, hoveredSize.w + 2 * HOVER_PADDING, hoveredSize.h);
+        ctx.fillRect(cardX, mouseYpos, cardW, hoveredSize.h);
 
         ctx.setForegroundColor(colors().textMain);
         ctx.drawText(Fonts.Style.Normal, hoveredTitle, cardX + HOVER_PADDING,
@@ -283,8 +286,11 @@ public class ThreadPanel extends TrackPanel<ThreadPanel> implements Selectable {
           return new Hover() {
             @Override
             public Area getRedraw() {
-              double redrawW = hoveredSize.w + 2 * HOVER_PADDING;
-              double redrawX = Math.min(x + HOVER_MARGIN, state.getWidth() - redrawW);
+              double redrawW = HOVER_MARGIN + hoveredSize.w + 2 * HOVER_PADDING;
+              double redrawX = x;
+              if (redrawX >= state.getWidth() - redrawW) {
+                redrawX = x - redrawW;
+              }
               return new Area(redrawX, mouseYpos, redrawW, hoveredSize.h);
             }
 
@@ -352,8 +358,11 @@ public class ThreadPanel extends TrackPanel<ThreadPanel> implements Selectable {
           return new Hover() {
             @Override
             public Area getRedraw() {
-              double redrawW = hoveredSize.w + 2 * HOVER_PADDING;
-              double redrawX = Math.min(x + HOVER_MARGIN, state.getWidth() - redrawW);
+              double redrawW = HOVER_MARGIN + hoveredSize.w + 2 * HOVER_PADDING;
+              double redrawX = x;
+              if (redrawX >= state.getWidth() - redrawW) {
+                redrawX = x - redrawW;
+              }
               return new Area(redrawX, mouseYpos, redrawW, hoveredSize.h);
             }
 

--- a/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventPanel.java
@@ -139,7 +139,10 @@ public class VulkanEventPanel extends TrackPanel<VulkanEventPanel> implements Se
 
       if (hoveredName != null) {
         double cardW = hoveredSize.w + 2 * HOVER_PADDING;
-        double cardX = Math.min(mouseXpos + HOVER_MARGIN, w - cardW);
+        double cardX = mouseXpos + HOVER_MARGIN;
+        if (cardX >= w - cardW) {
+          cardX = mouseXpos - HOVER_MARGIN - cardW;
+        }
         ctx.setBackgroundColor(colors().hoverBackground);
         ctx.fillRect(cardX, mouseYpos, cardW, hoveredSize.h);
         ctx.setForegroundColor(colors().textMain);
@@ -176,8 +179,11 @@ public class VulkanEventPanel extends TrackPanel<VulkanEventPanel> implements Se
         return new Hover() {
           @Override
           public Area getRedraw() {
-            double redrawW = hoveredSize.w + 2 * HOVER_PADDING;
-            double redrawX = Math.min(x + HOVER_MARGIN, state.getWidth() - redrawW);
+            double redrawW = HOVER_MARGIN + hoveredSize.w + 2 * HOVER_PADDING;
+            double redrawX = x;
+            if (redrawX >= state.getWidth() - redrawW) {
+              redrawX = x - redrawW;
+            }
             return new Area(redrawX, mouseYpos, redrawW, hoveredSize.h);
           }
 


### PR DESCRIPTION
Previously when hover point moves towards to the right boundary of the window,
the hover card will stick on the right edge of the window which blocks the view
of the current hover point and hence the selection. This patch modifies the
position of the hover card and moves the position of the hover card to the left
side of the hover point.

Bug: b/158506210