### PR TITLE
Fix sType for VkMemoryAllocateFlagsInfo

### DIFF
--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -1110,7 +1110,7 @@ func (sb *stateBuilder) createDeviceMemory(mem DeviceMemoryObjectʳ, allowDedica
 		flags := mem.MemoryAllocateFlagsInfo()
 		pNext = NewVoidᶜᵖ(sb.MustAllocReadData(
 			NewVkMemoryAllocateFlagsInfo(sb.ta,
-				VkStructureType_VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+				VkStructureType_VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO,
 				pNext,              // pNext
 				flags.Flags(),      // flags
 				flags.DeviceMask(), // deviceMask


### PR DESCRIPTION
sType must be VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO
https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryAllocateFlagsInfo.html