### PR TITLE
Don't attribute replay state reconstruction to server time.

### DIFF
--- a/gapic/src/main/com/google/gapid/util/StatusWatcher.java
+++ b/gapic/src/main/com/google/gapid/util/StatusWatcher.java
@@ -231,8 +231,12 @@ public class StatusWatcher {
       }
       if (executing > 0) {
         sb.append(sep).append(executing).append(" Running");
-        if (totalInstr > 0) {
+        if (totalInstr > 0 && doneInstr > 0) {
           sb.append(" ").append((int)(((double)doneInstr / totalInstr) * 100)).append("%");
+        } else {
+          // TODO(pmuetschard): This assumes that 0 done means state reconstruction. See server side
+          // for more details.
+          sb.append(" - Initializing");
         }
       }
       return (sb.length() == 0) ? "Idle" : sb.toString();

--- a/gapir/client/client.go
+++ b/gapir/client/client.go
@@ -213,6 +213,7 @@ func (client *Client) BeginReplay(ctx context.Context, key *ReplayerKey, payload
 			},
 		},
 	}
+	log.I(ctx, "Sending begin request")
 	err = replayer.rpcStream.Send(&idReq)
 	if err != nil {
 		return log.Err(ctx, err, "Sending replay id")

--- a/gapis/replay/batch.go
+++ b/gapis/replay/batch.go
@@ -383,6 +383,14 @@ func (m *manager) execute(
 	if Events.OnReplay != nil {
 		Events.OnReplay(d, intent, cfg)
 	}
+
+	// TODO(pmuetschard): Make the "state reconstruction" an actual event status and have gapir let us
+	// know how far along it is in executing it. Also, there is technically still some server work
+	// happening after this (e.g. storing the payload in the db), but that is fast and passing things
+	// down isn't worth it.
+	// This transitions the status from building to executing.
+	r.Progress(ctx, 0, 1, 0)
+
 	executeTimer.Time(func() {
 		err = Execute(
 			ctx,


### PR DESCRIPTION
Just (almost) before sending the "begin replay" message to gapir, update the replay progress status, so that it transitions from "building" (i.e. server time) to "executing".

Updates the UI to say "initializing" during state reconstruction. This is to avoid showing "Running 0%" for a long time.

TODO: Have gapir communicate its progress through state reconstruction (and resource fetching).