### PR TITLE
Do not request Framebuffer Attachments if resources are still loading

### DIFF
--- a/gapic/src/main/com/google/gapid/views/FramebufferView.java
+++ b/gapic/src/main/com/google/gapid/views/FramebufferView.java
@@ -290,12 +290,13 @@ public class FramebufferView extends Composite
   }
 
   private void loadBuffer() {
+    imagePanel.startLoading();
+
     if (models.commands.getSelectedCommands() == null) {
       imagePanel.showMessage(Info, Messages.SELECT_COMMAND);
     } else if (!models.devices.hasReplayDevice()) {
       imagePanel.showMessage(Error, Messages.NO_REPLAY_DEVICE);
-    } else {
-      imagePanel.startLoading();
+    } else if (models.resources.isLoaded()) {
       Rpc.listen(models.resources.loadFramebufferAttachments(),
           new UiErrorCallback<Service.FramebufferAttachments, Service.FramebufferAttachments, Loadable.Message>(this, LOG) {
         @Override

--- a/gapic/src/main/com/google/gapid/views/PipelineView.java
+++ b/gapic/src/main/com/google/gapid/views/PipelineView.java
@@ -170,8 +170,11 @@ public class PipelineView extends Composite
   }
 
   private void updatePipelines() {
-    if (models.resources.isLoaded() && models.commands.getSelectedCommands() != null) {
-      loading.startLoading();
+    loading.startLoading();
+
+    if (models.commands.getSelectedCommands() == null) {
+      loading.showMessage(Info, Messages.SELECT_DRAW_CALL);
+    } else if (models.resources.isLoaded()) {
       Rpc.listen(models.resources.loadBoundPipelines(),
           new UiErrorCallback<API.MultiResourceData, List<API.Pipeline>, Loadable.Message>(this, LOG) {
         @Override
@@ -207,8 +210,6 @@ public class PipelineView extends Composite
           loading.showMessage(error);
         }
       });
-    } else {
-      loading.showMessage(Info, Messages.SELECT_DRAW_CALL);
     }
   }
 

--- a/gapic/src/main/com/google/gapid/views/TextureView.java
+++ b/gapic/src/main/com/google/gapid/views/TextureView.java
@@ -253,7 +253,12 @@ public class TextureView extends Composite
   }
 
   private void updateTextures(boolean resourcesChanged) {
-    if (models.resources.isLoaded() && models.commands.getSelectedCommands() != null) {
+    if (!models.resources.isLoaded()) {
+      imagePanel.startLoading();
+    } else if (models.commands.getSelectedCommands() == null) {
+      imagePanel.showMessage(Info, Messages.SELECT_COMMAND);
+      clear();
+    } else {
       // Memorize selection index before disposing image resource.
       // When comparator is reset, the table is refreshed, and early image disposal will introduce null error.
       ViewerComparator comparator = textureTable.getComparator();
@@ -285,9 +290,6 @@ public class TextureView extends Composite
         imagePanel.showMessage(Info, Messages.SELECT_TEXTURE);
       }
       updateSelection();
-    } else {
-      imagePanel.showMessage(Info, Messages.SELECT_COMMAND);
-      clear();
     }
   }
 


### PR DESCRIPTION
Prevents a null pointer exception. Other views have similar checks.

Bug: b/161699220