### PR TITLE
[Frame events] Fix view names when layer name starts with a number

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/models/FrameInfo.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/FrameInfo.java
@@ -152,7 +152,10 @@ public class FrameInfo {
   private static ListenableFuture<List<List<Event>>> createPhases(QueryEngine qe,
       List<List<Event>> phases, List<String> layerNames, int idx) {
     String layerName = layerNames.get(idx);
-    String baseName = layerName.replaceAll("[^A-Za-z0-9]", "");
+    // SQL tables cannot start with a numeric or contain special characters.
+    // Some toast messages do not set the layer name properly.
+    // For example, "#0" is a valid layer name but cannot be used directly for SQL
+    String baseName = ("Layer" + layerName).replaceAll("[^A-Za-z0-9]", "");
     List<Event> currentLayerPhases = Lists.newArrayList();
 
     // Example:


### PR DESCRIPTION
There are cases where some apps do not set layer names properly, and we
receive, for example, "#0" as layer names. After removing
non-alphanumeric characters, the name we will have is just "0". SQL
tables cannot start with a number. A simple fix here is to prepend some
text to all layers. These names are used only internally for view
creation, so the UI is not going to be affected.

Bug: 166511262