### PR TITLE
Move frame lifecycle out of experimental

### DIFF
--- a/cmd/gapit/common.go
+++ b/cmd/gapit/common.go
@@ -69,7 +69,6 @@ func getGapis(ctx context.Context, gapisFlags GapisFlags, gapirFlags GapirFlags)
 
 	args = append(args, "--experimental-enable-vulkan-tracing")
 	args = append(args, "--experimental-enable-angle-tracing")
-	args = append(args, "--experimental-enable-frame-lifecycle")
 	args = append(args, "--experimental-enable-perf-tab")
 
 	if app.Flags.Analytics != "" {

--- a/core/app/flags/experimental.go
+++ b/core/app/flags/experimental.go
@@ -23,8 +23,7 @@ import (
 //     2) be by default false/off
 //     3) be removed once the feature is no longer in experiment
 var (
-	EnableFrameLifecycle = flag.Bool("experimental-enable-frame-lifecycle", false, "Enable the experimental feature Frame Lifecycle.")
-	EnableVulkanTracing  = flag.Bool("experimental-enable-vulkan-tracing", false, "Enable the experimental feature Vulkan tracing.")
-	EnableAngleTracing   = flag.Bool("experimental-enable-angle-tracing", false, "Enable the experimental feature ANGLE tracing.")
-	EnablePerfTab        = flag.Bool("experimental-enable-perf-tab", false, "Enable the experimental feature Counter performance tab.")
+	EnableVulkanTracing = flag.Bool("experimental-enable-vulkan-tracing", false, "Enable the experimental feature Vulkan tracing.")
+	EnableAngleTracing  = flag.Bool("experimental-enable-angle-tracing", false, "Enable the experimental feature ANGLE tracing.")
+	EnablePerfTab       = flag.Bool("experimental-enable-perf-tab", false, "Enable the experimental feature Counter performance tab.")
 )

--- a/core/os/android/adb/BUILD.bazel
+++ b/core/os/android/adb/BUILD.bazel
@@ -36,7 +36,6 @@ go_library(
     deps = [
         "//core/app:go_default_library",
         "//core/app/crash:go_default_library",
-        "//core/app/flags:go_default_library",
         "//core/context/keys:go_default_library",
         "//core/event/task:go_default_library",
         "//core/fault:go_default_library",

--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/gapid/core/app"
-	"github.com/google/gapid/core/app/flags"
 	"github.com/google/gapid/core/fault"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/android"
@@ -344,7 +343,7 @@ func (b *binding) QueryPerfettoServiceState(ctx context.Context) (*device.Perfet
 
 	// SurfaceFlinger frame lifecycle perfetto producer is mandated by Android 11 CTS, hence it will
 	// always exist.
-	if b.Instance().GetConfiguration().GetOS().GetAPIVersion() >= 30 && *flags.EnableFrameLifecycle {
+	if b.Instance().GetConfiguration().GetOS().GetAPIVersion() >= 30 {
 		result.HasFrameLifecycle = true
 	}
 	return result, nil

--- a/gapic/src/main/com/google/gapid/Main.java
+++ b/gapic/src/main/com/google/gapid/Main.java
@@ -48,7 +48,6 @@ import com.google.gapid.widgets.Widgets;
 
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.window.Window;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
@@ -228,7 +227,6 @@ public class Main {
     Flags.version,
     Devices.skipDeviceValidation,
     Experimental.enableAll,
-    Experimental.enableFrameLifecycle,
     Experimental.enableVulkanTracing,
     Experimental.enableAngleTracing,
     Experimental.enablePerfTab,

--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
@@ -550,7 +550,7 @@ public class TraceConfigDialog extends DialogBase {
 
         if (caps.getHasFrameLifecycle()) {
           gpuFrame = createCheckbox(
-              gpuGroup, "Frame Lifecycle (experimental)", sGpu.getSurfaceFlinger(), e -> updateGpu());
+              gpuGroup, "Frame Lifecycle", sGpu.getSurfaceFlinger(), e -> updateGpu());
         } else {
           gpuFrame = null;
         }

--- a/gapic/src/main/com/google/gapid/util/Experimental.java
+++ b/gapic/src/main/com/google/gapid/util/Experimental.java
@@ -29,9 +29,6 @@ public class Experimental {
       "Enable all experimental features. " +
       "Features turned on by this flag are all unstable and under development.");
 
-  public static final Flag<Boolean> enableFrameLifecycle = Flags.value("experimental-enable-frame-lifecycle",
-      false, "Enable the experimental feature Frame Lifecycle.");
-
   public static final Flag<Boolean> enableVulkanTracing = Flags.value("experimental-enable-vulkan-tracing",
       false, "Enable the experimental feature Vulkan tracing.");
 
@@ -46,14 +43,10 @@ public class Experimental {
     // The --experimental-enable-all flag is a sugar flag from the UI. GAPIS knows nothing about it.
     if (enableAllExperimentalFeatures || Experimental.enableAll.get()) {
       // All --experimental-enable-<feature-name> flags must be added here.
-      args.add("--experimental-enable-frame-lifecycle");
       args.add("--experimental-enable-vulkan-tracing");
       args.add("--experimental-enable-angle-tracing");
       args.add("--experimental-enable-perf-tab");
     } else {
-      if (Experimental.enableFrameLifecycle.get()) {
-        args.add("--experimental-enable-frame-lifecycle");
-      }
       if (Experimental.enableVulkanTracing.get()) {
         args.add("--experimental-enable-vulkan-tracing");
       }


### PR DESCRIPTION
Frame lifecycle was moved to experimental while working on the UI. Now that the new UI is complete, we can move it out of experimental.

Bug: 161440963