### PR TITLE
Fix possible replay crash in vkBeginCommandBuffer

### DIFF
--- a/gapis/api/vulkan/api/command_buffer_control.api
+++ b/gapis/api/vulkan/api/command_buffer_control.api
@@ -482,24 +482,30 @@ cmd VkResult vkBeginCommandBuffer(
   } else {
     buff := CommandBuffers[commandBuffer]
     clear(buff.ImageTransitions)
-    if (buff.Level == VK_COMMAND_BUFFER_LEVEL_SECONDARY) && (info.pInheritanceInfo != null) {
+    if (info.pInheritanceInfo != null) {
+      // Make sure to read InheritanceInfo even if the command buffer is not
+      // secondary. The spec allows a primary command buffer to have a non-null
+      // pInheritanceInfo, it will just be ignored. Not reading may lead to
+      // crashes in the validation layer at replay time, see b/161126544.
       inheritanceInfo := info.pInheritanceInfo[0]
-      begin.Inherited = true
-      begin.InheritedRenderPass = inheritanceInfo.renderPass
-      begin.InheritedSubpass = inheritanceInfo.subpass
-      begin.InheritedFramebuffer = inheritanceInfo.framebuffer
-      begin.InheritedOcclusionQuery = inheritanceInfo.occlusionQueryEnable
-      begin.InheritedQueryFlags = inheritanceInfo.queryFlags
-      begin.InheritedPipelineStatsFlags = inheritanceInfo.pipelineStatistics
-      // handle pBeginInfo->pInheritanceInfo->pNext
-      if inheritanceInfo.pNext != null {
-        numPNext := numberOfPNext(inheritanceInfo.pNext)
-        next := MutableVoidPtr(as!void*(inheritanceInfo.pNext))
-        for i in (0 .. numPNext) {
-          sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-          _ = sType
-          // TODO: handle extensions for VkCommandBufferInheritanceInfo
-          next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
+      if (buff.Level == VK_COMMAND_BUFFER_LEVEL_SECONDARY) {
+        begin.Inherited = true
+        begin.InheritedRenderPass = inheritanceInfo.renderPass
+        begin.InheritedSubpass = inheritanceInfo.subpass
+        begin.InheritedFramebuffer = inheritanceInfo.framebuffer
+        begin.InheritedOcclusionQuery = inheritanceInfo.occlusionQueryEnable
+        begin.InheritedQueryFlags = inheritanceInfo.queryFlags
+        begin.InheritedPipelineStatsFlags = inheritanceInfo.pipelineStatistics
+        // handle pBeginInfo->pInheritanceInfo->pNext
+        if inheritanceInfo.pNext != null {
+          numPNext := numberOfPNext(inheritanceInfo.pNext)
+          next := MutableVoidPtr(as!void*(inheritanceInfo.pNext))
+          for i in (0 .. numPNext) {
+            sType := as!const VkStructureType*(next.Ptr)[0:1][0]
+            _ = sType
+            // TODO: handle extensions for VkCommandBufferInheritanceInfo
+            next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
+          }
         }
       }
     }


### PR DESCRIPTION
Add a read observation on inheritanceInfo even for primary command
buffers.

If at capture time the pInheritanceInfo pointer is non-nil yet this
observation is not made (because the command buffer is primary), at
replay time the value pInheritanceInfo will be `0xbadf00d`, which is
the magic value used in GAPIS to mark pointers that should not be
dereferenced. This should be fine as this command buffer is primary,
so pInheritanceInfo should be ignored. Still, it appears that
validation layers try to dereference it even for primary command
buffers, leading to a replay segfault (for an app that requests
validation layers at capture time, such that any replay also has the
validation layers requested). This might be an issue in the validation
layers, but in any case let's make AGI robust to this by adding the
observation of pInheritanceInfo as soon as the pointer is not null.

Bug: b/161126544

Test: manually, using the com.powervr.VulkanPVRScopeExample demo that
systematically lead to the crash described above.