### PR TITLE
Clean up GPU profiling integration with BSP drivers.

### DIFF
--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -437,8 +437,7 @@ type (
 
 	ValidateGpuProfilingFlags struct {
 		DeviceFlags
-		Gapis          GapisFlags
-		UseSystemImage bool `help:"If true then validate against the GPU profiling libraries in the system image."`
+		Gapis GapisFlags
 	}
 
 	PerfettoFlags struct {

--- a/cmd/gapit/validate_gpu_profiling.go
+++ b/cmd/gapit/validate_gpu_profiling.go
@@ -51,7 +51,7 @@ func (verb *validateGpuProfilingVerb) Run(ctx context.Context, flags flag.FlagSe
 	someDeviceFailed := false
 	for i, p := range devices {
 		fmt.Fprintf(stdout, "-- Device %v: %v --\n", i, p.ID.ID())
-		err = client.ValidateDevice(ctx, p, verb.UseSystemImage)
+		err = client.ValidateDevice(ctx, p)
 		if err != nil {
 			fmt.Fprintf(stdout, "%v\n", log.Err(ctx, err, "Failed to validate device"))
 			someDeviceFailed = true

--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -327,8 +327,7 @@ func (b *binding) QueryPerfettoServiceState(ctx context.Context) (*device.Perfet
 	result := b.To.Configuration.PerfettoCapability
 	if result == nil {
 		result = &device.PerfettoCapability{
-			SystemImageGpuProfiling: &device.GPUProfiling{},
-			GpuProfiling:            &device.GPUProfiling{},
+			GpuProfiling: &device.GPUProfiling{},
 		}
 	}
 
@@ -336,16 +335,11 @@ func (b *binding) QueryPerfettoServiceState(ctx context.Context) (*device.Perfet
 		return result, fmt.Errorf("Perfetto is not supported on this device")
 	}
 
-	if supported, _ := b.HasGpuProfilingSupportInSystemImage(ctx); supported {
-		gpu, err := b.QueryPerfettoGpuProfilingDataSources(ctx)
-		if err != nil {
-			return result, log.Errf(ctx, err, "Failed to query perfetto GPU profiling data sources.")
-		}
-		gpu.HasRenderStage = true
-		layerApk, _ := b.GetGpuProfilingLayerPackageName(ctx)
-		gpu.HasRenderStageProducerLayer = layerApk != ""
-		result.SystemImageGpuProfiling = gpu
+	gpu, err := b.QueryPerfettoGpuProfilingDataSources(ctx)
+	if err != nil {
+		return result, log.Errf(ctx, err, "Failed to query perfetto GPU profiling data sources.")
 	}
+	result.GpuProfiling = gpu
 
 	// SurfaceFlinger frame lifecycle perfetto producer is mandated by Android 11 CTS, hence it will
 	// always exist.

--- a/core/os/android/adb/device.go
+++ b/core/os/android/adb/device.go
@@ -52,10 +52,6 @@ var (
 	devInfoProviders      []DeviceInfoProvider
 	devInfoProvidersMutex sync.Mutex
 
-	// launchProducerProvider is called to launch perfetto producer.
-	launchProducerProvider      LaunchProducerProvider
-	launchProducerProviderMutex sync.Mutex
-
 	// cache is a map of device serials to fully resolved bindings.
 	cache      = map[string]*binding{}
 	cacheMutex sync.Mutex // Guards cache.
@@ -68,21 +64,12 @@ var (
 // Device.
 type DeviceInfoProvider func(ctx context.Context, d Device) error
 
-type LaunchProducerProvider func(ctx context.Context, d Device, useSystemImage bool) error
-
 // RegisterDeviceInfoProvider registers f to be called to add additional
 // information to a newly discovered Android device.
 func RegisterDeviceInfoProvider(f DeviceInfoProvider) {
 	devInfoProvidersMutex.Lock()
 	defer devInfoProvidersMutex.Unlock()
 	devInfoProviders = append(devInfoProviders, f)
-}
-
-// RegisterLaunchProducerProvider stores its argument as the LaunchProducerProvider to use.
-func RegisterLaunchProducerProvider(f LaunchProducerProvider) {
-	launchProducerProviderMutex.Lock()
-	defer launchProducerProviderMutex.Unlock()
-	launchProducerProvider = f
 }
 
 // Monitor updates the registry with devices that are added and removed at the
@@ -225,30 +212,9 @@ func newDevice(ctx context.Context, serial string, status bind.Status) (*binding
 		}
 	}
 
-	// Attempt to launch the perfetto GPU profiling producers from system image.
-	// Ignore error as it shouldn't prevent us from querying existing data sources.
-	hasSystemImageGpuProfilingSupport, _ := d.HasGpuProfilingSupportInSystemImage(ctx)
-	if hasSystemImageGpuProfilingSupport {
-		launchProducerProviderMutex.Lock()
-		launchProducerProvider(ctx, d, true)
-		launchProducerProviderMutex.Unlock()
-	}
-
 	// Query device Perfetto service state
 	if perfettoCapability, err := d.QueryPerfettoServiceState(ctx); err == nil {
 		d.To.Configuration.PerfettoCapability = perfettoCapability
-	}
-
-	// If there's prerelease driver package, attempt to query the perfetto GPU
-	// profiling producers from it.
-	if driver, err := d.GraphicsDriver(ctx); err == nil && driver.Package != "" {
-		launchProducerProviderMutex.Lock()
-		if err := launchProducerProvider(ctx, d, false); err == nil {
-			if gpuProfiling, err := d.QueryPerfettoGpuProfilingDataSources(ctx); err == nil {
-				d.To.Configuration.PerfettoCapability.GpuProfiling = gpuProfiling
-			}
-		}
-		launchProducerProviderMutex.Unlock()
 	}
 
 	// Query device ANGLE support
@@ -267,10 +233,6 @@ func newDevice(ctx context.Context, serial string, status bind.Status) (*binding
 				}
 			}
 			gpu := capability.GpuProfiling
-			if gpu == nil {
-				gpu = &device.GPUProfiling{}
-				capability.GpuProfiling = gpu
-			}
 			gpu.HasRenderStageProducerLayer = true
 			gpu.HasRenderStage = true
 			break

--- a/core/os/android/adb/device_test.go
+++ b/core/os/android/adb/device_test.go
@@ -45,10 +45,6 @@ func TestParseDevices(t_ *testing.T) {
 				Name: "flame",
 			},
 			ABIs: []*device.ABI{device.AndroidARM64v8a},
-			PerfettoCapability: &device.PerfettoCapability{
-				SystemImageGpuProfiling: &device.GPUProfiling{},
-				GpuProfiling:            &device.GPUProfiling{},
-			},
 		},
 	}
 	expected.GenID()

--- a/core/os/device/device.proto
+++ b/core/os/device/device.proto
@@ -187,7 +187,6 @@ message PerfettoCapability {
   VulkanProfilingLayers vulkan_profile_layers = 2;
   bool can_specify_atrace_apps = 3;
   bool hasFrameLifecycle = 4;
-  GPUProfiling system_image_gpu_profiling = 5;
 }
 
 message GPUProfiling {

--- a/gapic/src/main/com/google/gapid/server/Client.java
+++ b/gapic/src/main/com/google/gapid/server/Client.java
@@ -251,7 +251,6 @@ public class Client {
         stack -> MoreFutures.transformAsync(
             client.validateDevice(Service.ValidateDeviceRequest.newBuilder()
                 .setDevice(device)
-                .setUseSystemImage(false)
                 .build()),
             in -> immediateFuture(in)));
   }

--- a/gapidapk/deviceinfo.go
+++ b/gapidapk/deviceinfo.go
@@ -104,29 +104,51 @@ func fetchDeviceInfo(ctx context.Context, d adb.Device) error {
 	// Close any previous runs of the apk
 	apk.Stop(ctx)
 
-	driver, err := d.GraphicsDriver(ctx)
-	if err != nil {
-		return err
-	}
-
 	var cleanup app.Cleanup
 
-	// Set up device info service to use prerelease driver.
-	nextCleanup, err := adb.SetupPrereleaseDriver(ctx, d, apk.InstalledPackage)
-	cleanup = cleanup.Then(nextCleanup)
+	packages := []string{}
+	driver, err := d.GraphicsDriver(ctx)
 	if err != nil {
-		cleanup.Invoke(ctx)
-		return err
+		// If there's an error, keep going to attempt to use GPU profiling
+		// libraries in system image.
+		log.W(ctx, "Failed to query developer driver: %v, assuming no developer driver found.", err)
+	}
+	if driver.Package != "" {
+		log.I(ctx, "Using GPU profiling libraries from developer driver package: %v.", driver.Package)
+
+		// Set up device info service to use prerelease driver.
+		nextCleanup, err := adb.SetupPrereleaseDriver(ctx, d, apk.InstalledPackage)
+		cleanup = cleanup.Then(nextCleanup)
+		if err != nil {
+			cleanup.Invoke(ctx)
+			return err
+		}
+		packages = append(packages, driver.Package)
+	} else {
+		log.I(ctx, "No developer driver found, attempting to use GPU profiling libraries in system image.")
+		if supported, err := d.HasGpuProfilingSupportInSystemImage(ctx); err != nil || !supported {
+			cleanup.Invoke(ctx)
+			return log.Err(ctx, err, "No developer driver found, and no GPU profiling support found in system image.")
+		}
+		if vulkanLayerApk, err := d.GetGpuProfilingLayerPackageName(ctx); err == nil && vulkanLayerApk != "" {
+			packages = append(packages, vulkanLayerApk)
+		}
 	}
 
 	// Set driver package
-	nextCleanup, err = android.SetupLayers(ctx, d, apk.Name, []string{driver.Package}, []string{})
+	nextCleanup, err := android.SetupLayers(ctx, d, apk.Name, packages, []string{})
 	cleanup = cleanup.Then(nextCleanup)
 	if err != nil {
 		cleanup.Invoke(ctx)
 		return err
 	}
 	defer cleanup.Invoke(ctx)
+
+	if d.Instance().GetConfiguration().GetOS().GetAPIVersion() >= 29 {
+		if err := ensurePerfettoProducerLaunched(ctx, d); err != nil {
+			return err
+		}
+	}
 
 	// Make sure the device is available to query device info, this is to prevent
 	// Vulkan trace from happening at the same time than device info query.

--- a/gapis/client/client.go
+++ b/gapis/client/client.go
@@ -564,10 +564,9 @@ func (c *client) PerfettoQuery(ctx context.Context, capture *path.Capture, query
 	return res.GetResult(), nil
 }
 
-func (c *client) ValidateDevice(ctx context.Context, device *path.Device, useSystemImage bool) error {
+func (c *client) ValidateDevice(ctx context.Context, device *path.Device) error {
 	res, err := c.client.ValidateDevice(ctx, &service.ValidateDeviceRequest{
-		Device:         device,
-		UseSystemImage: useSystemImage,
+		Device: device,
 	})
 	if err != nil {
 		return err

--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -666,7 +666,7 @@ func (s *grpcServer) PerfettoQuery(ctx xctx.Context, req *service.PerfettoQueryR
 }
 
 func (s *grpcServer) ValidateDevice(ctx xctx.Context, req *service.ValidateDeviceRequest) (*service.ValidateDeviceResponse, error) {
-	err := s.handler.ValidateDevice(s.bindCtx(ctx), req.Device, req.UseSystemImage)
+	err := s.handler.ValidateDevice(s.bindCtx(ctx), req.Device)
 	if err := service.NewError(err); err != nil {
 		return &service.ValidateDeviceResponse{Error: err}, nil
 	}

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -950,9 +950,9 @@ func (s *server) PerfettoQuery(ctx context.Context, c *path.Capture, query strin
 	return res, nil
 }
 
-func (s *server) ValidateDevice(ctx context.Context, d *path.Device, useSystemImage bool) error {
+func (s *server) ValidateDevice(ctx context.Context, d *path.Device) error {
 	ctx = status.Start(ctx, "RPC ValidateDevice")
 	defer status.Finish(ctx)
 	ctx = log.Enter(ctx, "ValidateDevice")
-	return trace.Validate(ctx, d, useSystemImage)
+	return trace.Validate(ctx, d)
 }

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -182,7 +182,7 @@ type Service interface {
 
 	// ValidateDevice validates the GPU profiling capabilities of the given device and returns
 	// an error if validation failed or the GPU profiling data is invalid.
-	ValidateDevice(ctx context.Context, d *path.Device, useSystemImage bool) error
+	ValidateDevice(ctx context.Context, d *path.Device) error
 }
 
 type TraceHandler interface {

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -737,7 +737,6 @@ service Gapid {
 
 message ValidateDeviceRequest {
   path.Device device = 1;
-  bool use_system_image = 2;
 }
 
 message ValidateDeviceResponse {
@@ -1143,8 +1142,6 @@ message TraceOptions {
   bool disable_coherent_memory_tracker = 25;
   // The config to use if doing a Perfetto trace.
   perfetto.protos.TraceConfig perfetto_config = 24;
-  // Whether to use GPU profiling libraries from the system image.
-  bool use_system_image_gpu_profiling = 26;
 }
 
 enum TraceEvent {

--- a/gapis/trace/desktop/trace.go
+++ b/gapis/trace/desktop/trace.go
@@ -55,7 +55,7 @@ func (t *DesktopTracer) ProcessProfilingData(ctx context.Context, buffer *bytes.
 	return nil, log.Err(ctx, nil, "Desktop replay profiling is unsupported.")
 }
 
-func (t *DesktopTracer) Validate(ctx context.Context, useSystemImage bool) error {
+func (t *DesktopTracer) Validate(ctx context.Context) error {
 	return nil
 }
 

--- a/gapis/trace/trace.go
+++ b/gapis/trace/trace.go
@@ -115,12 +115,12 @@ func ProcessProfilingData(ctx context.Context, device *path.Device, capture *pat
 	return t.ProcessProfilingData(ctx, buffer, capture, handleMapping, syncData)
 }
 
-func Validate(ctx context.Context, device *path.Device, useSystemImage bool) error {
+func Validate(ctx context.Context, device *path.Device) error {
 	t, err := GetTracer(ctx, device)
 	if err != nil {
 		return err
 	}
-	return t.Validate(ctx, useSystemImage)
+	return t.Validate(ctx)
 }
 
 func GetTracer(ctx context.Context, device *path.Device) (tracer.Tracer, error) {

--- a/gapis/trace/tracer/tracer.go
+++ b/gapis/trace/tracer/tracer.go
@@ -77,7 +77,7 @@ type Tracer interface {
 	ProcessProfilingData(ctx context.Context, buffer *bytes.Buffer, capture *path.Capture, handleMapping *map[uint64][]service.VulkanHandleMappingItem, syncData *sync.Data) (*service.ProfilingData, error)
 	// Validate validates the GPU profiling capabilities of the given device and returns
 	// an error if validation failed or the GPU profiling data is invalid.
-	Validate(ctx context.Context, useSystemImage bool) error
+	Validate(ctx context.Context) error
 }
 
 // LayersFromOptions Parses the perfetto options, and returns the required layers


### PR DESCRIPTION
Instead of trying to provide an option to profile against system driver, AGI
should always query and use the latest available drivers on the device. When
developer driver is present, AGI will always try to set up and use it, and when
fail to do so, fall back to use GPU profiling libraries in system image. If
developer driver is not installed or the device doesn't support developer
driver, always attempt to use GPU profiling libraries in system image.

Bug: b/148970509
Test: Perform below commands on supported devices.
Test: bazel run gapit -- device --os android
Test: bazel run gapit -- validate_gpu_profiling --os android