### PR TITLE
Improve wording of warning for no app selected

### DIFF
--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -283,8 +283,9 @@ public class TracerDialog {
       private static final String MEC_LABEL_WARNING =
           "NOTE: Mid-Execution capture for %s is experimental";
       private static final String PERFETTO_LABEL = "Profile Config: ";
+      // Quote 'GPU activity' in the warning message to match the config panel tickbox title.
       private static final String EMPTY_APP_WITH_RENDER_STAGE =
-          "Warning: cannot record GPU activity (render stages) when no application is selected";
+          "Warning: cannot record 'GPU activity' when no application is selected";
 
       private final String date = TRACE_DATE_FORMAT.format(new Date());
 

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -284,7 +284,7 @@ public class TracerDialog {
           "NOTE: Mid-Execution capture for %s is experimental";
       private static final String PERFETTO_LABEL = "Profile Config: ";
       private static final String EMPTY_APP_WITH_RENDER_STAGE =
-          "Warning: Application needs to be specified for GPU profiling data.";
+          "Warning: cannot record GPU activity (render stages) when no application is selected";
 
       private final String date = TRACE_DATE_FORMAT.format(new Date());
 


### PR DESCRIPTION
The previous message can be understood as: an application MUST be
selected to obtain ANY profiling data. Rewording to clarify that only
render stages will not be recorded.

Bug: b/159794064