### PR TITLE
Show a better error message on trace parse error.

### DIFF
--- a/core/data/pack/dynamic.go
+++ b/core/data/pack/dynamic.go
@@ -59,8 +59,14 @@ func (d Dynamic) Format(f fmt.State, r rune) {
 				fields = append(fields, fmt.Sprintf("%v%v", v, suffix))
 			}
 		}
+		// TODO: we should sort the fields before formatting, so that we can exit out early, as soon
+		// as the requested number of chars has been reached.
 		sort.Strings(fields)
-		fmt.Fprintf(f, "%vᵈ{%s}", d.Desc.GetName(), strings.Join(fields, ", "))
+		joined := strings.Join(fields, ", ")
+		if width, hasWidth := f.Width(); hasWidth && len(joined) > width {
+			joined = joined[0:width] + "..."
+		}
+		fmt.Fprintf(f, "%vᵈ{%s}", d.Desc.GetName(), joined)
 	}
 }
 

--- a/gapis/capture/decoder.go
+++ b/gapis/capture/decoder.go
@@ -165,7 +165,7 @@ func (d *decoder) add(ctx context.Context, child, parent interface{}) error {
 		case api.State:
 			return d.builder.addInitialState(ctx, obj)
 		default:
-			return fmt.Errorf("We do not expect a %T as a child of an initial state: %+v", obj, obj)
+			return fmt.Errorf("We do not expect a %T as a child of an initial state: %+200v", obj, obj)
 		}
 	}
 	return nil


### PR DESCRIPTION
If the capture load fails due to a proto conversion error, which can happen when loading a malformed or outdated capture, this will show a nicer message to the user rather than the low level proto conversion
error message.

http://b/155771026