### PR TITLE
Basic track filtering feature.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/views/CopyablePanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CopyablePanel.java
@@ -33,13 +33,13 @@ public interface CopyablePanel<T extends CopyablePanel<T>> extends Panel {
    */
   public T copy();
 
-  public static class Group implements CopyablePanel<Group> {
+  public static class Group implements CopyablePanel<Group>, Panel.Grouper {
     private final PanelGroup group = new PanelGroup();
 
     @Override
     public Group copy() {
       Group copy = new Group();
-      for (int i = 0; i < group.size(); i++) {
+      for (int i = 0; i < group.getPanelCount(); i++) {
         copy.add(((CopyablePanel<?>)group.getPanel(i)).copy());
         copy.group.setVisible(i, group.isVisible(i));
       }
@@ -50,6 +50,7 @@ public interface CopyablePanel<T extends CopyablePanel<T>> extends Panel {
       group.add(child);
     }
 
+    @Override
     public void setVisible(int idx, boolean visible) {
       group.setVisible(idx, visible);
     }
@@ -82,6 +83,21 @@ public interface CopyablePanel<T extends CopyablePanel<T>> extends Panel {
     @Override
     public void visit(Visitor v, Area area) {
       group.visit(v, area);
+    }
+
+    @Override
+    public int getPanelCount() {
+      return group.getPanelCount();
+    }
+
+    @Override
+    public Panel getPanel(int idx) {
+      return group.getPanel(idx);
+    }
+
+    @Override
+    public void setFiltered(int idx, boolean filtered) {
+      group.setFiltered(idx, filtered);
     }
   }
 }

--- a/gapic/src/main/com/google/gapid/perfetto/views/FilterablePanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/FilterablePanel.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.perfetto.views;
+
+/**
+ * Panels implementing this interface may be filtered based on a user search.
+ */
+public interface FilterablePanel {
+  public boolean include(String search);
+}

--- a/gapic/src/main/com/google/gapid/perfetto/views/RootPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/RootPanel.java
@@ -519,6 +519,17 @@ public abstract class RootPanel<S extends State> extends Panel.Base implements S
     return state.setVisibleTime(new TimeSpan(newStart, newEnd));
   }
 
+  public void updateFilter(String search) {
+    bottom.updateFilter(panel -> {
+      if (panel instanceof FilterablePanel) {
+        return ((FilterablePanel)panel).include(search) ?
+            Panel.FilterValue.Include : Panel.FilterValue.DescendOrExclude;
+      }
+      // Panels that are not filterable, should be shown if they are not groups.
+      return Panel.FilterValue.DescendOrInclude;
+    });
+  }
+
   public static class ForSystemTrace extends RootPanel<State.ForSystemTrace> {
 
     public ForSystemTrace(State.ForSystemTrace state, Settings settings) {

--- a/gapic/src/main/com/google/gapid/perfetto/views/ThreadPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/ThreadPanel.java
@@ -75,8 +75,8 @@ public class ThreadPanel extends TrackPanel<ThreadPanel> implements Selectable {
     return new ThreadPanel(state, track, expanded);
   }
 
-  public void setCollapsed(boolean collapsed) {
-    this.expanded = !collapsed;
+  public void setExpanded(boolean expanded) {
+    this.expanded = expanded;
   }
 
   @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/TrackContainer.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TrackContainer.java
@@ -97,7 +97,7 @@ public class TrackContainer {
   }
 
   private static class Single<T extends TrackPanel<T>> extends Panel.Base
-      implements CopyablePanel<Single<T>> {
+      implements CopyablePanel<Single<T>>, FilterablePanel {
     private final T track;
     private final boolean sep;
     protected final BiConsumer<T, Boolean> toggleDetails;
@@ -129,6 +129,11 @@ public class TrackContainer {
 
     private Single<T> copyWithSeparator() {
       return new Single<T>(track.copy(), true, toggleDetails, showDetails, pinState, rightTruncate);
+    }
+
+    @Override
+    public boolean include(String search) {
+      return track.getTitle().toLowerCase().contains(search);
     }
 
     @Override
@@ -209,7 +214,7 @@ public class TrackContainer {
   }
 
   private static class Group<T extends CopyablePanel<T> & TitledPanel, D extends CopyablePanel<D>>
-      extends Panel.Base implements CopyablePanel<Group<T, D>> {
+      extends Panel.Base implements CopyablePanel<Group<T, D>>, Panel.Grouper, FilterablePanel {
     private final T summary;
     private final CopyablePanel.Group children;
     protected final BiConsumer<CopyablePanel.Group, Boolean> toggleDetails;
@@ -242,6 +247,11 @@ public class TrackContainer {
     public TrackContainer.Group<T, D> copy() {
       return new TrackContainer.Group<T, D>(
           summary.copy(), children.copy(), expanded, toggleDetails, showDetails, pinState);
+    }
+
+    @Override
+    public boolean include(String search) {
+      return summary.getTitle().toLowerCase().contains(search);
     }
 
     @Override
@@ -370,6 +380,26 @@ public class TrackContainer {
       } else {
         return summary.onMouseMove(m, x, y, mods);
       }
+    }
+
+    @Override
+    public int getPanelCount() {
+      return children.getPanelCount();
+    }
+
+    @Override
+    public Panel getPanel(int idx) {
+      return children.getPanel(idx);
+    }
+
+    @Override
+    public void setVisible(int idx, boolean visible) {
+      children.setVisible(idx, visible);
+    }
+
+    @Override
+    public void setFiltered(int idx, boolean filtered) {
+      children.setFiltered(idx, filtered);
     }
 
     private class TrackTitleHover extends TrackContainer.TrackTitleHover {


### PR DESCRIPTION
Filters tracks based on track title. If a group's title matches the search term, all children are included, even if a child may not match.

If a group contains a child that matches, the group itself is shown as well, but only containing children that match. This is so that context is not lost.