### PR TITLE
Add gpu memory counter tracks

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
@@ -58,7 +58,7 @@ import java.util.stream.Collectors;
  * Determines what tracks to show for a trace.
  */
 public class Tracks {
-  private static final Logger LOG = Logger.getLogger(CounterInfo.class.getName());
+  private static final Logger LOG = Logger.getLogger(Tracks.class.getName());
 
   // CPU usage percentage at which a process/thread is considered idle.
   private static final double IDLE_PERCENT_CUTOFF = 0.001; // 0.1%.

--- a/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
@@ -16,9 +16,10 @@
 package com.google.gapid.perfetto.models;
 
 import static com.google.gapid.perfetto.views.StyleConstants.DEFAULT_COUNTER_TRACK_HEIGHT;
-import static com.google.gapid.perfetto.views.StyleConstants.PROCESS_COUNTER_TRACK_HIGHT;
+import static com.google.gapid.perfetto.views.StyleConstants.PROCESS_COUNTER_TRACK_HEIGHT;
 import static com.google.gapid.perfetto.views.TrackContainer.group;
 import static com.google.gapid.perfetto.views.TrackContainer.single;
+import static java.util.logging.Level.WARNING;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
@@ -50,12 +51,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
  * Determines what tracks to show for a trace.
  */
 public class Tracks {
+  private static final Logger LOG = Logger.getLogger(CounterInfo.class.getName());
+
   // CPU usage percentage at which a process/thread is considered idle.
   private static final double IDLE_PERCENT_CUTOFF = 0.001; // 0.1%.
   // Polled counters from the process_stats data source.
@@ -133,12 +137,28 @@ public class Tracks {
         .filter(c -> c.count > 0)
         .collect(toMap(c -> c.id, c -> c));
 
-    if (counters.isEmpty() && data.getGpu().isEmpty()) {
+    List<CounterInfo> gpuMemGlobalCounter = data.getCounters().values().stream()
+        .filter(c -> c.type == CounterInfo.Type.Global && c.ref == 0 /* pid - 0 */
+        && c.count > 0 && c.name.equals("gpumemtotal.global"))
+        .collect(toList());
+
+    if (counters.isEmpty() && data.getGpu().isEmpty() && gpuMemGlobalCounter.isEmpty()) {
       // No GPU data available.
       return data;
     }
 
     data.tracks.addLabelGroup(null, "gpu", "GPU", group(state -> new TitlePanel("GPU"), true));
+
+    if (!gpuMemGlobalCounter.isEmpty()) {
+      if (gpuMemGlobalCounter.size() > 1) {
+        LOG.log(WARNING, "Expected 1 global gpu memory counter. Found " + gpuMemGlobalCounter.size());
+      }
+      CounterInfo counter = gpuMemGlobalCounter.get(0);
+      CounterTrack track = new CounterTrack(data.qe, counter);
+      data.tracks.addTrack("gpu", track.getId(), counter.name,
+          single(state -> new CounterPanel(state, track, DEFAULT_COUNTER_TRACK_HEIGHT), true,
+              /*right truncate*/ true));
+    }
 
     if (data.getGpu().queueCount() > 0) {
       String parent = "gpu";
@@ -296,7 +316,7 @@ public class Tracks {
         for (CounterInfo counter : counters) {
           CounterTrack track = new CounterTrack(data.qe, counter);
           data.tracks.addTrack(parentId, track.getId(), counter.name,
-              single(state -> new CounterPanel(state, track, PROCESS_COUNTER_TRACK_HIGHT),false,
+              single(state -> new CounterPanel(state, track, PROCESS_COUNTER_TRACK_HEIGHT),false,
                   false));
         }
       }

--- a/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
@@ -23,7 +23,6 @@ import static com.google.gapid.util.MoreFutures.transform;
 
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
-
 import com.google.gapid.perfetto.TimeSpan;
 import com.google.gapid.perfetto.canvas.Area;
 import com.google.gapid.perfetto.canvas.Fonts;
@@ -66,6 +65,12 @@ public class CounterPanel extends TrackPanel<CounterPanel> implements Selectable
     CounterInfo info = track.getCounter();
     if (info.type == CounterInfo.Type.Gpu && "gpufreq".equals(info.name)) {
       return "GPU " + info.ref + " Frequency";
+    }
+    if (info.type == CounterInfo.Type.Process && "gpumemtotal.process".equals(info.name)) {
+      return "GPU Memory Process Total";
+    }
+    if (info.type == CounterInfo.Type.Global && "gpumemtotal.global".equals(info.name)) {
+      return "GPU Memory Global Total";
     }
     return track.getCounter().name;
   }

--- a/gapic/src/main/com/google/gapid/perfetto/views/StyleConstants.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/StyleConstants.java
@@ -38,7 +38,7 @@ public class StyleConstants {
   public static final double LABEL_TOGGLE_X = LABEL_PIN_X - LABEL_ICON_SIZE;
   public static final double TRACK_MARGIN = 4;
   public static final double DEFAULT_COUNTER_TRACK_HEIGHT = 45;
-  public static final double PROCESS_COUNTER_TRACK_HIGHT = 30;
+  public static final double PROCESS_COUNTER_TRACK_HEIGHT = 30;
   public static final double HIGHLIGHT_EDGE_NEARBY_WIDTH = 10;
   public static final double SELECTION_THRESHOLD = 0.333;
   public static final double ZOOM_FACTOR_SCALE = 0.05;

--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
@@ -56,8 +56,8 @@ import com.google.protobuf.TextFormat.ParseException;
 
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.viewers.ArrayContentProvider;
-import org.eclipse.jface.viewers.CheckboxTableViewer;
 import org.eclipse.jface.viewers.CheckStateChangedEvent;
+import org.eclipse.jface.viewers.CheckboxTableViewer;
 import org.eclipse.jface.viewers.ICheckStateListener;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerFilter;
@@ -136,6 +136,9 @@ public class TraceConfigDialog extends DialogBase {
   };
   private static final String[] GPU_FREQ_FTRACE = {
       "power/gpu_frequency",
+  };
+  private static final String[] GPU_MEM_FTRACE = {
+      "gpu_mem/gpu_mem_total",
   };
   private static final PerfettoConfig.MeminfoCounters[] MEM_COUNTERS = {
       PerfettoConfig.MeminfoCounters.MEMINFO_MEM_TOTAL,
@@ -264,6 +267,7 @@ public class TraceConfigDialog extends DialogBase {
 
     if (p.getGpuOrBuilder().getEnabled()) {
       ftrace.addAllFtraceEvents(Arrays.asList(GPU_FREQ_FTRACE));
+      ftrace.addAllFtraceEvents(Arrays.asList(GPU_MEM_FTRACE));
 
       Device.GPUProfiling gpuCaps = caps.getGpuProfiling();
       SettingsProto.Perfetto.GPUOrBuilder gpu = p.getGpuOrBuilder();
@@ -828,6 +832,7 @@ public class TraceConfigDialog extends DialogBase {
         collectCheckedElements();
 
         table.addCheckStateListener(new ICheckStateListener() {
+          @Override
           public void checkStateChanged(CheckStateChangedEvent event) {
             if (event.getChecked()) {
               checkedElements.add(event.getElement());

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -185,8 +185,8 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
         name = "perfetto",
         locals = locals,
         remote = "https://android.googlesource.com/platform/external/perfetto",
-        commit = "3d920083ed23e730aece1252ce18ef25bbe10256",
-        shallow_since = "1591207640 +0100",
+        commit = "026b1e2be09a8cd8ced37f99e771eca00ea439b0",
+        shallow_since = "1595276873 +0000",
     )
 
     maybe_repository(


### PR DESCRIPTION
This PR includes the following changes:

1. Counter tracks for Global GPU memory usage and Per process total usage. Design doc : [https://docs.google.com/document/d/149ArKJi1E3ZJNcrp3Tfo9oj9FLRMomdBqtFMknE-m_w/edit#heading=h.h4nppfches2w](url)
2. Update perfetto to get the trace processor related changes for GPU memory support
3. Fix a typo for a static variable name

Bug: 157152869