### PR TITLE
Fix issue where traces weren't properly opened.

### DIFF
--- a/gapic/src/main/com/google/gapid/views/DeviceDialog.java
+++ b/gapic/src/main/com/google/gapid/views/DeviceDialog.java
@@ -92,6 +92,7 @@ public class DeviceDialog implements Devices.Listener, Capture.Listener {
         dialog.close();
       }
     });
+    selectReplayDevice();
   }
 
   @Override
@@ -105,7 +106,6 @@ public class DeviceDialog implements Devices.Listener, Capture.Listener {
   }
 
   protected void selectReplayDevice() {
-
     // If the dialog has been closed, remove the reference to it.
     if (dialog != null && dialog.getShell() == null) {
       dialog = null;


### PR DESCRIPTION
The device dialog had a race condition. After loading a capture, the UI is scheduled to be created, while at the same time the replay devices are scheduled to be loaded. If the replay devices finished loading before the UI was created, the device dialog never got the "devices loaded" event.

This change fixes it by having the dialog initialize itself based on the current state of the models when it is created, instead of relying on the timing of its creation.

Bug: http://b/158824824