### PR TITLE
Better horizontal scrolling in the system profiler.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/views/StyleConstants.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/StyleConstants.java
@@ -51,6 +51,10 @@ public class StyleConstants {
   public static final double KB_ZOOM_SLOW = 2 * ZOOM_FACTOR_SCALE;
   public static final double KB_ZOOM_FAST = 3 * ZOOM_FACTOR_SCALE;
 
+  // Touchpad handling constants.
+  public static final int TP_PAN_SLOW = 30;
+  public static final int TP_PAN_FAST = 60;
+
   public static class Colors {
     public final RGBA background;
     public final RGBA titleBackground;

--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceComposite.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceComposite.java
@@ -21,6 +21,8 @@ import static com.google.gapid.perfetto.views.StyleConstants.KB_PAN_FAST;
 import static com.google.gapid.perfetto.views.StyleConstants.KB_PAN_SLOW;
 import static com.google.gapid.perfetto.views.StyleConstants.KB_ZOOM_FAST;
 import static com.google.gapid.perfetto.views.StyleConstants.KB_ZOOM_SLOW;
+import static com.google.gapid.perfetto.views.StyleConstants.TP_PAN_FAST;
+import static com.google.gapid.perfetto.views.StyleConstants.TP_PAN_SLOW;
 import static com.google.gapid.perfetto.views.StyleConstants.ZOOM_FACTOR_SCALE;
 import static com.google.gapid.widgets.Widgets.createButtonWithImage;
 import static com.google.gapid.widgets.Widgets.createLabel;
@@ -82,9 +84,17 @@ public abstract class TraceComposite<S extends State> extends Composite implemen
       }
     });
     canvas.addListener(SWT.MouseHorizontalWheel, e -> {
-      if ((e.stateMask & SWT.MODIFIER_MASK) == SWT.MOD1) {
-        // Ignore horizontal scroll, only when zooming.
-        e.doit = false;
+      int mods = e.stateMask & SWT.MODIFIER_MASK;
+      // Treat horizontal touch pad/scroll wheel ourselves, rather than going through the
+      // scrollbar, since the scrollbar's size is limited.
+      e.doit = false;
+      if (mods == SWT.MOD1) {
+        // Ignore horizontal scroll, when zooming.
+      } else {
+        if (state.dragX(
+            state.getVisibleTime(), e.count * ((mods == SWT.SHIFT) ? TP_PAN_FAST : TP_PAN_SLOW))) {
+          canvas.redraw(Area.FULL, true);
+        }
       }
     });
     canvas.addListener(SWT.Gesture, this::handleGesture);


### PR DESCRIPTION
When the scrolling is done via the touch pad or mouse wheel, handle it ourselves, rather than going via the scrollbar. The scrollbar size is limited, and thus when zoomed in, the scroll accuracy is limited and leads to scrolling too fast/far. We can scroll better by handling it directly if the event comes from the touch pad or mouse wheel.

Bug: http://b/160731902