### PR TITLE
Add wait-for-debugger option in GAPII

### DIFF
--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -330,8 +330,9 @@ type (
 		Local struct {
 			Port int `help:"connect to an application already running on the server using this port"`
 		}
-		PipeName string `help:"The name of the pipe to connect/listen to."`
-		Perfetto string `help:"File containing the Perfetto configuration proto."`
+		PipeName        string `help:"The name of the pipe to connect/listen to."`
+		Perfetto        string `help:"File containing the Perfetto configuration proto."`
+		WaitForDebugger bool   `help:"Make GAPII wait for a debugger to attach"`
 	}
 	BenchmarkFlags struct {
 		DeviceFlags

--- a/cmd/gapit/trace.go
+++ b/cmd/gapit/trace.go
@@ -244,6 +244,7 @@ func (verb *traceVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		ServerLocalSavePath:          out,
 		PipeName:                     verb.PipeName,
 		DisableCoherentMemoryTracker: verb.Disable.CoherentMemoryTracker,
+		WaitForDebugger:              verb.WaitForDebugger,
 	}
 	target(options)
 

--- a/gapii/cc/connection_header.h
+++ b/gapii/cc/connection_header.h
@@ -38,6 +38,8 @@ class ConnectionHeader {
 
   static const size_t MAX_PATH = 512;
 
+  // NOTE: flags must be kept in sync with gapii/client/capture.go
+
   // Fakes no support for PCS, forcing the app to share shader source.
   static const uint32_t FLAG_DISABLE_PRECOMPILED_SHADERS = 0x00000001;
   // Driver errors are queried after each call and stored as extras.
@@ -52,6 +54,8 @@ class ConnectionHeader {
   static const uint32_t FLAG_STORE_TIMESTAMPS = 0x00000080;
   // Disables the coherent memory tracker (useful for debug)
   static const uint32_t FLAG_DISABLE_COHERENT_MEMORY_TRACKER = 0x00000100;
+  // Waits for the debugger to attach (useful for debug)
+  static const uint32_t FLAG_WAIT_FOR_DEBUGGER = 0x00000200;
 
   // read reads the ConnectionHeader from the provided stream, returning true
   // on success or false on error.

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -24,6 +24,7 @@
 
 #include "gapii/cc/spy.h"
 
+#include "core/cc/debugger.h"
 #include "core/cc/lock.h"
 #include "core/cc/log.h"
 #include "core/cc/null_writer.h"
@@ -172,6 +173,13 @@ Spy::Spy()
   SpyBase::set_current_abi(query::currentABI());
   if (!SpyBase::writeHeader()) {
     GAPID_ERROR("Failed at writing trace header.");
+  }
+
+  // Waiting for debugger must come after we sent back the trace header,
+  // otherwise GAPIS thinks GAPII had an issue at init time.
+  if (header.mFlags & ConnectionHeader::FLAG_WAIT_FOR_DEBUGGER) {
+    GAPID_INFO("Wait for debugger");
+    core::Debugger::waitForAttach();
   }
 
   auto context = enter("init", 0);

--- a/gapii/client/capture.go
+++ b/gapii/client/capture.go
@@ -34,6 +34,9 @@ import (
 type Flags uint32
 
 const (
+
+	// NOTE: flags must be kept in sync with gapii/cc/connection_header.h
+
 	// DeferStart does not start tracing right away but waits for a signal
 	// from gapit
 	DeferStart Flags = 0x00000010
@@ -47,6 +50,8 @@ const (
 	StoreTimestamps Flags = 0x00000080
 	// DisableCoherentMemoryTracker disables the coherent memory tracker from running.
 	DisableCoherentMemoryTracker Flags = 0x000000100
+	// WaitForDebugger makes gapii wait for a debugger to connect
+	WaitForDebugger Flags = 0x000000200
 
 	// VulkanAPI is hard-coded bit mask for Vulkan API, it needs to be kept in sync
 	// with the api_index in the vulkan.api file.

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -1146,6 +1146,8 @@ message TraceOptions {
   string pipe_name = 22;
   // Disable coherent_memory_tracking. (Useful if you want to attach a debugger)
   bool disable_coherent_memory_tracker = 25;
+  // Make GAPII wait for a debugger to attach
+  bool wait_for_debugger = 26;
   // The config to use if doing a Perfetto trace.
   perfetto.protos.TraceConfig perfetto_config = 24;
 }

--- a/gapis/trace/tracer/tracer.go
+++ b/gapis/trace/tracer/tracer.go
@@ -131,6 +131,9 @@ func GapiiOptions(o *service.TraceOptions) gapii.Options {
 	if o.DisableCoherentMemoryTracker {
 		flags |= gapii.DisableCoherentMemoryTracker
 	}
+	if o.WaitForDebugger {
+		flags |= gapii.WaitForDebugger
+	}
 
 	return gapii.Options{
 		o.ObserveFrameFrequency,


### PR DESCRIPTION
Add all the necessary plumbing to have a -waitfordebugger flag when
tracing that forces GAPII to wait for a debugger to attach.

This makes it much easier to debug capture-time issues.

Bug: b/149735005
Test: manual