### PR TITLE
Give informative message when there's no available geometry.

### DIFF
--- a/gapic/src/main/com/google/gapid/models/Geometries.java
+++ b/gapic/src/main/com/google/gapid/models/Geometries.java
@@ -141,8 +141,7 @@ public class Geometries
       return success(result.get());
     } catch (DataUnavailableException e) {
       DeviceDependentModel.Source<Source> s = getSource();
-      // TODO: don't assume that it's because of not selecting a draw call.
-      return success(new Data(s.device, s.source.semantics, null, null));
+      return error(Loadable.Message.error(e));
     } catch (RpcException e) {
       LOG.log(WARNING, "Failed to load the geometry", e);
       return error(Loadable.Message.error(e));

--- a/gapic/src/main/com/google/gapid/util/Messages.java
+++ b/gapic/src/main/com/google/gapid/util/Messages.java
@@ -33,6 +33,7 @@ public interface Messages {
   public static final String SELECT_SHADER = "Select a shader.";
   public static final String SELECT_PROGRAM = "Select a program.";
   public static final String NO_IMAGE_DATA = "No image data available at this point in the trace.";
+  public static final String NO_MESH_DATA = "No mesh data available at this point in the trace.";
   public static final String NO_TEXTURES = "No textures have been created by this point.";
   public static final String VIEW_DETAILS = "View Details";
   public static final String LICENSES = "Licenses";

--- a/gapic/src/main/com/google/gapid/views/GeometryView.java
+++ b/gapic/src/main/com/google/gapid/views/GeometryView.java
@@ -292,9 +292,8 @@ public class GeometryView extends Composite
     }
 
     Geometries.Data meshes = models.geos.getData();
-    if (!meshes.hasFaceted()) {
-      loading.showMessage(Info, Messages.SELECT_DRAW_CALL);
-      // ?? saveItem.setEnabled(false);
+    if (!meshes.hasOriginal() && !meshes.hasFaceted()) {
+      loading.showMessage(Info, Messages.NO_MESH_DATA);
       return;
     }
 


### PR DESCRIPTION
 - Fix a server exception hiding problem inside geometry view.
   (We have better server error visualization inside gapic now.)
 - Fix an early return logic, to allow showing original geometry
   mesh, when there's only original but no faceted geometry mesh.
 - Bug: b/159016023.