### PR TITLE
Fix a NPE triggered by querying unloaded profile.

### DIFF
--- a/gapic/src/main/com/google/gapid/views/PerformanceView.java
+++ b/gapic/src/main/com/google/gapid/views/PerformanceView.java
@@ -101,6 +101,10 @@ public class PerformanceView extends Composite
 
   @Override
   public void onProfileLoaded(Loadable.Message error) {
+    if (error != null) {
+      loading.showMessage(error);
+      return;
+    }
     // Create columns for counters after profile get loaded, because we need to know counter numbers.
     for (Service.ProfilingData.Counter counter : models.profile.getData().getCounters()) {
       tree.addColumnForCounter(counter);


### PR DESCRIPTION
 - Sometimes a profile loading will fail in practice, e.g. when desktop replay profiling
 is unsupported. At performance tab's column initialization, check whether there's a
 valid profile data first before the attempt to fetch the profile's counter data.
 - Bug: b/168807497.