### PR TITLE
Avoid recording invalid command buffer

### DIFF
--- a/gapis/api/vulkan/command_buffer_rebuilder.go
+++ b/gapis/api/vulkan/command_buffer_rebuilder.go
@@ -921,6 +921,9 @@ func rebuildVkCmdExecuteCommands(
 		if !GetState(s).CommandBuffers().Contains(buf) {
 			return nil, nil, fmt.Errorf("Cannot find CommandBuffer %v", buf)
 		}
+		if GetState(s).CommandBuffers().Get(buf).Recording() != RecordingState_COMPLETED {
+			return nil, nil, fmt.Errorf("vkCmdExecuteCommands: secondary command buffer %v has not completed its recording", buf)
+		}
 	}
 
 	commandBufferData, commandBufferCount := unpackMap(ctx, s, d.CommandBuffers())

--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -268,14 +268,14 @@ func (API) RebuildState(ctx context.Context, oldState *api.GlobalState) ([]api.C
 		sb.createQueryPool(s.QueryPools().Get(qp))
 	}
 
-	for _, qp := range s.CommandBuffers().Keys() {
-		sb.createCommandBuffer(s.CommandBuffers().Get(qp), VkCommandBufferLevel_VK_COMMAND_BUFFER_LEVEL_SECONDARY)
-		sb.recordCommandBuffer(s.CommandBuffers().Get(qp), VkCommandBufferLevel_VK_COMMAND_BUFFER_LEVEL_SECONDARY, sb.oldState)
+	for _, cb := range s.CommandBuffers().Keys() {
+		sb.createCommandBuffer(s.CommandBuffers().Get(cb), VkCommandBufferLevel_VK_COMMAND_BUFFER_LEVEL_SECONDARY)
+		sb.recordCommandBuffer(s.CommandBuffers().Get(cb), VkCommandBufferLevel_VK_COMMAND_BUFFER_LEVEL_SECONDARY, sb.oldState)
 	}
 
-	for _, qp := range s.CommandBuffers().Keys() {
-		sb.createCommandBuffer(s.CommandBuffers().Get(qp), VkCommandBufferLevel_VK_COMMAND_BUFFER_LEVEL_PRIMARY)
-		sb.recordCommandBuffer(s.CommandBuffers().Get(qp), VkCommandBufferLevel_VK_COMMAND_BUFFER_LEVEL_PRIMARY, sb.oldState)
+	for _, cb := range s.CommandBuffers().Keys() {
+		sb.createCommandBuffer(s.CommandBuffers().Get(cb), VkCommandBufferLevel_VK_COMMAND_BUFFER_LEVEL_PRIMARY)
+		sb.recordCommandBuffer(s.CommandBuffers().Get(cb), VkCommandBufferLevel_VK_COMMAND_BUFFER_LEVEL_PRIMARY, sb.oldState)
 	}
 
 	sb.scratchRes.Free(sb)


### PR DESCRIPTION
Some of the command buffers contained in the initial state cannot be
recorded due to some lacking resources. This fix adds a check to avoid
recording a command buffer which has a vkCmdExecuteCommands command
with as an argument a list of secondary command buffers where one of
the secondary command buffer recording has not been completed.

Also, fix a variable name typo: use `cb` to refer to a command
buffer (`qp` probably came from a copy-paste of the loop on QueryPools
just above).

Bug: b/161071991

Test: manual, with a trace that had a vkCmdExecuteCommands with a
secondary command buffer whose recording was not completed.