### PR TITLE
[Frame events] Fix instant events depth and ignore negative duration slices

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/models/FrameInfo.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/FrameInfo.java
@@ -76,6 +76,8 @@ public class FrameInfo {
       "where gpu_track.id = %d";
   private static final String MAX_DEPTH_QUERY =
       "select max(depth) from %s";
+  private static final String EVENTS_COUNT_QUERY =
+      "select COUNT(1) from %s";
 
   private static final String DISPLAY_TOOLTIP =
       "The time when from was on screen";
@@ -261,13 +263,15 @@ public class FrameInfo {
     return transformAsync(qe.queries(
         dropView("buffer_" + trackId),
         createView("buffer_" + trackId, buffersViewQuery(trackId))), $ -> {
-          // Depth of instant events is always 1, the depth query can be avoided here.
-          buffers.add(new Event(names.get(idx), "buffer_" + trackId, 1));
-          if (idx + 1 >= trackIds.size()) {
-            return Futures.immediateFuture(buffers);
-          }
-          // Create view for the next buffer.
-          return createBufferViews(qe, trackIds, names, buffers, idx + 1);
+          return transformAsync(expectOneRow(qe.query(eventsCountQuery("buffer_" + trackId))), r -> {
+            // Depth of instant events is always 1, the depth query can be avoided here.
+            buffers.add(new Event(names.get(idx), "buffer_" + trackId, 1, r.getLong(0)));
+            if (idx + 1 >= trackIds.size()) {
+              return Futures.immediateFuture(buffers);
+            }
+            // Create view for the next buffer.
+            return createBufferViews(qe, trackIds, names, buffers, idx + 1);
+          });
     });
   }
 
@@ -283,8 +287,13 @@ public class FrameInfo {
     return format(BUFFERS_VIEW_QUERY, filter);
   }
 
+  private static String eventsCountQuery(String viewName) {
+    return format(EVENTS_COUNT_QUERY, viewName);
+  }
+
   public static class Layer {
     public final String layerName;
+    public final long numEvents;
     private final List<Event> bufferEvents;
     private final List<Event> phaseEvents;
 
@@ -292,6 +301,7 @@ public class FrameInfo {
       this.layerName = layerName;
       this.bufferEvents = bufferEvents;
       this.phaseEvents = phaseEvents;
+      this.numEvents = bufferEvents.stream().mapToLong(e -> e.numEvents).sum();
     }
 
     public boolean isBufferEventsEmpty() {
@@ -324,19 +334,22 @@ public class FrameInfo {
     public final String viewName;
     public final long maxDepth;
     public final String tooltip;
+    public final long numEvents;
 
     public Event(String name, String viewName, long maxDepth, String tooltip) {
       this.name = name;
       this.viewName = viewName;
       this.maxDepth = maxDepth;
       this.tooltip = tooltip;
+      this.numEvents = 0;
     }
 
-    public Event(String name, String viewName, long maxDepth) {
+    public Event(String name, String viewName, long maxDepth, long numEvents) {
       this.name = name;
       this.viewName = viewName;
       this.maxDepth = maxDepth;
       this.tooltip = name;
+      this.numEvents = numEvents;
     }
 
     public String getDisplay() {

--- a/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
@@ -242,9 +242,19 @@ public class Tracks {
       data.tracks.addLabelGroup(null, parent, "Surface Flinger Events",
           group(state -> new TitlePanel("Surface Flinger Events"), true));
 
+      // We assume here that the target application's layer will generally have more
+      // events than unintended layers from the likes of StatusBar, NavBar etc.
+      long maxEvents = 0;
       for (FrameInfo.Layer layer : data.getFrame().layers()) {
+        if (layer.numEvents > maxEvents) {
+          maxEvents = layer.numEvents;
+        }
+      }
+
+      for (FrameInfo.Layer layer : data.getFrame().layers()) {
+        boolean expanded = (layer.numEvents == maxEvents);
         data.tracks.addLabelGroup(parent, layer.layerName, layer.layerName,
-            group(state -> new TitlePanel(layer.layerName), true));
+            group(state -> new TitlePanel("Layer - " + layer.layerName), expanded));
         for (FrameInfo.Event phase : layer.phaseEvents()) {
           FrameEventsTrack track = FrameEventsTrack.forFrameEvent(data.qe, layer.layerName, phase);
           data.tracks.addTrack(layer.layerName, track.getId(), phase.getDisplay(),

--- a/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsPanel.java
@@ -137,7 +137,7 @@ public class FrameEventsPanel extends TrackPanel<FrameEventsPanel>
         double y = depth * SLICE_HEIGHT;
         double[] diamondX = { rectStart - (rectWidth / 2), rectStart, rectStart + (rectWidth / 2),
             rectStart};
-        double[] diamondY = { y + (SLICE_HEIGHT / 2), y, y + (SLICE_HEIGHT / 2), SLICE_HEIGHT };
+        double[] diamondY = { y + (SLICE_HEIGHT / 2), y, y + (SLICE_HEIGHT / 2), y + SLICE_HEIGHT };
         ctx.fillPolygon(diamondX, diamondY, 4);
 
         if (selected.contains(data.ids[i]) || selectedFrameNumbers.contains(data.frameNumbers[i])) {


### PR DESCRIPTION
Due to missing events (happens at the end of the trace and sometimes randomly), the artificial slices we create for the phases track end up having negative duration. Our assumption that <=0 duration is meant for instant events becomes a problem here because of the -1 duration for these slices. This change fixes this by ignoring -1 duration slices altogether, since they do not represent any meaningful data and it goes against our design to draw diamonds and slices together on the same track.

Bug: 159623083