### PR TITLE
Add duration in renderstages hover

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/views/GpuQueuePanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/GpuQueuePanel.java
@@ -206,7 +206,7 @@ public class GpuQueuePanel extends TrackPanel<GpuQueuePanel> implements Selectab
           hoveredCategory = "";
         }
         hoveredTitle = buildSliceTitle(hoveredTitle, data.args[i]);
-        hoveredTitle += " (" + TimeSpan.timeToShortString(tEnd -tStart) + ")";
+        hoveredTitle += " (" + TimeSpan.timeToString(tEnd - tStart) + ")";
 
         hoveredSize = Size.vertCombine(HOVER_PADDING, HOVER_PADDING / 2,
             m.measure(Fonts.Style.Normal, hoveredTitle),

--- a/gapic/src/main/com/google/gapid/perfetto/views/GpuQueuePanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/GpuQueuePanel.java
@@ -193,7 +193,9 @@ public class GpuQueuePanel extends TrackPanel<GpuQueuePanel> implements Selectab
     mouseYpos = depth * SLICE_HEIGHT;
     long t = state.pxToTime(x);
     for (int i = 0; i < data.starts.length; i++) {
-      if (data.depths[i] == depth && data.starts[i] <= t && t <= data.ends[i]) {
+      long tStart = data.starts[i];
+      long tEnd = data.ends[i];
+      if (data.depths[i] == depth && tStart <= t && t <= tEnd) {
         hoveredTitle = data.titles[i];
         hoveredCategory = data.categories[i];
         if (hoveredTitle.isEmpty()) {
@@ -204,6 +206,7 @@ public class GpuQueuePanel extends TrackPanel<GpuQueuePanel> implements Selectab
           hoveredCategory = "";
         }
         hoveredTitle = buildSliceTitle(hoveredTitle, data.args[i]);
+        hoveredTitle += " (" + TimeSpan.timeToShortString(tEnd -tStart) + ")";
 
         hoveredSize = Size.vertCombine(HOVER_PADDING, HOVER_PADDING / 2,
             m.measure(Fonts.Style.Normal, hoveredTitle),

--- a/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventPanel.java
@@ -171,7 +171,7 @@ public class VulkanEventPanel extends TrackPanel<VulkanEventPanel> implements Se
       long tStart = data.starts[i];
       long tEnd = data.ends[i];
       if (data.depths[i] == depth && tStart <= t && t <= tEnd) {
-        hoveredName = data.names[i] + " (" + TimeSpan.timeToShortString(tEnd - tStart) + ")";
+        hoveredName = data.names[i] + " (" + TimeSpan.timeToString(tEnd - tStart) + ")";
         hoveredSize = Size.vertCombine(HOVER_PADDING, HOVER_PADDING / 2,
             m.measure(Fonts.Style.Normal, hoveredName));
         mouseYpos = Math.max(0, Math.min(mouseYpos - (hoveredSize.h - SLICE_HEIGHT) / 2,

--- a/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventPanel.java
@@ -168,8 +168,10 @@ public class VulkanEventPanel extends TrackPanel<VulkanEventPanel> implements Se
     mouseYpos = SLICE_Y + depth * SLICE_HEIGHT;
     long t = state.pxToTime(x);
     for (int i = 0; i < data.starts.length; i++) {
-      if (data.depths[i] == depth && data.starts[i] <= t && t <= data.ends[i]) {
-        hoveredName = data.names[i];
+      long tStart = data.starts[i];
+      long tEnd = data.ends[i];
+      if (data.depths[i] == depth && tStart <= t && t <= tEnd) {
+        hoveredName = data.names[i] + " (" + TimeSpan.timeToShortString(tEnd - tStart) + ")";
         hoveredSize = Size.vertCombine(HOVER_PADDING, HOVER_PADDING / 2,
             m.measure(Fonts.Style.Normal, hoveredName));
         mouseYpos = Math.max(0, Math.min(mouseYpos - (hoveredSize.h - SLICE_HEIGHT) / 2,


### PR DESCRIPTION
Add duration in the tooltip showed when hovering a renderstage or
Vulkan event.

Bug: b/161698450
Test: manual

Before:
![hover-duration-before](https://user-images.githubusercontent.com/6726747/88425263-05670b00-cde7-11ea-8017-4a18a1d49e10.png)

After:
![hover-duration-after](https://user-images.githubusercontent.com/6726747/88425259-04ce7480-cde7-11ea-9b52-11c6f8b03b86.png)
