### PR TITLE
Support GpuMemTotal datasource for initial counter values

### DIFF
--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -45,6 +45,7 @@ const (
 
 	maxRootAttempts                         = 5
 	gpuRenderStagesDataSourceDescriptorName = "gpu.renderstages"
+	gpuMemTotalDataSourceDescriptorName     = "android.gpu.memory"
 
 	perfettoPort = NamedFileSystemSocket("/dev/socket/traced_consumer")
 
@@ -353,6 +354,7 @@ func (b *binding) QueryPerfettoServiceState(ctx context.Context) (*device.Perfet
 // that support the GPU profiling functionailities, it includes:
 //     1) gpu.counters
 //     2) gpu.renderstages
+//     3) android.gpu.memory
 func (b *binding) QueryPerfettoGpuProfilingDataSources(ctx context.Context) (*device.GPUProfiling, error) {
 	gpu := &device.GPUProfiling{}
 	encoded, err := b.Shell("perfetto", "--query-raw", "|", "base64").Call(ctx)
@@ -369,6 +371,10 @@ func (b *binding) QueryPerfettoGpuProfilingDataSources(ctx context.Context) (*de
 		desc := ds.GetDsDescriptor()
 		if desc.GetName() == gpuRenderStagesDataSourceDescriptorName {
 			gpu.HasRenderStage = true
+			continue
+		}
+		if desc.GetName() == gpuMemTotalDataSourceDescriptorName {
+			gpu.HasGpuMemTotal = true
 			continue
 		}
 		counters := desc.GetGpuCounterDescriptor().GetSpecs()

--- a/core/os/device/device.proto
+++ b/core/os/device/device.proto
@@ -195,6 +195,7 @@ message GPUProfiling {
   GpuCounterDescriptor gpu_counter_descriptor = 2;
   reserved 3;
   bool has_render_stage_producer_layer = 4;
+  bool has_gpu_mem_total = 5;
 }
 
 // Instance represents a physical device.

--- a/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
@@ -137,10 +137,13 @@ public class Tracks {
         .filter(c -> c.count > 0)
         .collect(toMap(c -> c.id, c -> c));
 
-    List<CounterInfo> gpuMemGlobalCounter = data.getCounters().values().stream()
-        .filter(c -> c.type == CounterInfo.Type.Global && c.ref == 0 /* pid - 0 */
-        && c.count > 0 && c.name.equals("gpumemtotal.global"))
-        .collect(toList());
+    List<CounterInfo> gpuMemGlobalCounter =
+        data.getCounters().values().stream()
+            .filter(c -> c.type == CounterInfo.Type.Global &&
+                c.ref == 0 /* pid - 0 */ &&
+                c.count > 0 &&
+                c.name.equals("GPU Memory"))
+            .collect(toList());
 
     if (counters.isEmpty() && data.getGpu().isEmpty() && gpuMemGlobalCounter.isEmpty()) {
       // No GPU data available.

--- a/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
@@ -66,12 +66,6 @@ public class CounterPanel extends TrackPanel<CounterPanel> implements Selectable
     if (info.type == CounterInfo.Type.Gpu && "gpufreq".equals(info.name)) {
       return "GPU " + info.ref + " Frequency";
     }
-    if (info.type == CounterInfo.Type.Process && "gpumemtotal.process".equals(info.name)) {
-      return "GPU Memory Process Total";
-    }
-    if (info.type == CounterInfo.Type.Global && "gpumemtotal.global".equals(info.name)) {
-      return "GPU Memory Global Total";
-    }
     return track.getCounter().name;
   }
 

--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
@@ -295,6 +295,14 @@ public class TraceConfigDialog extends DialogBase {
             .getConfigBuilder()
                 .setName("android.surfaceflinger.frame");
       }
+      // Always enable GPU memory total counters, if available, because this
+      // datasource provides the initial counters upon tracing start, while the
+      // gpu_mem/gpu_mem_total ftrace tracepoint provides later counter updates.
+      if (gpuCaps.getHasGpuMemTotal()) {
+        config.addDataSourcesBuilder()
+            .getConfigBuilder()
+                .setName("android.gpu.memory");
+      }
     }
 
     if (p.getMemoryOrBuilder().getEnabled()) {

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -185,8 +185,8 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
         name = "perfetto",
         locals = locals,
         remote = "https://android.googlesource.com/platform/external/perfetto",
-        commit = "bbba7b0b884545401dbf5272819823752812412b",
-        shallow_since = "1595504601 +0100",
+        commit = "1dd60f85b97ef5068e9a39a4165087ccbdf6b09f",
+        shallow_since = "1596837015 -0700",
     )
 
     maybe_repository(


### PR DESCRIPTION
This PR includes the following changes:

1. Add the GPU memory total datasource to the trace config if the producer is available.
2. The raw counter name of GPU Memory total has been updated, so the special mappings have been removed.

Bug: 157152869

<img width="963" alt="unit" src="https://user-images.githubusercontent.com/2199903/89805763-fcff1780-daea-11ea-8a5b-650885d4bf63.png">
<img width="458" alt="tooltip_proc" src="https://user-images.githubusercontent.com/2199903/89805767-fec8db00-daea-11ea-85ca-a89441148ba8.png">
<img width="708" alt="tooltip_global" src="https://user-images.githubusercontent.com/2199903/89805769-ff617180-daea-11ea-89d1-5c6f339f7f58.png">
<img width="1674" alt="initial_counter_from_producer" src="https://user-images.githubusercontent.com/2199903/89805931-359ef100-daeb-11ea-80ae-cf7a22327b83.png">


