### PR TITLE
Fix undefined pool ID sometimes panicking state rebuilder

### DIFF
--- a/gapii/cc/spy_base.cpp
+++ b/gapii/cc/spy_base.cpp
@@ -37,6 +37,7 @@ SpyBase::SpyBase()
 #endif  // TARGET_OS
       mDisableCoherentMemoryTracker(false),
       mHideUnknownExtensions(false),
+      mNextPoolId(1),  // Start at 1 as 0 is reserved for application pool
       mNullEncoder(PackEncoder::noop()),
       mDeviceInstance(nullptr),
       mCurrentABI(nullptr),

--- a/gapis/memory/pool.go
+++ b/gapis/memory/pool.go
@@ -181,7 +181,7 @@ func (m *Pool) String() string {
 }
 
 // NextPoolID returns the next free pool ID (but does not assign it).
-// All existing pools in the set have pool ID which is less then this value.
+// All existing pools in the set have pool ID which is less than this value.
 func (m *Pools) NextPoolID() PoolID {
 	return m.nextPoolID
 }
@@ -201,7 +201,7 @@ func (m *Pools) New() (id PoolID, p *Pool) {
 // NewAt creates and returns a new Pool with a specific ID, fails if it cannot
 func (m *Pools) NewAt(id PoolID) *Pool {
 	if _, ok := m.pools[id]; ok {
-		panic("Could not create given pool")
+		panic(fmt.Sprintf("Could not create pool at id %v since it already exists", id))
 	}
 	p := &Pool{}
 	m.pools[id] = p


### PR DESCRIPTION
Initialize gapii spy mNextPoolId to 1, such that observations recorded
when encoding the state at the beginning of a mid-execution capture
have relevant pool IDs. As this field was not initialized, it had an
undefined value which in practice was often either:

 - 0, such that the first observation related to state encoding would
   end up in the application pool ID 0 -- while this is bogus, it
   seemed to be working fine in most cases.

 - -1 (0xffffffff), such that the second observation would have a pool
   ID of 0, leading to a panic in the state rebuilder when trying to
   create this pool ID 0 since this pool ID is already present as the
   application pool (the panic is in gapis/memory.Pools.NewAt())

Also, improve the panic error message to indicate the requested pool
ID, and fix a typo.

Bug: b/157626574
Test: manual, with an app that exposed the panic quite regularly