### PR TITLE
Avoid "Viewing full screen" notifications

### DIFF
--- a/test/swarming/bot-harness.py
+++ b/test/swarming/bot-harness.py
@@ -89,6 +89,8 @@ def main():
     botutil.adb(['shell', 'settings', 'put', 'system', 'screen_brightness', '0'])
     # Make sure to have the screen "stay awake" during the test, we turn off the screen ourselves at the end
     botutil.adb(['shell', 'settings', 'put', 'global', 'stay_on_while_plugged_in', '7'])
+    # Avoid "Viewing full screen" notifications that makes app loose focus
+    botutil.adb(['shell', 'settings', 'put', 'secure', 'immersive_mode_confirmations', 'confirmed'])
     # Remove any implicit vulkan layers
     botutil.adb(['shell', 'settings', 'delete', 'global', 'enable_gpu_debug_layers'])
     botutil.adb(['shell', 'settings', 'delete', 'global', 'gpu_debug_app'])


### PR DESCRIPTION
Swarming devices typiclaly have fresh Android installs with all the
first-time-use warnings. Some swarming tests seemed to fail due to the
app loosing focus because of a "Viewing full screen" notification
taking over and waiting for user input. This change makes sure to
disable this notification when preparing the device.

Bug: b/161212931
Test: using test/swarming/manual-run.sh