### PR TITLE
Add gapit verb server_performance

### DIFF
--- a/cmd/gapit/BUILD.bazel
+++ b/cmd/gapit/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "replace_resource.go",
         "report.go",
         "screenshot.go",
+        "server_performance.go",
         "split.go",
         "state.go",
         "status.go",

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -269,6 +269,14 @@ type (
 		SkipOutput           bool   `help:"skip writing the modified trace to a file"`
 		CaptureFileFlags
 	}
+	ServerPerformanceFlags struct {
+		Gapis          GapisFlags
+		Gapir          GapirFlags
+		OriginalDevice bool `help:"export replay for the original device"`
+		LoopCount      int  `help:"_The number of times to loop the trace. (experimental)"`
+		CommandFilterFlags
+		CaptureFileFlags
+	}
 	StateFlags struct {
 		Gapis  GapisFlags
 		Gapir  GapirFlags

--- a/cmd/gapit/server_performance.go
+++ b/cmd/gapit/server_performance.go
@@ -1,0 +1,87 @@
+// Copyright (C) 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"time"
+
+	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/service"
+	gapidPath "github.com/google/gapid/gapis/service/path"
+)
+
+type serverPerformanceVerb struct{ ServerPerformanceFlags }
+
+func init() {
+	verb := &serverPerformanceVerb{}
+	app.AddVerb(&app.Verb{
+		Name:      "server_performance",
+		ShortHelp: "Test the performance of GAPIS replay generation.",
+		Action:    verb,
+	})
+}
+
+func (verb *serverPerformanceVerb) Run(ctx context.Context, flags flag.FlagSet) error {
+
+	if flags.NArg() != 1 {
+		app.Usage(ctx, "Exactly one gfx trace file expected, got %d", flags.NArg())
+		return nil
+	}
+
+	client, capturePath, err := getGapisAndLoadCapture(ctx, verb.Gapis, verb.Gapir, flags.Arg(0), verb.CaptureFileFlags)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	var device *gapidPath.Device
+	if !verb.OriginalDevice {
+		device, err = getDevice(ctx, client, capturePath, verb.Gapir)
+		if err != nil {
+			return err
+		}
+	}
+
+	opts := &service.ExportReplayOptions{
+		FramebufferAttachments: make([]*gapidPath.FramebufferAttachment, 0),
+		GetTimestampsRequest:   nil,
+		DisplayToSurface:       false,
+		LoopCount:              int32(verb.LoopCount),
+	}
+
+	start := time.Now()
+	if err := client.ExportReplay(ctx, capturePath, device, "replay_export", opts); err != nil {
+		return log.Err(ctx, err, "Failed to export replay")
+	}
+	elapsed := time.Since(start)
+
+	startRepeat := time.Now()
+	if err := client.ExportReplay(ctx, capturePath, device, "replay_export", opts); err != nil {
+		return log.Err(ctx, err, "Failed to export replay")
+	}
+	elapsedRepeat := time.Since(startRepeat)
+
+	log.W(ctx, "\n\n\n\n")
+	log.W(ctx, "--------------------------------")
+	log.W(ctx, "RESULTS:")
+	log.W(ctx, "First time replay generation:\t%s\t", elapsed)
+	log.W(ctx, "Repeat replay generation:\t%s\t", elapsedRepeat)
+	log.W(ctx, "--------------------------------\n\n\n\n")
+
+	return nil
+}


### PR DESCRIPTION
This times the server responding to an ExportReplay request. The request is made twice, once cold and once again to measure the performance of repeated evaluation.