### PR TITLE
Make sure to report devices that do not support profiling

### DIFF
--- a/core/os/android/adb/bind.go
+++ b/core/os/android/adb/bind.go
@@ -17,6 +17,7 @@ package adb
 import (
 	"context"
 
+	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/os/android"
 	"github.com/google/gapid/core/os/device/bind"
 	"github.com/google/gapid/core/os/shell"
@@ -38,11 +39,11 @@ type Device interface {
 	RemoveForward(ctx context.Context, local Port) error
 	// GraphicsDriver queries and returns info about the prerelease graphics driver.
 	GraphicsDriver(ctx context.Context) (Driver, error)
-	// HasGpuProfilingSupportInSystemImage returns whether system image has GPU profiling support.
-	HasGpuProfilingSupportInSystemImage(ctx context.Context) (bool, error)
-	// GetGpuProfilingLayerPackageName queries and returns the package name of the apk that contains
-	// the GPU profiling Vulkan layer.
-	GetGpuProfilingLayerPackageName(ctx context.Context) (string, error)
+	// PrepareGpuProfiling queries GPU profiling support, and when supported it sets
+	// up the device for profiling of installedPackage. It returns a bool to indicate
+	// if GPU profiling is supported and setup is done, and when that's the case it
+	// also returns the package where to find profiling layers, and a cleanup.
+	PrepareGpuProfiling(ctx context.Context, installedPackage *android.InstalledPackage) (bool, string, app.Cleanup, error)
 }
 
 // Driver contains the information about a graphics driver.

--- a/core/os/android/adb/bind.go
+++ b/core/os/android/adb/bind.go
@@ -39,10 +39,14 @@ type Device interface {
 	RemoveForward(ctx context.Context, local Port) error
 	// GraphicsDriver queries and returns info about the prerelease graphics driver.
 	GraphicsDriver(ctx context.Context) (Driver, error)
-	// PrepareGpuProfiling queries GPU profiling support, and when supported it sets
-	// up the device for profiling of installedPackage. It returns a bool to indicate
-	// if GPU profiling is supported and setup is done, and when that's the case it
-	// also returns the package where to find profiling layers, and a cleanup.
+	// PrepareGpuProfiling queries GPU profiling support, and when profiling is supported it sets up
+	// the device for profiling of installedPackage app. It returns:
+	// - a bool which is true when GPU profiling is supported and the setup is done without errors
+	// - a string that contains the name of the package where to find profiling layers, this string
+	//   is empty if there is no profiling layer required
+	// - a cleanup function to revert the device settings after profiling is done
+	// - an error to indicate if anything went wrong
+	// The returned bool disambiguates between "an error happened" and "profiling is not supported".
 	PrepareGpuProfiling(ctx context.Context, installedPackage *android.InstalledPackage) (bool, string, app.Cleanup, error)
 }
 

--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -496,14 +496,7 @@ func (b *binding) DriverVersionCode(ctx context.Context) (int, error) {
 	return ip.VersionCode, err
 }
 
-// PrepareGpuProfiling queries GPU profiling support, and when profiling is supported it sets up
-// the device for profiling of installedPackage app. It returns:
-// - a bool which is true when GPU profiling is supported and the setup is done without errors
-// - a string that contains the name of the package where to find profiling layers, if profiling
-//   is supported by the system image, then this string is empty
-// - a cleanup function to revert the device settings after profiling is done
-// - an error to indicate if anything went wrong
-// The returned bool disambiguates between "an error happened" and "profiling is not supported".
+// PrepareGpuProfiling implements the adb.Device interface.
 func (b *binding) PrepareGpuProfiling(ctx context.Context, installedPackage *android.InstalledPackage) (bool, string, app.Cleanup, error) {
 	driver, err := b.GraphicsDriver(ctx)
 	if err != nil {

--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -499,7 +499,8 @@ func (b *binding) DriverVersionCode(ctx context.Context) (int, error) {
 // PrepareGpuProfiling queries GPU profiling support, and when profiling is supported it sets up
 // the device for profiling of installedPackage app. It returns:
 // - a bool which is true when GPU profiling is supported and the setup is done without errors
-// - a string that contains the name of the package where to find profiling layers
+// - a string that contains the name of the package where to find profiling layers, if profiling
+//   is supported by the system image, then this string is empty
 // - a cleanup function to revert the device settings after profiling is done
 // - an error to indicate if anything went wrong
 // The returned bool disambiguates between "an error happened" and "profiling is not supported".

--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -496,29 +496,49 @@ func (b *binding) DriverVersionCode(ctx context.Context) (int, error) {
 	return ip.VersionCode, err
 }
 
-// HasGpuProfilingSupportInSystemImage returns whether system image has GPU profiling support.
-func (b *binding) HasGpuProfilingSupportInSystemImage(ctx context.Context) (bool, error) {
+// PrepareGpuProfiling queries GPU profiling support, and when profiling is supported it sets up
+// the device for profiling of installedPackage app. It returns:
+// - a bool which is true when GPU profiling is supported and the setup is done without errors
+// - a string that contains the name of the package where to find profiling layers
+// - a cleanup function to revert the device settings after profiling is done
+// - an error to indicate if anything went wrong
+// The returned bool disambiguates between "an error happened" and "profiling is not supported".
+func (b *binding) PrepareGpuProfiling(ctx context.Context, installedPackage *android.InstalledPackage) (bool, string, app.Cleanup, error) {
+	driver, err := b.GraphicsDriver(ctx)
+	if err != nil {
+		// If there's an error, keep going to attempt to use GPU profiling
+		// libraries in system image.
+		log.W(ctx, "Failed to query developer driver: %v, assuming no developer driver found.", err)
+	}
+
+	if driver.Package != "" {
+		log.I(ctx, "Using GPU profiling libraries from developer driver package: %v.", driver.Package)
+
+		// Set up device info service to use prerelease driver.
+		cleanup, err := SetupPrereleaseDriver(ctx, b, installedPackage)
+		if err != nil {
+			return false, "", cleanup, err
+		}
+		return true, driver.Package, cleanup, nil
+	}
+
+	// For Android 11, GPU profiling could be part of the system driver. It can be implemented as
+	// a vulkan layer. Hence check whether GPU profiling is supported as part of the system driver,
+	// and append the vulkan profiling layer apk package name as a place to discover the vulkan
+	// profiling library.
+	log.I(ctx, "No developer driver found, attempting to use GPU profiling libraries in system image.")
+
 	supported, err := b.SystemProperty(ctx, systemImageGpuProfilerSupportProperty)
 	if err != nil {
-		return false, err
+		return false, "", nil, err
 	}
-	return supported == "true", nil
-}
+	if supported != "true" {
+		return false, "", nil, nil
+	}
 
-// GetGpuProfilingLayerPackageName queries and returns the package name of the apk that contains
-// the GPU profiling Vulkan layer.
-// For Android 11, GPU profiling could be part of the system driver. It can be implemented as
-// a vulkan layer. Hence check whether GPU profiling is supported as part of the system driver,
-// and append the vulkan profiling layer apk package name as a place to discover the vulkan
-// profiling library.
-func (b *binding) GetGpuProfilingLayerPackageName(ctx context.Context) (string, error) {
-	supported, err := b.HasGpuProfilingSupportInSystemImage(ctx)
-	if !supported || err != nil {
-		return "", log.Err(ctx, err, "No GPU profiling support found in system image.")
-	}
-	vulkanLayerApk, err := b.SystemProperty(ctx, gpuProfilerVulkanLayerApkProperty)
+	packageName, err := b.SystemProperty(ctx, gpuProfilerVulkanLayerApkProperty)
 	if err != nil {
-		return "", err
+		return false, "", nil, err
 	}
-	return vulkanLayerApk, nil
+	return true, packageName, nil, nil
 }

--- a/core/os/android/adb/device.go
+++ b/core/os/android/adb/device.go
@@ -198,7 +198,7 @@ func newDevice(ctx context.Context, serial string, status bind.Status) (*binding
 
 	// Make sure Perfetto daemons are running.
 	if err := d.EnsurePerfettoPersistent(ctx); err != nil {
-		log.W(ctx, "Failed to singal Perfetto services to start", err)
+		log.W(ctx, "Failed to signal Perfetto services to start", err)
 	}
 
 	// Run device info providers only if the API is supported

--- a/core/os/android/layers.go
+++ b/core/os/android/layers.go
@@ -44,31 +44,17 @@ func SetupLayers(ctx context.Context, d Device, appPkg string, layerPkgs []strin
 		return d.SetSystemSetting(ctx, ns, key, val)
 	}
 
-	// Filter out empty package or layer names
-	filteredLayerPkgs := []string{}
-	for _, p := range layerPkgs {
-		if p != "" {
-			filteredLayerPkgs = append(filteredLayerPkgs, p)
-		}
-	}
-	filteredLayers := []string{}
-	for _, l := range layers {
-		if l != "" {
-			filteredLayers = append(filteredLayers, l)
-		}
-	}
-
 	if err := pushSetting("global", "enable_gpu_debug_layers", "1"); err != nil {
 		return cleanup.Invoke(ctx), err
 	}
 	if err := pushSetting("global", "gpu_debug_app", appPkg); err != nil {
 		return cleanup.Invoke(ctx), err
 	}
-	if err := pushSetting("global", "gpu_debug_layer_app", "\""+strings.Join(filteredLayerPkgs, ":")+"\""); err != nil {
+	if err := pushSetting("global", "gpu_debug_layer_app", "\""+strings.Join(layerPkgs, ":")+"\""); err != nil {
 		return cleanup.Invoke(ctx), err
 	}
 	if len(layers) > 0 {
-		if err := pushSetting("global", "gpu_debug_layers", "\""+strings.Join(filteredLayers, ":")+"\""); err != nil {
+		if err := pushSetting("global", "gpu_debug_layers", "\""+strings.Join(layers, ":")+"\""); err != nil {
 			return cleanup.Invoke(ctx), err
 		}
 	} else {

--- a/gapidapk/deviceinfo.go
+++ b/gapidapk/deviceinfo.go
@@ -106,47 +106,26 @@ func fetchDeviceInfo(ctx context.Context, d adb.Device) error {
 
 	var cleanup app.Cleanup
 
-	packages := []string{}
-	driver, err := d.GraphicsDriver(ctx)
-	if err != nil {
-		// If there's an error, keep going to attempt to use GPU profiling
-		// libraries in system image.
-		log.W(ctx, "Failed to query developer driver: %v, assuming no developer driver found.", err)
-	}
-	if driver.Package != "" {
-		log.I(ctx, "Using GPU profiling libraries from developer driver package: %v.", driver.Package)
-
-		// Set up device info service to use prerelease driver.
-		nextCleanup, err := adb.SetupPrereleaseDriver(ctx, d, apk.InstalledPackage)
-		cleanup = cleanup.Then(nextCleanup)
-		if err != nil {
-			cleanup.Invoke(ctx)
-			return err
-		}
-		packages = append(packages, driver.Package)
-	} else {
-		log.I(ctx, "No developer driver found, attempting to use GPU profiling libraries in system image.")
-		if supported, err := d.HasGpuProfilingSupportInSystemImage(ctx); err != nil || !supported {
-			cleanup.Invoke(ctx)
-			return log.Err(ctx, err, "No developer driver found, and no GPU profiling support found in system image.")
-		}
-		if vulkanLayerApk, err := d.GetGpuProfilingLayerPackageName(ctx); err == nil && vulkanLayerApk != "" {
-			packages = append(packages, vulkanLayerApk)
-		}
-	}
-
-	// Set driver package
-	nextCleanup, err := android.SetupLayers(ctx, d, apk.Name, packages, []string{})
+	supported, packageName, nextCleanup, err := d.PrepareGpuProfiling(ctx, apk.InstalledPackage)
 	cleanup = cleanup.Then(nextCleanup)
 	if err != nil {
 		cleanup.Invoke(ctx)
 		return err
 	}
-	defer cleanup.Invoke(ctx)
-
-	if d.Instance().GetConfiguration().GetOS().GetAPIVersion() >= 29 {
-		if err := ensurePerfettoProducerLaunched(ctx, d); err != nil {
+	if supported {
+		// Set driver package
+		nextCleanup, err := android.SetupLayers(ctx, d, apk.Name, []string{packageName}, []string{})
+		cleanup = cleanup.Then(nextCleanup)
+		defer cleanup.Invoke(ctx)
+		if err != nil {
 			return err
+		}
+
+		// Start perfetto producer
+		if d.Instance().GetConfiguration().GetOS().GetAPIVersion() >= 29 {
+			if err := ensurePerfettoProducerLaunched(ctx, d); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/gapidapk/deviceinfo.go
+++ b/gapidapk/deviceinfo.go
@@ -106,15 +106,20 @@ func fetchDeviceInfo(ctx context.Context, d adb.Device) error {
 
 	var cleanup app.Cleanup
 
+	packages := []string{}
 	supported, packageName, nextCleanup, err := d.PrepareGpuProfiling(ctx, apk.InstalledPackage)
 	cleanup = cleanup.Then(nextCleanup)
 	if err != nil {
 		cleanup.Invoke(ctx)
 		return err
 	}
+	if packageName != "" {
+		packages = append(packages, packageName)
+	}
+
 	if supported {
 		// Set driver package
-		nextCleanup, err := android.SetupLayers(ctx, d, apk.Name, []string{packageName}, []string{})
+		nextCleanup, err := android.SetupLayers(ctx, d, apk.Name, packages, []string{})
 		cleanup = cleanup.Then(nextCleanup)
 		defer cleanup.Invoke(ctx)
 		if err != nil {

--- a/gapidapk/gapidapk.go
+++ b/gapidapk/gapidapk.go
@@ -225,23 +225,6 @@ func ensurePerfettoProducerLaunched(ctx context.Context, d adb.Device) error {
 	if err != nil {
 		log.W(ctx, "Failed to query developer driver: %v, assuming no developer driver found.", err)
 	}
-	if driver.Package == "" {
-		log.I(ctx, "No developer driver found.")
-		// When there's no developer drivers, attempt to use the GPU profiling
-		// libraries in the system image. If there's no GPU profiling support
-		// found in system image, then abort because there's no GPU profiling
-		// capabilities.
-		hasSystemImageSupport, err := d.HasGpuProfilingSupportInSystemImage(ctx)
-		if err != nil {
-			return log.Err(ctx, err, "No developer drivers and fail to query GPU profiling support in system image.")
-		}
-		if !hasSystemImageSupport {
-			log.E(ctx, "No developer drivers and no GPU profiling support found in system image.")
-			return log.Err(ctx, nil, "No developer drivers and no GPU profiling support found in system image.")
-		}
-		// Can proceed to start the data producers because GPU profiling support
-		// is found in system image.
-	}
 
 	startSignal, startFunc := task.NewSignal()
 	startFunc = task.Once(startFunc)


### PR DESCRIPTION
Android devices that do not support GPU profiling should still be
listed by GAPIS. In particular, this is needed to list them in the UI
when selecting a replay device: they will be listed as invalid
devices, but at least the user can see that AGI is aware of these
devices.

In practice, this change makes sure fetchDeviceInfo does not return an
error when there is not GPU profiling support.

Bug: b/161878283
Test: manual