### PR TITLE
Use grpc's forceful stop instead of the graceful stop.

### DIFF
--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -138,7 +138,7 @@ func (s *grpcServer) stopIfIdle(ctx context.Context, server *grpc.Server, idleTi
 	stoppedSignal, stopped := task.NewSignal()
 	defer func() {
 		stop()
-		server.GracefulStop()
+		server.Stop()
 		stopped(ctx)
 	}()
 
@@ -171,7 +171,7 @@ func (s *grpcServer) stopOnInterrupt(ctx context.Context, server *grpc.Server, s
 	stoppedSignal, stopped := task.NewSignal()
 	defer func() {
 		stop()
-		server.GracefulStop()
+		server.Stop()
 		stopped(ctx)
 	}()
 


### PR DESCRIPTION
The graceful stop seems to deadlock when there are streaming RPCs.