### PR TITLE
Increase the range to search for the Perfetto marker.

### DIFF
--- a/gapis/capture/perfetto.go
+++ b/gapis/capture/perfetto.go
@@ -31,7 +31,7 @@ import (
 const (
 	// maxSearchBytes is the maximum number of bytes at the beginning of the
 	// file to search for the Perfetto magic UUID.
-	maxSearchBytes = 256
+	maxSearchBytes = 4096
 )
 
 // perfettoUUID is the magic UUID found near the beginning of a Perfetto trace.


### PR DESCRIPTION
We've seen traces where the Perfetto UUID shows up a bit later in the trace. Increasing it to a full page should not hurt much and should be more than enough.

Bug: http://b/161355914