### PR TITLE
Show the min/avg/max values of the current time range.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/canvas/Panel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/canvas/Panel.java
@@ -37,7 +37,8 @@ public interface Panel {
   }
 
   @SuppressWarnings("unused")
-  public default Panel.Hover onMouseMove(Fonts.TextMeasurer m, double x, double y, int mods) {
+  public default Panel.Hover onMouseMove(
+      Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
     return Hover.NONE;
   }
 

--- a/gapic/src/main/com/google/gapid/perfetto/canvas/PanelCanvas.java
+++ b/gapic/src/main/com/google/gapid/perfetto/canvas/PanelCanvas.java
@@ -146,7 +146,8 @@ public class PanelCanvas extends Canvas {
         }
         return;
       }
-      hover = panel.onMouseMove(context, x, y, mods);
+      hover = panel.onMouseMove(
+          context, a -> scheduleIfNotDisposed(this, () -> redraw(a, true)), x, y, mods);
       if (!dragging) {
         setCursor(hover.getCursor(getDisplay()));
       }

--- a/gapic/src/main/com/google/gapid/perfetto/canvas/PanelGroup.java
+++ b/gapic/src/main/com/google/gapid/perfetto/canvas/PanelGroup.java
@@ -148,12 +148,13 @@ public class PanelGroup extends Panel.Base implements Panel.Grouper {
   }
 
   @Override
-  public Hover onMouseMove(Fonts.TextMeasurer m, double x, double y, int mods) {
+  public Hover onMouseMove(Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
     Child child = findPanel(y);
     if (child == null) {
       return Hover.NONE;
     }
-    return child.panel.onMouseMove(m, x, y - child.y, mods).translated(0, child.y);
+    return child.panel.onMouseMove(m, repainter.translated(0, child.y), x, y - child.y, mods)
+        .translated(0, child.y);
   }
 
   private int findPanelIdx(double y) {

--- a/gapic/src/main/com/google/gapid/perfetto/models/CounterTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/CounterTrack.java
@@ -33,10 +33,10 @@ import com.google.gapid.perfetto.TimeSpan;
 import com.google.gapid.perfetto.views.CountersSelectionView;
 import com.google.gapid.perfetto.views.State;
 
-import java.util.Map;
 import org.eclipse.swt.widgets.Composite;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 

--- a/gapic/src/main/com/google/gapid/perfetto/views/BatterySummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/BatterySummaryPanel.java
@@ -30,7 +30,6 @@ import com.google.gapid.perfetto.canvas.RenderContext;
 import com.google.gapid.perfetto.canvas.Size;
 import com.google.gapid.perfetto.models.BatterySummaryTrack;
 import com.google.gapid.perfetto.models.Selection;
-import com.google.gapid.perfetto.models.Selection.CombiningBuilder;
 import com.google.gapid.perfetto.models.Selection.Kind;
 
 import org.eclipse.swt.SWT;
@@ -46,7 +45,7 @@ public class BatterySummaryPanel extends TrackPanel<BatterySummaryPanel> impleme
   private static final double CURSOR_SIZE = 5;
   private static final double LEGEND_SIZE = 8;
 
-  private final BatterySummaryTrack track;
+  protected final BatterySummaryTrack track;
   protected HoverCard hovered = null;
   protected double mouseXpos, mouseYpos;
 
@@ -228,7 +227,7 @@ public class BatterySummaryPanel extends TrackPanel<BatterySummaryPanel> impleme
   }
 
   @Override
-  public void computeSelection(CombiningBuilder builder, Area area, TimeSpan ts) {
+  public void computeSelection(Selection.CombiningBuilder builder, Area area, TimeSpan ts) {
     builder.add(Selection.Kind.Battery, track.getValues(ts));
   }
 

--- a/gapic/src/main/com/google/gapid/perfetto/views/BatterySummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/BatterySummaryPanel.java
@@ -25,7 +25,6 @@ import com.google.common.collect.Lists;
 import com.google.gapid.perfetto.TimeSpan;
 import com.google.gapid.perfetto.canvas.Area;
 import com.google.gapid.perfetto.canvas.Fonts;
-import com.google.gapid.perfetto.canvas.Fonts.TextMeasurer;
 import com.google.gapid.perfetto.canvas.RenderContext;
 import com.google.gapid.perfetto.canvas.Size;
 import com.google.gapid.perfetto.models.BatterySummaryTrack;
@@ -164,8 +163,9 @@ public class BatterySummaryPanel extends TrackPanel<BatterySummaryPanel> impleme
   }
 
   @Override
-  protected Hover onTrackMouseMove(TextMeasurer m, double x, double y, int mods) {
-    BatterySummaryTrack.Data data = track.getData(state.toRequest(), onUiThread());
+  protected Hover onTrackMouseMove(
+      Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
+    BatterySummaryTrack.Data data = track.getData(state.toRequest(), onUiThread(repainter));
     if (data == null || data.ts.length == 0) {
       return Hover.NONE;
     }

--- a/gapic/src/main/com/google/gapid/perfetto/views/CopyablePanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CopyablePanel.java
@@ -16,7 +16,7 @@
 package com.google.gapid.perfetto.views;
 
 import com.google.gapid.perfetto.canvas.Area;
-import com.google.gapid.perfetto.canvas.Fonts.TextMeasurer;
+import com.google.gapid.perfetto.canvas.Fonts;
 import com.google.gapid.perfetto.canvas.Panel;
 import com.google.gapid.perfetto.canvas.PanelGroup;
 import com.google.gapid.perfetto.canvas.RenderContext;
@@ -76,8 +76,9 @@ public interface CopyablePanel<T extends CopyablePanel<T>> extends Panel {
     }
 
     @Override
-    public Hover onMouseMove(TextMeasurer m, double x, double y, int mods) {
-      return group.onMouseMove(m, x, y, mods);
+    public Hover onMouseMove(
+        Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
+      return group.onMouseMove(m, repainter, x, y, mods);
     }
 
     @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
@@ -30,9 +30,7 @@ import com.google.gapid.perfetto.canvas.RenderContext;
 import com.google.gapid.perfetto.canvas.Size;
 import com.google.gapid.perfetto.models.CounterInfo;
 import com.google.gapid.perfetto.models.CounterTrack;
-import com.google.gapid.perfetto.models.CounterTrack.Values;
 import com.google.gapid.perfetto.models.Selection;
-import com.google.gapid.perfetto.models.Selection.CombiningBuilder;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Cursor;
@@ -271,9 +269,13 @@ public class CounterPanel extends TrackPanel<CounterPanel> implements Selectable
   }
 
   @Override
-  public void computeSelection(CombiningBuilder builder, Area area, TimeSpan ts) {
-    builder.add(Selection.Kind.Counter, (ListenableFuture<Values>)transform(track.getValues(ts),
-        data -> new CounterTrack.Values(track.getCounter().name, data)));
+  public void computeSelection(Selection.CombiningBuilder builder, Area area, TimeSpan ts) {
+    builder.add(Selection.Kind.Counter, computeSelection(ts));
+  }
+
+  private ListenableFuture<CounterTrack.Values> computeSelection(TimeSpan ts) {
+    return transform(track.getValues(ts),
+        data -> new CounterTrack.Values(track.getCounter().name, data));
   }
 
   private static class HoverCard {

--- a/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
@@ -46,11 +46,13 @@ public class CounterPanel extends TrackPanel<CounterPanel> implements Selectable
   protected final CounterTrack track;
   protected final double trackHeight;
   protected HoverCard hovered = null;
+  private CounterTrack.Stats cachedStats;
 
   public CounterPanel(State state, CounterTrack track, double trackHeight) {
     super(state);
     this.track = track;
     this.trackHeight = trackHeight;
+    this.cachedStats = new CounterTrack.Stats(track.getCounter());
   }
 
   @Override
@@ -155,9 +157,9 @@ public class CounterPanel extends TrackPanel<CounterPanel> implements Selectable
         // The difference between the x-axis coordinate of the left labels and the right labels.
         double dx = hovered.leftWidth + HOVER_PADDING, dy = hovered.size.h / 2;
         ctx.drawText(Fonts.Style.Normal, "Value:", x, y);
-        ctx.drawText(Fonts.Style.Normal, "Avg:", x, y + dy);
-        ctx.drawText(Fonts.Style.Normal, "Min:", x + dx, y);
-        ctx.drawText(Fonts.Style.Normal, "Max:", x + dx, y + dy);
+        ctx.drawText(Fonts.Style.Normal, hovered.avgLabel, x, y + dy);
+        ctx.drawText(Fonts.Style.Normal, hovered.minLabel, x + dx, y);
+        ctx.drawText(Fonts.Style.Normal, hovered.maxLabel, x + dx, y + dy);
 
         x = hx + HOVER_PADDING + hovered.leftWidth;
         ctx.drawTextRightJustified(Fonts.Style.Normal, hovered.label, x, y, dy);
@@ -196,7 +198,8 @@ public class CounterPanel extends TrackPanel<CounterPanel> implements Selectable
     long id = data.ids[idx];
     double startX = state.timeToPx(data.ts[idx]);
     double endX = (idx >= data.ts.length - 1) ? startX : state.timeToPx(data.ts[idx + 1]);
-    hovered = new HoverCard(m, track.getCounter(), data.values[idx], startX, endX, x);
+    hovered = new HoverCard(
+        m, track.getCounter(), getStats(repainter), data.values[idx], startX, endX, x);
 
     return new Hover() {
       @Override
@@ -279,25 +282,46 @@ public class CounterPanel extends TrackPanel<CounterPanel> implements Selectable
         data -> new CounterTrack.Values(track.getCounter().name, data));
   }
 
+  private CounterTrack.Stats getStats(Repainter repainter) {
+    TimeSpan span = state.getHighlight();
+    if (!span.equals(cachedStats.span)) {
+      if (span.isEmpty()) {
+        cachedStats = new CounterTrack.Stats(track.getCounter());
+      } else {
+        state.thenOnUiThread(track.getStats(span), stats -> {
+          cachedStats = stats;
+          repainter.repaint(Area.FULL);
+        });
+      }
+    }
+    return cachedStats;
+  }
+
   private static class HoverCard {
     public final double value;
     public final double startX, endX;
     public final double mouseX;
     public final String label;
     public final String min, max, avg;
+    public final String minLabel, maxLabel, avgLabel;
     public final double leftWidth;
     public final Size size;
 
-    public HoverCard(Fonts.TextMeasurer tm, CounterInfo counter, double value, double startX,
-        double endX, double mouseX) {
+    public HoverCard(Fonts.TextMeasurer tm, CounterInfo counter, CounterTrack.Stats stats,
+        double value, double startX, double endX, double mouseX) {
       this.value = value;
       this.startX = startX;
       this.endX = endX;
       this.mouseX = mouseX;
       this.label = counter.unit.format(value);
-      this.min = counter.unit.format(counter.min);
-      this.max = counter.unit.format(counter.max);
-      this.avg = counter.unit.format(counter.avg);
+      this.min = counter.unit.format(stats.min);
+      this.max = counter.unit.format(stats.max);
+      this.avg = counter.unit.format(stats.avg);
+      boolean isTotal = stats.isTotal();
+      this.minLabel = isTotal ? "Trace Min:" : "Range Min:";
+      this.maxLabel = isTotal ? "Trace Max:" : "Range Max:";
+      this.avgLabel = isTotal ? "Trace Avg:" : "Range Avg:";
+
 
       Size valueSize = tm.measure(Fonts.Style.Normal, label);
       Size minSize = tm.measure(Fonts.Style.Normal, min);
@@ -306,10 +330,10 @@ public class CounterPanel extends TrackPanel<CounterPanel> implements Selectable
 
       double leftLabel = Math.max(
           tm.measure(Fonts.Style.Normal, "Value:").w,
-          tm.measure(Fonts.Style.Normal, "Avg:").w) + HOVER_PADDING;
+          tm.measure(Fonts.Style.Normal, avgLabel).w) + HOVER_PADDING;
       double rightLabel = Math.max(
-          tm.measure(Fonts.Style.Normal, "Min:").w,
-          tm.measure(Fonts.Style.Normal, "Max:").w) + HOVER_PADDING;
+          tm.measure(Fonts.Style.Normal, minLabel).w,
+          tm.measure(Fonts.Style.Normal, maxLabel).w) + HOVER_PADDING;
       this.leftWidth = leftLabel + Math.max(valueSize.w, avgSize.w);
       this.size = new Size(leftWidth + HOVER_PADDING + rightLabel + Math.max(minSize.w, maxSize.w),
           Math.max(valueSize.h + avgSize.h, minSize.h + maxSize.h) + HOVER_PADDING);

--- a/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
@@ -170,8 +170,9 @@ public class CounterPanel extends TrackPanel<CounterPanel> implements Selectable
   }
 
   @Override
-  protected Hover onTrackMouseMove(Fonts.TextMeasurer m, double x, double y, int mods) {
-    CounterTrack.Data data = track.getData(state.toRequest(), onUiThread());
+  protected Hover onTrackMouseMove(
+      Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
+    CounterTrack.Data data = track.getData(state.toRequest(), onUiThread(repainter));
     if (data == null || data.ts.length == 0) {
       return Hover.NONE;
     }

--- a/gapic/src/main/com/google/gapid/perfetto/views/CpuFrequencyPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CpuFrequencyPanel.java
@@ -183,8 +183,9 @@ public class CpuFrequencyPanel extends TrackPanel<CpuFrequencyPanel> {
   }
 
   @Override
-  public Hover onTrackMouseMove(Fonts.TextMeasurer m, double x, double y, int mods) {
-    CpuFrequencyTrack.Data data = track.getData(state.toRequest(), onUiThread());
+  public Hover onTrackMouseMove(
+      Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
+    CpuFrequencyTrack.Data data = track.getData(state.toRequest(), onUiThread(repainter));
     if (data == null) {
       return Hover.NONE;
     }

--- a/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
@@ -25,16 +25,13 @@ import static com.google.gapid.util.MoreFutures.transform;
 
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
-
 import com.google.gapid.perfetto.TimeSpan;
 import com.google.gapid.perfetto.canvas.Area;
 import com.google.gapid.perfetto.canvas.Fonts;
 import com.google.gapid.perfetto.canvas.RenderContext;
 import com.google.gapid.perfetto.canvas.Size;
 import com.google.gapid.perfetto.models.CpuTrack;
-import com.google.gapid.perfetto.models.CpuTrack.Slices;
 import com.google.gapid.perfetto.models.Selection;
-import com.google.gapid.perfetto.models.Selection.CombiningBuilder;
 import com.google.gapid.perfetto.models.ThreadInfo;
 import com.google.gapid.util.Arrays;
 
@@ -345,13 +342,17 @@ public class CpuPanel extends TrackPanel<CpuPanel> implements Selectable {
   }
 
   @Override
-  public void computeSelection(CombiningBuilder builder, Area area, TimeSpan ts) {
+  public void computeSelection(Selection.CombiningBuilder builder, Area area, TimeSpan ts) {
     if (area.h / height >= SELECTION_THRESHOLD) {
-      builder.add(Selection.Kind.Cpu, (ListenableFuture<Slices>)transform(track.getSlices(ts), slices -> {
-        slices.utids.forEach(utid -> state.addSelectedThread(state.getThreadInfo(utid)));
-        return slices;
-      }));
+      builder.add(Selection.Kind.Cpu, computeSelection(ts));
     }
+  }
+
+  private ListenableFuture<CpuTrack.Slices> computeSelection(TimeSpan ts) {
+    return transform(track.getSlices(ts), slices -> {
+      slices.utids.forEach(utid -> state.addSelectedThread(state.getThreadInfo(utid)));
+      return slices;
+    });
   }
 
   private static class HoverCard {

--- a/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
@@ -212,8 +212,9 @@ public class CpuPanel extends TrackPanel<CpuPanel> implements Selectable {
   }
 
   @Override
-  public Hover onTrackMouseMove(Fonts.TextMeasurer m, double x, double y, int mods) {
-    CpuTrack.Data data = track.getData(state.toRequest(), onUiThread());
+  public Hover onTrackMouseMove(
+      Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
+    CpuTrack.Data data = track.getData(state.toRequest(), onUiThread(repainter));
     if (data == null) {
       return Hover.NONE;
     }

--- a/gapic/src/main/com/google/gapid/perfetto/views/CpuSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CpuSummaryPanel.java
@@ -24,7 +24,6 @@ import static com.google.gapid.perfetto.views.StyleConstants.mainGradient;
 import static com.google.gapid.util.MoreFutures.transform;
 
 import com.google.common.util.concurrent.ListenableFuture;
-
 import com.google.gapid.perfetto.TimeSpan;
 import com.google.gapid.perfetto.canvas.Area;
 import com.google.gapid.perfetto.canvas.Fonts;
@@ -168,11 +167,15 @@ public class CpuSummaryPanel extends TrackPanel<CpuSummaryPanel> implements Sele
   @Override
   public void computeSelection(Selection.CombiningBuilder builder, Area area, TimeSpan ts) {
     if (area.h / height >= SELECTION_THRESHOLD) {
-      builder.add(Selection.Kind.Cpu, (ListenableFuture<Slices>)transform(track.getSlices(ts), slices -> {
-        slices.utids.forEach(utid -> state.addSelectedThread(state.getThreadInfo(utid)));
-        return slices;
-      }));
+      builder.add(Selection.Kind.Cpu, computeSelection(ts));
     }
+  }
+
+  private ListenableFuture<Slices> computeSelection(TimeSpan ts) {
+    return transform(track.getSlices(ts), slices -> {
+      slices.utids.forEach(utid -> state.addSelectedThread(state.getThreadInfo(utid)));
+      return slices;
+    });
   }
 
   private static class HoverCard {

--- a/gapic/src/main/com/google/gapid/perfetto/views/CpuSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CpuSummaryPanel.java
@@ -121,8 +121,9 @@ public class CpuSummaryPanel extends TrackPanel<CpuSummaryPanel> implements Sele
   }
 
   @Override
-  protected Hover onTrackMouseMove(Fonts.TextMeasurer m, double x, double y, int mods) {
-    CpuSummaryTrack.Data data = track.getData(state.toRequest(), onUiThread());
+  protected Hover onTrackMouseMove(
+      Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
+    CpuSummaryTrack.Data data = track.getData(state.toRequest(), onUiThread(repainter));
     if (data == null || data.utilizations.length == 0) {
       return Hover.NONE;
     }

--- a/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsPanel.java
@@ -30,7 +30,6 @@ import com.google.gapid.perfetto.models.ArgSet;
 import com.google.gapid.perfetto.models.FrameEventsTrack;
 import com.google.gapid.perfetto.models.FrameInfo;
 import com.google.gapid.perfetto.models.Selection;
-import com.google.gapid.perfetto.models.Selection.CombiningBuilder;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Cursor;
@@ -261,7 +260,7 @@ public class FrameEventsPanel extends TrackPanel<FrameEventsPanel>
   }
 
   @Override
-  public void computeSelection(CombiningBuilder builder, Area area, TimeSpan ts) {
+  public void computeSelection(Selection.CombiningBuilder builder, Area area, TimeSpan ts) {
     int startDepth = (int)(area.y / SLICE_HEIGHT);
     int endDepth = (int)((area.y + area.h) / SLICE_HEIGHT);
     if (startDepth == endDepth && area.h / SLICE_HEIGHT < SELECTION_THRESHOLD) {

--- a/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsPanel.java
@@ -180,8 +180,9 @@ public class FrameEventsPanel extends TrackPanel<FrameEventsPanel>
   }
 
   @Override
-  protected Hover onTrackMouseMove(Fonts.TextMeasurer m, double x, double y, int mods) {
-    FrameEventsTrack.Data data = track.getData(state.toRequest(), onUiThread());
+  protected Hover onTrackMouseMove(
+      Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
+    FrameEventsTrack.Data data = track.getData(state.toRequest(), onUiThread(repainter));
     if (data == null) {
       return Hover.NONE;
     }

--- a/gapic/src/main/com/google/gapid/perfetto/views/GpuQueuePanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/GpuQueuePanel.java
@@ -177,8 +177,9 @@ public class GpuQueuePanel extends TrackPanel<GpuQueuePanel> implements Selectab
   }
 
   @Override
-  protected Hover onTrackMouseMove(Fonts.TextMeasurer m, double x, double y, int mods) {
-    SliceTrack.Data data = track.getData(state.toRequest(), onUiThread());
+  protected Hover onTrackMouseMove(
+      Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
+    SliceTrack.Data data = track.getData(state.toRequest(), onUiThread(repainter));
     if (data == null) {
       return Hover.NONE;
     }

--- a/gapic/src/main/com/google/gapid/perfetto/views/GpuQueuePanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/GpuQueuePanel.java
@@ -30,7 +30,6 @@ import com.google.gapid.perfetto.canvas.Size;
 import com.google.gapid.perfetto.models.ArgSet;
 import com.google.gapid.perfetto.models.GpuInfo;
 import com.google.gapid.perfetto.models.Selection;
-import com.google.gapid.perfetto.models.Selection.CombiningBuilder;
 import com.google.gapid.perfetto.models.SliceTrack;
 import com.google.gapid.perfetto.models.VulkanEventTrack;
 
@@ -264,7 +263,7 @@ public class GpuQueuePanel extends TrackPanel<GpuQueuePanel> implements Selectab
   }
 
   @Override
-  public void computeSelection(CombiningBuilder builder, Area area, TimeSpan ts) {
+  public void computeSelection(Selection.CombiningBuilder builder, Area area, TimeSpan ts) {
     int startDepth = (int)(area.y / SLICE_HEIGHT);
     int endDepth = (int)((area.y + area.h) / SLICE_HEIGHT);
     if (startDepth == endDepth && area.h / SLICE_HEIGHT < SELECTION_THRESHOLD) {

--- a/gapic/src/main/com/google/gapid/perfetto/views/MemorySummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/MemorySummaryPanel.java
@@ -30,7 +30,6 @@ import com.google.gapid.perfetto.canvas.RenderContext;
 import com.google.gapid.perfetto.canvas.Size;
 import com.google.gapid.perfetto.models.MemorySummaryTrack;
 import com.google.gapid.perfetto.models.Selection;
-import com.google.gapid.perfetto.models.Selection.CombiningBuilder;
 import com.google.gapid.perfetto.models.Selection.Kind;
 
 import org.eclipse.swt.SWT;
@@ -241,7 +240,7 @@ public class MemorySummaryPanel extends TrackPanel<MemorySummaryPanel> implement
   }
 
   @Override
-  public void computeSelection(CombiningBuilder builder, Area area, TimeSpan ts) {
+  public void computeSelection(Selection.CombiningBuilder builder, Area area, TimeSpan ts) {
     builder.add(Selection.Kind.Memory, track.getValues(ts));
   }
 

--- a/gapic/src/main/com/google/gapid/perfetto/views/MemorySummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/MemorySummaryPanel.java
@@ -178,8 +178,9 @@ public class MemorySummaryPanel extends TrackPanel<MemorySummaryPanel> implement
   }
 
   @Override
-  protected Hover onTrackMouseMove(Fonts.TextMeasurer m, double x, double y, int mods) {
-    MemorySummaryTrack.Data data = track.getData(state.toRequest(), onUiThread());
+  protected Hover onTrackMouseMove(
+      Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
+    MemorySummaryTrack.Data data = track.getData(state.toRequest(), onUiThread(repainter));
     if (data == null || data.ts.length == 0) {
       return Hover.NONE;
     }

--- a/gapic/src/main/com/google/gapid/perfetto/views/PinnedTracks.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/PinnedTracks.java
@@ -16,7 +16,7 @@
 package com.google.gapid.perfetto.views;
 
 import com.google.gapid.perfetto.canvas.Area;
-import com.google.gapid.perfetto.canvas.Fonts.TextMeasurer;
+import com.google.gapid.perfetto.canvas.Fonts;
 import com.google.gapid.perfetto.canvas.Panel;
 import com.google.gapid.perfetto.canvas.PanelGroup;
 import com.google.gapid.perfetto.canvas.RenderContext;
@@ -65,8 +65,9 @@ public class PinnedTracks extends Panel.Base {
   }
 
   @Override
-  public Hover onMouseMove(TextMeasurer m, double x, double y, int mods) {
-    return group.onMouseMove(m, x, y, mods);
+  public Hover onMouseMove(
+      Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
+    return group.onMouseMove(m, repainter, x, y, mods);
   }
 
   @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/ProcessMemoryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/ProcessMemoryPanel.java
@@ -33,7 +33,6 @@ import com.google.gapid.perfetto.canvas.RenderContext;
 import com.google.gapid.perfetto.canvas.Size;
 import com.google.gapid.perfetto.models.ProcessMemoryTrack;
 import com.google.gapid.perfetto.models.Selection;
-import com.google.gapid.perfetto.models.Selection.CombiningBuilder;
 import com.google.gapid.perfetto.models.Selection.Kind;
 
 import org.eclipse.swt.SWT;
@@ -83,7 +82,7 @@ public class ProcessMemoryPanel extends TrackPanel<ProcessMemoryPanel> implement
         return;
       }
 
-      Selection selected = state.getSelection(Selection.Kind.ProcessMemory);
+      Selection<?> selected = state.getSelection(Selection.Kind.ProcessMemory);
       List<Integer> visibleSelected = Lists.newArrayList();
       long maxUsage = track.getMaxUsage(), maxSwap = Math.max(maxUsage, track.getMaxSwap());
 
@@ -278,7 +277,7 @@ public class ProcessMemoryPanel extends TrackPanel<ProcessMemoryPanel> implement
   }
 
   @Override
-  public void computeSelection(CombiningBuilder builder, Area area, TimeSpan ts) {
+  public void computeSelection(Selection.CombiningBuilder builder, Area area, TimeSpan ts) {
     builder.add(Selection.Kind.ProcessMemory, track.getValues(ts));
   }
 

--- a/gapic/src/main/com/google/gapid/perfetto/views/ProcessMemoryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/ProcessMemoryPanel.java
@@ -28,7 +28,6 @@ import com.google.common.collect.Lists;
 import com.google.gapid.perfetto.TimeSpan;
 import com.google.gapid.perfetto.canvas.Area;
 import com.google.gapid.perfetto.canvas.Fonts;
-import com.google.gapid.perfetto.canvas.Fonts.TextMeasurer;
 import com.google.gapid.perfetto.canvas.RenderContext;
 import com.google.gapid.perfetto.canvas.Size;
 import com.google.gapid.perfetto.models.ProcessMemoryTrack;
@@ -215,8 +214,9 @@ public class ProcessMemoryPanel extends TrackPanel<ProcessMemoryPanel> implement
   }
 
   @Override
-  protected Hover onTrackMouseMove(TextMeasurer m, double x, double y, int mods) {
-    ProcessMemoryTrack.Data data = track.getData(state.toRequest(), onUiThread());
+  protected Hover onTrackMouseMove(
+      Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
+    ProcessMemoryTrack.Data data = track.getData(state.toRequest(), onUiThread(repainter));
     if (data == null || data.ts.length == 0) {
       return Hover.NONE;
     }

--- a/gapic/src/main/com/google/gapid/perfetto/views/ProcessSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/ProcessSummaryPanel.java
@@ -24,7 +24,6 @@ import static com.google.gapid.util.MoreFutures.transform;
 
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
-
 import com.google.gapid.perfetto.TimeSpan;
 import com.google.gapid.perfetto.canvas.Area;
 import com.google.gapid.perfetto.canvas.Fonts;
@@ -34,7 +33,6 @@ import com.google.gapid.perfetto.models.CpuInfo;
 import com.google.gapid.perfetto.models.CpuTrack.Slices;
 import com.google.gapid.perfetto.models.ProcessSummaryTrack;
 import com.google.gapid.perfetto.models.Selection;
-import com.google.gapid.perfetto.models.Selection.CombiningBuilder;
 import com.google.gapid.perfetto.models.ThreadInfo;
 import com.google.gapid.util.Arrays;
 
@@ -365,11 +363,15 @@ public class ProcessSummaryPanel extends TrackPanel<ProcessSummaryPanel> impleme
   }
 
   @Override
-  public void computeSelection(CombiningBuilder builder, Area area, TimeSpan ts) {
-    builder.add(Selection.Kind.Cpu, (ListenableFuture<Slices>)transform(track.getSlices(ts), slices -> {
+  public void computeSelection(Selection.CombiningBuilder builder, Area area, TimeSpan ts) {
+    builder.add(Selection.Kind.Cpu, computeSelection(ts));
+  }
+
+  private ListenableFuture<Slices> computeSelection(TimeSpan ts) {
+    return transform(track.getSlices(ts), slices -> {
       slices.utids.forEach(utid -> state.addSelectedThread(state.getThreadInfo(utid)));
       return slices;
-    }));
+    });
   }
 
   private static class HoverCard {

--- a/gapic/src/main/com/google/gapid/perfetto/views/ProcessSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/ProcessSummaryPanel.java
@@ -217,8 +217,9 @@ public class ProcessSummaryPanel extends TrackPanel<ProcessSummaryPanel> impleme
   }
 
   @Override
-  public Hover onTrackMouseMove(Fonts.TextMeasurer m, double x, double y, int mods) {
-    ProcessSummaryTrack.Data data = track.getData(state.toRequest(), onUiThread());
+  public Hover onTrackMouseMove(
+      Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
+    ProcessSummaryTrack.Data data = track.getData(state.toRequest(), onUiThread(repainter));
     if (data == null) {
       return Hover.NONE;
     }

--- a/gapic/src/main/com/google/gapid/perfetto/views/RootPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/RootPanel.java
@@ -404,14 +404,16 @@ public abstract class RootPanel<S extends State> extends Panel.Base implements S
   }
 
   @Override
-  public Hover onMouseMove(Fonts.TextMeasurer m, double x, double y, int mods) {
+  public Hover onMouseMove(Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
     if (y >= (timeline.getPreferredHeight()/2) && y <= timeline.getPreferredHeight() && x > LABEL_WIDTH) {
       return flagHover(x);
     }
     double topHeight = top.getPreferredHeight();
-    Hover result = (y < topHeight) ? top.onMouseMove(m, x, y, mods) :
-      bottom.onMouseMove(m, x, y - topHeight + state.getScrollOffset(), mods)
-          .transformed(a -> a.translate(0, topHeight - state.getScrollOffset()));
+    Hover result = (y < topHeight) ? top.onMouseMove(m, repainter, x, y, mods) :
+      bottom.onMouseMove(m,
+          repainter.transformed(a -> a.translate(0, topHeight - state.getScrollOffset())),
+          x, y - topHeight + state.getScrollOffset(), mods
+        ).transformed(a -> a.translate(0, topHeight - state.getScrollOffset()));
     if (x >= LABEL_WIDTH && y >= topHeight && result == Hover.NONE) {
       result = result.withClick(() -> state.resetSelections());
     }

--- a/gapic/src/main/com/google/gapid/perfetto/views/ThreadPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/ThreadPanel.java
@@ -259,8 +259,9 @@ public class ThreadPanel extends TrackPanel<ThreadPanel> implements Selectable {
   }
 
   @Override
-  protected Hover onTrackMouseMove(Fonts.TextMeasurer m, double x, double y, int mods) {
-    ThreadTrack.Data data = track.getData(state.toRequest(), onUiThread());
+  protected Hover onTrackMouseMove(
+      Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
+    ThreadTrack.Data data = track.getData(state.toRequest(), onUiThread(repainter));
     if (data == null) {
       return Hover.NONE;
     }

--- a/gapic/src/main/com/google/gapid/perfetto/views/TrackContainer.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TrackContainer.java
@@ -181,22 +181,23 @@ public class TrackContainer {
     }
 
     @Override
-    public Hover onMouseMove(Fonts.TextMeasurer m, double x, double y, int mods) {
+    public Hover onMouseMove(
+        Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
       if (x < LABEL_WIDTH) {
         hovered = true;
         if (toggleDetails != null && y < TITLE_HEIGHT && x >= LABEL_TOGGLE_X && x < LABEL_PIN_X) {
-          return new TrackTitleHover(track.onMouseMove(m, x, y, mods), () -> {
+          return new TrackTitleHover(track.onMouseMove(m, repainter, x, y, mods), () -> {
             showDetails = !showDetails;
             toggleDetails.accept(track, showDetails);
           });
         } else if (y < TITLE_HEIGHT && x >= LABEL_PIN_X) {
-          return new TrackTitleHover(
-              track.onMouseMove(m, x, y, mods), () -> pinState.toggle(this::copyWithSeparator));
+          return new TrackTitleHover(track.onMouseMove(m, repainter, x, y, mods),
+              () -> pinState.toggle(this::copyWithSeparator));
         } else {
-          return new TrackTitleHover(track.onMouseMove(m, x, y, mods), null);
+          return new TrackTitleHover(track.onMouseMove(m, repainter, x, y, mods), null);
         }
       } else {
-        return track.onMouseMove(m, x, y, mods);
+        return track.onMouseMove(m, repainter, x, y, mods);
       }
     }
 
@@ -340,7 +341,8 @@ public class TrackContainer {
     }
 
     @Override
-    public Hover onMouseMove(Fonts.TextMeasurer m, double x, double y, int mods) {
+    public Hover onMouseMove(
+        Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
       if (y < TITLE_HEIGHT && (expanded || x < LABEL_WIDTH)) {
         hovered = true;
         double textEnd =
@@ -355,7 +357,8 @@ public class TrackContainer {
           }
         } else {
           if (x < Math.min(textEnd, LABEL_PIN_X - LABEL_MARGIN)) {
-            return new TrackTitleHover(summary.onMouseMove(m, x, y, mods), redraw, () -> expanded = true);
+            return new TrackTitleHover(
+                summary.onMouseMove(m, repainter, x, y, mods), redraw, () -> expanded = true);
           }
           toggleEnd = LABEL_PIN_X;
           pinEnd = LABEL_WIDTH;
@@ -376,9 +379,11 @@ public class TrackContainer {
       }
 
       if (expanded) {
-        return children.onMouseMove(m, x, y - TITLE_HEIGHT, mods).translated(0, TITLE_HEIGHT);
+        return children.onMouseMove(
+            m, repainter.translated(0, TITLE_HEIGHT), x, y - TITLE_HEIGHT, mods
+          ).translated(0, TITLE_HEIGHT);
       } else {
-        return summary.onMouseMove(m, x, y, mods);
+        return summary.onMouseMove(m, repainter, x, y, mods);
       }
     }
 

--- a/gapic/src/main/com/google/gapid/perfetto/views/TrackPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TrackPanel.java
@@ -93,7 +93,8 @@ public abstract class TrackPanel<T extends TrackPanel<T>> extends Panel.Base
   }
 
   @Override
-  public Hover onMouseMove(Fonts.TextMeasurer m, double x, double y, int mods) {
+  public Hover onMouseMove(
+      Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
     if (x < LABEL_WIDTH) {
       String text = getTooltip();
       if (text.isEmpty()) {

--- a/gapic/src/main/com/google/gapid/perfetto/views/TrackPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TrackPanel.java
@@ -122,16 +122,13 @@ public abstract class TrackPanel<T extends TrackPanel<T>> extends Panel.Base
     } else if (y < TRACK_MARGIN || y > height - TRACK_MARGIN) {
       return Hover.NONE;
     }
-    return onTrackMouseMove(m, x - LABEL_WIDTH, y - TRACK_MARGIN, mods)
-        .translated(LABEL_WIDTH, TRACK_MARGIN);
+    return onTrackMouseMove(m, repainter.translated(LABEL_WIDTH, TRACK_MARGIN),
+        x - LABEL_WIDTH, y - TRACK_MARGIN, mods
+      ).translated(LABEL_WIDTH, TRACK_MARGIN);
   }
 
-  protected abstract Hover onTrackMouseMove(Fonts.TextMeasurer m, double x, double y, int mods);
-
-  // Helper functions for the track.getData(..) calls.
-  protected <D> Track.OnUiThread<D> onUiThread() {
-    return onUiThread(state, () -> { /* do nothing */ });
-  }
+  protected abstract Hover onTrackMouseMove(
+      Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods);
 
   // Helper functions for the track.getData(..) calls.
   protected <D> Track.OnUiThread<D> onUiThread(Repainter repainter) {

--- a/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventPanel.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Lists;
 import com.google.gapid.perfetto.TimeSpan;
 import com.google.gapid.perfetto.canvas.Area;
 import com.google.gapid.perfetto.canvas.Fonts;
-import com.google.gapid.perfetto.canvas.Fonts.TextMeasurer;
 import com.google.gapid.perfetto.canvas.RenderContext;
 import com.google.gapid.perfetto.canvas.Size;
 import com.google.gapid.perfetto.models.GpuInfo;
@@ -152,8 +151,9 @@ public class VulkanEventPanel extends TrackPanel<VulkanEventPanel> implements Se
   }
 
   @Override
-  protected Hover onTrackMouseMove(TextMeasurer m, double x, double y, int mods) {
-    VulkanEventTrack.Data data = track.getData(state.toRequest(), onUiThread());
+  protected Hover onTrackMouseMove(
+      Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
+    VulkanEventTrack.Data data = track.getData(state.toRequest(), onUiThread(repainter));
     if (data == null) {
       return Hover.NONE;
     }

--- a/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventPanel.java
@@ -29,7 +29,6 @@ import com.google.gapid.perfetto.canvas.RenderContext;
 import com.google.gapid.perfetto.canvas.Size;
 import com.google.gapid.perfetto.models.GpuInfo;
 import com.google.gapid.perfetto.models.Selection;
-import com.google.gapid.perfetto.models.Selection.CombiningBuilder;
 import com.google.gapid.perfetto.models.VulkanEventTrack;
 
 import org.eclipse.swt.SWT;
@@ -218,7 +217,7 @@ public class VulkanEventPanel extends TrackPanel<VulkanEventPanel> implements Se
   }
 
   @Override
-  public void computeSelection(CombiningBuilder builder, Area area, TimeSpan ts) {
+  public void computeSelection(Selection.CombiningBuilder builder, Area area, TimeSpan ts) {
     int startDepth = (int)((area.y - SLICE_Y) / SLICE_HEIGHT);
     int endDepth = (int)((area.y + area.h - SLICE_Y) / SLICE_HEIGHT);
     if (startDepth == endDepth && area.h / SLICE_HEIGHT < SELECTION_THRESHOLD) {

--- a/gapic/src/main/com/google/gapid/views/ProfileView.java
+++ b/gapic/src/main/com/google/gapid/views/ProfileView.java
@@ -269,8 +269,9 @@ public class ProfileView extends Composite implements Tab, Capture.Listener, Pro
       }
 
       @Override
-      public Hover onMouseMove(Fonts.TextMeasurer m, double x, double y, int mods) {
-        return (x < LABEL_WIDTH) ? Hover.NONE : track.onMouseMove(m, x, y, mods);
+      public Hover onMouseMove(
+          Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
+        return (x < LABEL_WIDTH) ? Hover.NONE : track.onMouseMove(m, repainter, x, y, mods);
       }
     }
 
@@ -296,14 +297,14 @@ public class ProfileView extends Composite implements Tab, Capture.Listener, Pro
       public ListenableFuture<Slices> getSlices(String concatedId) {
         Set<Long> ids = Sets.newHashSet();
         Arrays.stream(concatedId.split(",")).mapToLong(Long::parseLong).forEach(ids::add);
-        return Scheduler.EXECUTOR.submit(() -> this.toSlices(slices.stream()
+        return Scheduler.EXECUTOR.submit(() -> toSlices(slices.stream()
             .filter(s -> ids.contains(s.getId()))
             .collect(toList())));
       }
 
       @Override
       public ListenableFuture<Slices> getSlices(TimeSpan ts, int minDepth, int maxDepth) {
-        return Scheduler.EXECUTOR.submit(() -> this.toSlices(slices.stream()
+        return Scheduler.EXECUTOR.submit(() -> toSlices(slices.stream()
             .filter(s -> ts.overlaps(s.getTs(), s.getTs() + s.getDur()))
             .filter(s -> s.getDepth() >= minDepth && s.getDepth() <= maxDepth)
             .collect(toList())));
@@ -342,11 +343,11 @@ public class ProfileView extends Composite implements Tab, Capture.Listener, Pro
         });
       }
 
-      private Slices toSlices(Service.ProfilingData.GpuSlices.Slice serverSlice) {
+      private static Slices toSlices(Service.ProfilingData.GpuSlices.Slice serverSlice) {
         return new Slices(Lists.newArrayList(serverSlice), "GPU Queue Events");
       }
 
-      private Slices toSlices(List<Service.ProfilingData.GpuSlices.Slice> serverSlices) {
+      private static Slices toSlices(List<Service.ProfilingData.GpuSlices.Slice> serverSlices) {
         return new Slices(serverSlices, "GPU Queue Events");
       }
     }


### PR DESCRIPTION
In the counter hover tooltip, if a time range has been selected, show the min/avg/max values of that range. If no range is selected, keep showing the total trace min/avg/max. The tooltip indicates whether it shows the trace or range values.

Bug: http://b/156680380