### PR TITLE
Trim down invalid ftrace events to the time all data producers ack start.

### DIFF
--- a/gapis/perfetto/cc/processor.cpp
+++ b/gapis/perfetto/cc/processor.cpp
@@ -27,6 +27,10 @@ namespace ptp = perfetto::trace_processor;
 
 processor new_processor() {
   ptp::Config config;
+  // TODO(b/154156099): In Android S, AGI should use the time when trace starts
+  // instead of the time when all data sources ack the start.
+  config.drop_ftrace_data_before =
+      ptp::DropFtraceDataBefore::kAllDataSourcesStarted;
   return ptp::TraceProcessor::CreateInstance(config).release();
 }
 

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -185,8 +185,8 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
         name = "perfetto",
         locals = locals,
         remote = "https://android.googlesource.com/platform/external/perfetto",
-        commit = "026b1e2be09a8cd8ced37f99e771eca00ea439b0",
-        shallow_since = "1595276873 +0000",
+        commit = "bbba7b0b884545401dbf5272819823752812412b",
+        shallow_since = "1595504601 +0100",
     )
 
     maybe_repository(


### PR DESCRIPTION
The ftrace can occasionally be buggy and may lead to events being included in
the trace from well before the tracing started. Until now we've just included
these events in the trace even though they really shouldn't be.

Now that Perfetto has introduced parsing of the tracing_started
TraceServiceEvent which gives the timestamp where tracing started (before any
producer is informed of tracing being ready) as well as the timestamp of when
all data producers ack the start. This patch modifies our trace processor
wrapper to use this option to filter out all events before it.

Note that such filtering is restricted to ftrace only as it's the only data
source fully under Perfetto's control, hence it's possible that other data
producers write data from before trace start.

Bug: b/154156099