### PR TITLE
Do not have input attachments link to a texture resource

### DIFF
--- a/gapis/api/vulkan/resources.go
+++ b/gapis/api/vulkan/resources.go
@@ -1155,10 +1155,7 @@ func commonShaderDataGroups(ctx context.Context,
 							viewHandle := descInfo.ImageView()
 							viewPath := path.NewField("ImageViews", resolve.APIStateAfter(path.FindCommand(cmd), ID)).MapIndex(viewHandle).Path()
 
-							imageView, _ := vkState.ImageViews().Lookup(viewHandle)
-							imageViewPath := cmd.ResourceAfter(path.NewID(resources[imageView.Image().ResourceHandle()])).Path()
-
-							paths := []*path.Any{viewPath, imageViewPath}
+							paths := []*path.Any{viewPath}
 
 							if !fb.IsNil() {
 								for _, v := range fb.ImageAttachments().Keys() {


### PR DESCRIPTION
They technically aren't texture resources in AGI, which causes a null link terminal message

Bug: b/156906215