### PR TITLE
Fix gapis crash when perfetto profile data is empty.

### DIFF
--- a/gapic/src/main/com/google/gapid/views/CommandTree.java
+++ b/gapic/src/main/com/google/gapid/views/CommandTree.java
@@ -245,10 +245,13 @@ public class CommandTree extends Composite
   }
 
   @Override
+  public void onProfileLoadingStart() {
+    tree.profileLoadingError = null;
+  }
+
+  @Override
   public void onProfileLoaded(Loadable.Message error) {
-    if (error != null) {
-      tree.profileLoadingError = error;
-    }
+    tree.profileLoadingError = error;
     tree.refresh();
   }
 

--- a/gapic/src/main/com/google/gapid/views/CommandTree.java
+++ b/gapic/src/main/com/google/gapid/views/CommandTree.java
@@ -246,6 +246,9 @@ public class CommandTree extends Composite
 
   @Override
   public void onProfileLoaded(Loadable.Message error) {
+    if (error != null) {
+      tree.profileLoadingError = error;
+    }
     tree.refresh();
   }
 
@@ -313,6 +316,7 @@ public class CommandTree extends Composite
     protected final Models models;
     private final Widgets widgets;
     private final Map<Long, Color> threadBackgroundColors = Maps.newHashMap();
+    private Loadable.Message profileLoadingError;
 
     public Tree(Composite parent, Models models, Widgets widgets) {
       super(parent, SWT.H_SCROLL | SWT.V_SCROLL | SWT.MULTI, widgets);
@@ -334,6 +338,8 @@ public class CommandTree extends Composite
         Service.CommandTreeNode data = node.getData();
         if (data == null) {
           return "";
+        } else if (profileLoadingError != null) {
+          return "Profiling failed.";
         } else if (!models.profile.isLoaded()) {
           return "Profiling...";
         } else {

--- a/gapis/perfetto/processor.go
+++ b/gapis/perfetto/processor.go
@@ -33,13 +33,12 @@ type Processor struct {
 }
 
 func NewProcessor(ctx context.Context, data []byte) (*Processor, error) {
-	p := C.new_processor()
-	log.D(ctx, "[perfetto] Parsing %d bytes", len(data))
 	if len(data) == 0 {
 		log.W(ctx, "[perfetto] Empty profile data.")
-		C.delete_processor(p)
 		return nil, log.Errf(ctx, nil, "profile data is empty.")
 	}
+	p := C.new_processor()
+	log.D(ctx, "[perfetto] Parsing %d bytes", len(data))
 	if !C.parse_data(p, unsafe.Pointer(&data[0]), C.size_t(len(data))) {
 		log.W(ctx, "[perfetto] Parsing failed")
 		C.delete_processor(p)
@@ -65,6 +64,9 @@ func (p *Processor) Query(q string) (*service.QueryResult, error) {
 }
 
 func (p *Processor) Close() {
+	if p == nil {
+		return
+	}
 	C.delete_processor(p.handle)
 	p.handle = nil
 }

--- a/gapis/perfetto/processor.go
+++ b/gapis/perfetto/processor.go
@@ -35,6 +35,11 @@ type Processor struct {
 func NewProcessor(ctx context.Context, data []byte) (*Processor, error) {
 	p := C.new_processor()
 	log.D(ctx, "[perfetto] Parsing %d bytes", len(data))
+	if len(data) == 0 {
+		log.W(ctx, "[perfetto] Empty profile data.")
+		C.delete_processor(p)
+		return nil, log.Errf(ctx, nil, "profile data is empty.")
+	}
 	if !C.parse_data(p, unsafe.Pointer(&data[0]), C.size_t(len(data))) {
 		log.W(ctx, "[perfetto] Parsing failed")
 		C.delete_processor(p)

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -133,7 +133,9 @@ func (t *androidTracer) ProcessProfilingData(ctx context.Context, buffer *bytes.
 		return nil, log.Err(ctx, err, "Failed to read trace buffer")
 	}
 	processor, err := perfetto.NewProcessor(ctx, rawData)
-	defer processor.Close()
+	if processor != nil {
+		defer processor.Close()
+	}
 	if err != nil {
 		return nil, log.Errf(ctx, err, "Failed to create trace processor")
 	}

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -133,9 +133,7 @@ func (t *androidTracer) ProcessProfilingData(ctx context.Context, buffer *bytes.
 		return nil, log.Err(ctx, err, "Failed to read trace buffer")
 	}
 	processor, err := perfetto.NewProcessor(ctx, rawData)
-	if processor != nil {
-		defer processor.Close()
-	}
+	defer processor.Close()
 	if err != nil {
 		return nil, log.Errf(ctx, err, "Failed to create trace processor")
 	}


### PR DESCRIPTION
  - This bug is triggered when the returned perfetto profile is empty, and AGI
 tries to read the first byte in the buffer when creating a perfetto processor.
 - Instead of crashing AGI entirely, throw an error from server and mirror
 it in UI.
 - Bug: b/169426834.