### PR TITLE
Don't crash on some out-of-band gapir responses.

### DIFF
--- a/gapir/client/client.go
+++ b/gapir/client/client.go
@@ -247,7 +247,7 @@ func (client *Client) PrewarmReplay(ctx context.Context, key *ReplayerKey, paylo
 
 	replayer, err := client.getActiveReplayer(ctx, key)
 	if err != nil {
-		return log.Err(ctx, err, "Getting replayer replayer")
+		return log.Err(ctx, err, "Getting active replayer")
 	}
 
 	PrerunReq := replaysrv.ReplayRequest{


### PR DESCRIPTION
Ignore out-of-band replay finished and notification responses but treat out-of-band post data responses as errors, without crashing.