### PR TITLE
Fix the viewport in the our GL renderers.

### DIFF
--- a/gapic/src/main/com/google/gapid/glviewer/gl/Renderer.java
+++ b/gapic/src/main/com/google/gapid/glviewer/gl/Renderer.java
@@ -23,7 +23,6 @@ import com.google.gapid.glviewer.vec.MatD;
 import com.google.gapid.glviewer.vec.VecD;
 
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.internal.DPIUtil;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL30;
 
@@ -77,11 +76,11 @@ public final class Renderer {
    * @param width of the back-buffer in real pixels.
    * @param height of the back-buffer in real pixels.
    */
-  public void setSize(int width, int height) {
-    physicalWidth = width;
-    physicalHeight = height;
-    dipWidth = DPIUtil.autoScaleDown(width);
-    dipHeight = DPIUtil.autoScaleDown(height);
+  public void setSize(int width, int height, float factor) {
+    physicalWidth = (int)(width * factor);
+    physicalHeight = (int)(height * factor);
+    dipWidth = width;
+    dipHeight = height;
     GL11.glViewport(0, 0, physicalWidth, physicalHeight);
   }
 

--- a/gapic/src/main/com/google/gapid/widgets/ScenePanel.java
+++ b/gapic/src/main/com/google/gapid/widgets/ScenePanel.java
@@ -118,17 +118,17 @@ public class ScenePanel<T> extends GlCanvas {
 
   private void initialize() {
     renderer.initialize();
-    Point size = DPIUtil.autoScaleUp(getSize());
-    renderer.setSize(size.x, size.y);
+    Point size = getSize();
+    renderer.setSize(size.x, size.y, DPIUtil.getDeviceZoom() / 100f);
     scene.init(renderer);
   }
 
   private void dispatchEvents(Event event) {
     withSuspendedUpdate(() -> {
       if (event.type == SWT.Resize && isOpenGL()) {
-        Point size = DPIUtil.autoScaleUp(getSize());
+        Point size = getSize();
         setCurrent();
-        renderer.setSize(size.x, size.y);
+        renderer.setSize(size.x, size.y, DPIUtil.getDeviceZoom() / 100f);
         scene.resize(renderer, size.x, size.y);
       }
       for (Listener listener : eventListeners.get(event.type)) {


### PR DESCRIPTION
When Cairo auto-scaling is used for GTK, the handling of the scaling is passed along to the underlying system, instead of handled by SWT. Thus, the utility class we relied on to scale things for GL no longer behaves as expected. This change makes use handle it correctly ourselves when computing the viewport for GL.