### PR TITLE
Fix compilation-time apic warning

### DIFF
--- a/gapis/api/templates/BUILD.bazel
+++ b/gapis/api/templates/BUILD.bazel
@@ -55,10 +55,7 @@ filegroup(
 
 api_template(
     name = "api",
-    includes = [
-        "c_common.tmpl",
-        ":go_common_deps",
-    ],
+    includes = [":go_common_deps"],
     outputs = [
         "api.go",
         "api_amrp.go",

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -16,7 +16,6 @@
 
 {{/* ---- Includes ---- */}}
 {{Include "go_common.tmpl"}}
-{{Include "c_common.tmpl"}}
 
 {{$ | Macro "ApiGo"}}
 

--- a/gapis/api/templates/api_types.go.tmpl
+++ b/gapis/api/templates/api_types.go.tmpl
@@ -16,7 +16,6 @@
 
 {{/* ---- Includes ---- */}}
 {{Include "go_common.tmpl"}}
-{{Include "c_common.tmpl"}}
 
 {{$ | Macro "api_types.go" | GoFmt | Write "api_types.go"}}
 


### PR DESCRIPTION
Delete useless imports that were triggering a warning.

Bug: b/168111325