### PR TITLE
Show an error if graphics tracing is disabled when opening a trace.

### DIFF
--- a/gapic/src/main/com/google/gapid/models/Capture.java
+++ b/gapic/src/main/com/google/gapid/models/Capture.java
@@ -35,6 +35,7 @@ import com.google.gapid.server.Client;
 import com.google.gapid.server.Client.InternalServerErrorException;
 import com.google.gapid.server.Client.UnsupportedVersionException;
 import com.google.gapid.util.Events;
+import com.google.gapid.util.Experimental;
 import com.google.gapid.util.Loadable;
 import com.google.gapid.util.MoreFutures;
 
@@ -124,6 +125,10 @@ public class Capture extends ModelBase<Capture.Data, File, Loadable.Message, Cap
       Data data = result.get();
       if (data == null || data.path == null) {
         return error(Loadable.Message.error("Invalid/Corrupted trace file!"));
+      } else if (data.isGraphics() && !Experimental.enableVulkanTracing(settings)) {
+        return error(Loadable.Message.error(
+            "The experimental graphics trace feature is currently disabled.\n" +
+            "Enable it via the --experimental-enable-vulkan-tracing command line flag."));
       } else {
         return success(data);
       }

--- a/gapic/src/main/com/google/gapid/util/Experimental.java
+++ b/gapic/src/main/com/google/gapid/util/Experimental.java
@@ -16,7 +16,7 @@
 package com.google.gapid.util;
 
 import com.google.common.collect.Lists;
-import com.google.gapid.util.Flags;
+import com.google.gapid.models.Settings;
 import com.google.gapid.util.Flags.Flag;
 
 import java.util.List;
@@ -58,5 +58,10 @@ public class Experimental {
       }
     }
     return args;
+  }
+
+  public static boolean enableVulkanTracing(Settings settings) {
+    return settings.preferences().getEnableAllExperimentalFeatures() ||
+        enableAll.get() || enableVulkanTracing.get();
   }
 }


### PR DESCRIPTION
If a graphcis trace is opened and the Vulkan tracing experimental feature is not enabled, this will cause an error to be shown to the user requesting for the feature to be enabled to open the trace.

Bug: http://b/159197656