### PR TITLE
Fix vkCmdEndRenderPass number of attachment

### DIFF
--- a/gapis/api/vulkan/api/renderpass_framebuffer.api
+++ b/gapis/api/vulkan/api/renderpass_framebuffer.api
@@ -471,9 +471,11 @@ cmd void vkCmdEndRenderPass(
     } else {
       rpo := cmdBuf.CurrentRecordingRenderpass
       for _, i, at in rpo.AttachmentDescriptions {
-        view := cmdBuf.CurrentRecordingFramebuffer.ImageAttachments[i]
-        rng := view.SubresourceRange
-        RecordLayoutTransition(cmdBuf, view.Image, rng, at.finalLayout)
+        if (i < len(cmdBuf.CurrentRecordingFramebuffer.ImageAttachments)) {
+          view := cmdBuf.CurrentRecordingFramebuffer.ImageAttachments[i]
+          rng := view.SubresourceRange
+          RecordLayoutTransition(cmdBuf, view.Image, rng, at.finalLayout)
+        }
       }
     }
     cmdBuf.CurrentRecordingRenderpass = null


### PR DESCRIPTION
In vkCmdEndRenderPass, it was assumed that there is the same number of
CurrentRecordingFramebuffer.ImageAttachments and
cmdBuf.CurrentRecordingRenderpass.AttachmentDescriptions, whereas
these two numbers can differ.

For example:

- framebuffer FB is created with 1 attachement, based on renderpass
  RP1 which has attachementCount of 1

- vkCmdBeginRenderPass is called with FB, and another renderpass RP2
  which has 2 attachements: in our code, this will result in
  cmdBuf.CurrentRecordingRenderpass (RP2) to have 2 attachements,
  while cmdBuf.CurrentRecordingFramebuffer (FB) has 1 attachement.

This is OK as the spec requirement is for RP1 and RP2 to be
"compatible" (VUID-VkRenderPassBeginInfo-renderPass-00904), and
renderpass compatibility does not enforce to have the same number of
attachements, see spec v1.2 sec7.2 "Render Pass Compatibility":

> Two arrays of attachment references are compatible if all
> corresponding pairs of attachments are compatible. If the arrays are
> of different lengths, attachment references not present in the
> smaller array are treated as VK_ATTACHMENT_UNUSED.

The fix makes sure we stay within the relevant number of attachements.

Bug: b/168803168

Test: manual, on a trace that systematically triggers an issue due to
accessing an inexisting framebuffer attachement.