### PR TITLE
Geometry View Fixes

### DIFF
--- a/gapic/src/main/com/google/gapid/models/Geometries.java
+++ b/gapic/src/main/com/google/gapid/models/Geometries.java
@@ -38,6 +38,7 @@ import com.google.gapid.rpc.RpcException;
 import com.google.gapid.rpc.UiErrorCallback.ResultOrError;
 import com.google.gapid.server.Client;
 import com.google.gapid.server.Client.DataUnavailableException;
+import com.google.gapid.server.Client.InvalidArgumentException;
 import com.google.gapid.util.Events;
 import com.google.gapid.util.Loadable;
 import com.google.gapid.util.MoreFutures;
@@ -200,7 +201,7 @@ public class Geometries
     API.DrawPrimitive primitive = mesh.getDrawPrimitive();
     if (positions == null || (normals == null && isPolygon(primitive))) {
       return Futures.immediateFailedFuture(
-          new DataUnavailableException(NO_MESH_ERR, new Client.Stack(() -> "")));
+          new InvalidArgumentException(NO_MESH_ERR, new Client.Stack(() -> "")));
     }
 
     int[] indices = mesh.getIndexBuffer().getIndicesList().stream().mapToInt(x -> x).toArray();

--- a/gapic/src/main/com/google/gapid/views/GeometryView.java
+++ b/gapic/src/main/com/google/gapid/views/GeometryView.java
@@ -279,6 +279,7 @@ public class GeometryView extends Composite
       originalModelItem.setEnabled(false);
       facetedModelItem.setEnabled(false);
       saveItem.setEnabled(false);
+      statusBar.setText("");
     }
   }
 
@@ -294,7 +295,6 @@ public class GeometryView extends Composite
     Geometries.Data meshes = models.geos.getData();
     if (!meshes.hasFaceted()) {
       loading.showMessage(Info, Messages.SELECT_DRAW_CALL);
-      // ?? saveItem.setEnabled(false);
       return;
     }
 

--- a/gapis/api/mesh.go
+++ b/gapis/api/mesh.go
@@ -17,6 +17,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/google/gapid/core/data/endian"
@@ -29,10 +30,15 @@ import (
 	"github.com/google/gapid/gapis/vertex"
 )
 
+var (
+	// ErrMeshNotAvailable is an error returned by MeshProvider if a mesh is
+	// requested on an object that does not have a mesh (e.g. non-draw call).
+	ErrMeshNotAvailable = errors.New("Mesh not available at this command")
+)
+
 // MeshProvider is the interface implemented by types that provide meshes.
 type MeshProvider interface {
 	// Mesh returns the mesh representation of the object o.
-	// If nil, nil then the object cannot be represented as a mesh.
 	Mesh(ctx context.Context, o interface{}, p *path.Mesh, r *path.ResolveConfig) (*Mesh, error)
 }
 

--- a/gapis/api/vulkan/draw_call_mesh.go
+++ b/gapis/api/vulkan/draw_call_mesh.go
@@ -35,6 +35,15 @@ func drawCallMesh(ctx context.Context, dc *VkQueueSubmit, p *path.Mesh, r *path.
 		return nil, nil
 	}
 
+	cmd, err := resolve.Cmd(ctx, cmdPath, r)
+	if err != nil {
+		return nil, err
+	}
+
+	if !cmd.CmdFlags().IsExecutedDraw() {
+		return nil, nil
+	}
+
 	s, err := resolve.GlobalState(ctx, cmdPath.GlobalStateAfter(), r)
 	if err != nil {
 		return nil, err

--- a/gapis/api/vulkan/draw_call_mesh.go
+++ b/gapis/api/vulkan/draw_call_mesh.go
@@ -32,7 +32,7 @@ func drawCallMesh(ctx context.Context, dc *VkQueueSubmit, p *path.Mesh, r *path.
 	cmdPath := path.FindCommand(p)
 	if cmdPath == nil {
 		log.W(ctx, "Couldn't find command at path '%v'", p)
-		return nil, nil
+		return nil, api.ErrMeshNotAvailable
 	}
 
 	cmd, err := resolve.Cmd(ctx, cmdPath, r)
@@ -41,7 +41,7 @@ func drawCallMesh(ctx context.Context, dc *VkQueueSubmit, p *path.Mesh, r *path.
 	}
 
 	if !cmd.CmdFlags().IsExecutedDraw() {
-		return nil, nil
+		return nil, api.ErrMeshNotAvailable
 	}
 
 	s, err := resolve.GlobalState(ctx, cmdPath.GlobalStateAfter(), r)

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -26,9 +26,7 @@ import (
 	"github.com/google/gapid/gapis/api/sync"
 	"github.com/google/gapid/gapis/api/transform"
 	"github.com/google/gapid/gapis/capture"
-	"github.com/google/gapid/gapis/messages"
 	"github.com/google/gapid/gapis/resolve"
-	"github.com/google/gapid/gapis/service"
 	"github.com/google/gapid/gapis/service/path"
 )
 
@@ -140,7 +138,7 @@ func (API) Mesh(ctx context.Context, o interface{}, p *path.Mesh, r *path.Resolv
 	case *VkQueueSubmit:
 		return drawCallMesh(ctx, dc, p, r)
 	}
-	return nil, &service.ErrDataUnavailable{Reason: messages.ErrMeshNotAvailable()}
+	return nil, nil
 }
 
 type MarkerType int

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -138,7 +138,7 @@ func (API) Mesh(ctx context.Context, o interface{}, p *path.Mesh, r *path.Resolv
 	case *VkQueueSubmit:
 		return drawCallMesh(ctx, dc, p, r)
 	}
-	return nil, nil
+	return nil, api.ErrMeshNotAvailable
 }
 
 type MarkerType int

--- a/gapis/resolve/mesh.go
+++ b/gapis/resolve/mesh.go
@@ -30,15 +30,10 @@ func Mesh(ctx context.Context, p *path.Mesh, r *path.ResolveConfig) (*api.Mesh, 
 	if err != nil {
 		return nil, err
 	}
-	mesh, err := meshFor(ctx, obj, p, r)
-	switch {
-	case err != nil:
-		return nil, err
-	case mesh != nil:
-		return mesh, nil
-	default:
-		return nil, &service.ErrDataUnavailable{Reason: messages.ErrMeshNotAvailable()}
+	if mesh, err := meshFor(ctx, obj, p, r); err != api.ErrMeshNotAvailable {
+		return mesh, err
 	}
+	return nil, &service.ErrDataUnavailable{Reason: messages.ErrMeshNotAvailable()}
 }
 
 func meshFor(ctx context.Context, o interface{}, p *path.Mesh, r *path.ResolveConfig) (*api.Mesh, error) {
@@ -71,7 +66,7 @@ func meshFor(ctx context.Context, o interface{}, p *path.Mesh, r *path.ResolveCo
 		for i := o.Commands.To[lastSubcommand]; i >= o.Commands.From[lastSubcommand]; i-- {
 			cmd[lastSubcommand] = i
 			p := o.Commands.Capture.Command(cmd[0], cmd[1:]...).Mesh(p.Options)
-			if mesh, err := meshFor(ctx, cmds[o.Commands.From[0]], p, r); mesh != nil || err != nil {
+			if mesh, err := meshFor(ctx, cmds[o.Commands.From[0]], p, r); err != api.ErrMeshNotAvailable {
 				return mesh, err
 			}
 		}


### PR DESCRIPTION
- Fixes how we communicate in Vulkan whether a mesh is available at a requested command/sub-command.
- Does some refactoring to make it more obvious how to communicate mesh un-availability
- Verifies that we are on a draw call inside a queue submit (this is inspired from PR #378)
- Fixes the UI to show a proper error if the mesh is empty
- Resets the UI's status bar so that it doesn't keep showing the stats from the last successfully loaded model

Bug: http://b/159016023, http://b/150769254
