### PR TITLE
Fixes a memory alignment issue.

### DIFF
--- a/gapis/api/vulkan/scratch_resources.go
+++ b/gapis/api/vulkan/scratch_resources.go
@@ -275,7 +275,7 @@ func flushDataToMemory(sb *stateBuilder, deviceMemory VkDeviceMemory, alignment 
 	dev := GetState(sb.newState).DeviceMemories().Get(deviceMemory).Device()
 	sort.Slice(dataSlices, func(i, j int) bool { return dataSlices[i].offset < dataSlices[j].offset })
 	begin := dataSlices[0].offset / alignment * alignment
-	end := nextMultipleOf(dataSlices[len(dataSlices)-1].offset+dataSlices[len(dataSlices)-1].data.size, 256)
+	end := nextMultipleOf(dataSlices[len(dataSlices)-1].offset+dataSlices[len(dataSlices)-1].data.size, alignment)
 	atData := sb.MustReserve(end - begin)
 	ptrAtData := sb.newState.AllocDataOrPanic(sb.ctx, NewVoidᵖ(atData.Ptr()))
 


### PR DESCRIPTION
The crash here was due to us trying to read/write 256 bytes from a 64 byte buffer. The 256 comes from the nonCoherentAtomSize constant. When using the scratch resources buffer we align things to 256 bytes defensively
for the coherent memory case. We, however, are also re-using this code for the linear image priming, where we do not need that alignment. When the code was made to be re-used, the alignment was turned into a parameter to the functions, but here it was missed and stayed an inline constant.

Bug: http://b/152434105