### PR TITLE
Update macOS docs to get notarized NDK

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -152,13 +152,12 @@ cd <sdk-path>
 tools/bin/sdkmanager platform-tools
 ```
 
-Unzip the
-[Android NDK **r21d**](https://dl.google.com/android/repository/android-ndk-r21d-darwin-x86_64.zip)
-into a directory of your choosing, and set the `ANDROID_NDK_HOME` environment
-variable to point to this directory:
+Install
+[Android NDK **r21d**](https://dl.google.com/android/repository/android-ndk-r21d-darwin-x86_64.dmg) (installing the App Bundle is needed in order to keep the notarization) 
+into the /Applications/ folder, and set the `ANDROID_NDK_HOME` environment pointing to NDK subdirectory:
 
 ```
-export ANDROID_NDK_HOME=<ndk-path>
+export ANDROID_NDK_HOME=/Applications/AndroidNDK6528147.app/Contents/NDK
 ```
 
 ### Install the XCode command line tools


### PR DESCRIPTION
As explained in https://developer.android.com/ndk/downloads?hl=hu:

"If you require a notarized NDK for macOS, make sure you download the App Bundle rather than the zip file."

This change points the user in the direction of the App Bundle.