### PR TITLE
Fix for destroying the last instance on windows.

### DIFF
--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -16,6 +16,12 @@
 
 #include "spy.h"
 
+#include <cstdlib>
+#include <memory>
+#include <sstream>
+#include <thread>
+#include <vector>
+
 #include "connection_header.h"
 #include "connection_stream.h"
 #include "protocol.h"
@@ -35,11 +41,10 @@
 #include "gapis/capture/capture.pb.h"
 #include "gapis/memory/memory_pb/memory.pb.h"
 
-#include <cstdlib>
-#include <memory>
-#include <sstream>
-#include <thread>
-#include <vector>
+#if TARGET_OS == GAPID_OS_WINDOWS
+#include <windows.h>
+#include "windows/wgl.h"
+#endif  //  TARGET_OS == GAPID_OS_WINDOWS
 
 #if TARGET_OS == GAPID_OS_ANDROID
 
@@ -68,6 +73,9 @@ namespace gapii {
 
 struct spy_creator {
   spy_creator() {
+#if TARGET_OS == GAPID_OS_WINDOWS
+    LoadLibraryA("libgapii");
+#endif
     GAPID_LOGGER_INIT(LOG_LEVEL_INFO, "gapii", nullptr);
     GAPID_INFO("Constructing spy...");
     m_spy.reset(new Spy());

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -43,7 +43,6 @@
 
 #if TARGET_OS == GAPID_OS_WINDOWS
 #include <windows.h>
-#include "windows/wgl.h"
 #endif  //  TARGET_OS == GAPID_OS_WINDOWS
 
 #if TARGET_OS == GAPID_OS_ANDROID


### PR DESCRIPTION
If a game destroys that last instance, some static data
will fail to get cleaned up causing a crash. Prevent
libgapii from being unloaded on windows in this case.

Cherry-pick of: https://github.com/google/gapid/pull/3843