### PR TITLE
Store pipeline cache data during trace and use it on replay.

### DIFF
--- a/gapii/cc/vulkan_mid_execution.cpp
+++ b/gapii/cc/vulkan_mid_execution.cpp
@@ -1035,6 +1035,26 @@ void VulkanSpy::serializeGPUBuffers(StateSerializer* serializer) {
       }
     }
   }
+
+  for (auto& cache : mState.PipelineCaches) {
+    VkPipelineCache cache_handle = cache.first;
+    auto cache_obj = cache.second;
+
+    auto& device = mState.Devices[cache_obj->mDevice];
+    auto& device_functions = mImports.mVkDeviceFunctions[cache_obj->mDevice];
+
+    size_val size;
+    device_functions.vkGetPipelineCacheData(device->mVulkanHandle, cache_handle,
+                                            &size, nullptr);
+    std::vector<uint8_t> data(size);
+    device_functions.vkGetPipelineCacheData(device->mVulkanHandle, cache_handle,
+                                            &size, data.data());
+
+    serializer->encodeBuffer<uint8_t>(
+        size, &cache_obj->mData, [serializer, &data](memory::Observation* obs) {
+          serializer->sendData(obs, false, data.data(), data.size());
+        });
+  }
 }
 
 }  // namespace gapii

--- a/gapis/api/templates/go_convert_common.tmpl
+++ b/gapis/api/templates/go_convert_common.tmpl
@@ -55,6 +55,14 @@
       ϟv := from.{{$proto}}[ϟi]¶
       ϟc.{{$name}}().Set(ϟi, {{Template "Convert.FromProto" "Type" $underlying.ValueType "Value" "ϟv"}})¶
     «}¶
+  {{else if and (IsSlice $underlying) (GetAnnotation $.Field "internal")}}
+    {{$target := Macro "Convert.LiveType" $type}}
+    {{$value := printf "from.%s" $proto}}
+    if {{$value}} == nil {»¶
+      ϟc.Set{{$name}}(New{{$target}}(ϟa, 0, 0, 0, 0, ϟmem.ApplicationPool))¶
+    «} else {»¶
+      ϟc.Set{{$name}}({{Template "Convert.FromProto" "Type" $type "Value" $value}})¶
+    «}¶
   {{else}}
     {{$value := printf "from.%s" $proto}}
     ϟc.Set{{$name}}({{Template "Convert.FromProto" "Type" $type "Value" $value}})¶

--- a/gapis/api/vulkan/api/pipeline.api
+++ b/gapis/api/vulkan/api/pipeline.api
@@ -848,6 +848,7 @@ cmd void vkDestroyShaderModule(
   @unused VkDevice                  Device
   @unused VkPipelineCache           VulkanHandle
   @unused ref!VulkanDebugMarkerInfo DebugInfo
+  @hidden @nobox @internal u8[]     Data
 }
 
 @indirect("VkDevice")

--- a/gapis/api/vulkan/api/pipeline.api
+++ b/gapis/api/vulkan/api/pipeline.api
@@ -320,17 +320,17 @@ cmd VkResult vkCreateGraphicsPipelines(
             obj.UsedDescriptors[len(obj.UsedDescriptors)] = d
             seenDescs.Set[(as!u64(d.Set)<<32) | as!u64(d.Binding)] = true
           }
-        } 
+        }
       } else {
         nSets := len(obj.Layout.SetLayouts)
         for ii in (0 .. nSets) {
           set := obj.Layout.SetLayouts[as!u32(ii)]
           for _, k, v in set.Bindings {
             if !seenDescs.Set[(as!u64(ii)<<32) | as!u64(k)] {
-              obj.UsedDescriptors[len(obj.UsedDescriptors)] = 
+              obj.UsedDescriptors[len(obj.UsedDescriptors)] =
                 DescriptorUsage(Set: as!u32(ii),
-                  Binding: k, 
-                  DescriptorCount: v.Count) 
+                  Binding: k,
+                  DescriptorCount: v.Count)
               seenDescs.Set[(as!u64(ii)<<32) | as!u64(k)] = true
             }
           }
@@ -938,7 +938,7 @@ sub void dovkCmdBindPipeline(ref!vkCmdBindPipelineArgs args) {
     lci := lastComputeInfo()
     lci.ComputePipeline = ComputePipelines[args.Pipeline]
   } else {
-    ldi := lastDrawInfo()    
+    ldi := lastDrawInfo()
     ldi.GraphicsPipeline = GraphicsPipelines[args.Pipeline]
   }
 }

--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -1974,10 +1974,10 @@ func (sb *stateBuilder) createPipelineCache(pc PipelineCacheObjectʳ) {
 		pc.Device(),
 		sb.MustAllocReadData(NewVkPipelineCacheCreateInfo(sb.ta,
 			VkStructureType_VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO, // sType
-			0, // pNext
-			0, // flags
-			0, // initialDataSize
-			0, // pInitialData
+			0,                             // pNext
+			0,                             // flags
+			memory.Size(pc.Data().Size()), // initialDataSize
+			NewVoidᶜᵖ(sb.mustReadSlice(pc.Data()).Ptr()), // pInitialData
 		)).Ptr(),
 		memory.Nullptr,
 		sb.MustAllocWriteData(pc.VulkanHandle()).Ptr(),


### PR DESCRIPTION
When serializing the state, get the pipeline caches' data and store it in the state. When reconstructing the state, use the stored data to initialize the pipeline caches.

This dramatically improves replay performance of applications that use pipeline caches.