### PR TITLE
add mutex to grpcServer.interrupters

### DIFF
--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -86,10 +86,10 @@ func NewWithListener(ctx context.Context, l net.Listener, cfg Config, srvChan ch
 		return err
 	case <-task.ShouldStop(ctx):
 		s.mutex.Lock()
+		defer s.mutex.Unlock()
 		for _, f := range s.interrupters {
 			f()
 		}
-		s.mutex.Unlock()
 		return <-done
 	}
 }
@@ -183,14 +183,14 @@ func (s *grpcServer) stopOnInterrupt(ctx context.Context, server *grpc.Server, s
 
 func (s *grpcServer) addInterrupter(f func()) (remove func()) {
 	s.mutex.Lock()
+	defer s.mutex.Unlock()
 	li := s.lastInterrupter
 	s.lastInterrupter++
 	s.interrupters[li] = f
-	s.mutex.Unlock()
 	return func() {
 		s.mutex.Lock()
+		defer s.mutex.Unlock()
 		delete(s.interrupters, li)
-		s.mutex.Unlock()
 	}
 }
 


### PR DESCRIPTION
Concurrent status requests can cause gapis to crash, because the write access to grpcServer.interrupters in gapis/server/grpc.go is not thread safe and needs to be protected with a mutex.

Bug: b/161880755