### PR TITLE
Create a "gapit commands" option that only shows draw calls

### DIFF
--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -254,6 +254,7 @@ type (
 		GroupByUserMarkers   bool   `help:"Group commands by user markers"`
 		GroupBySubmission    bool   `help:"Group commands by submissions"`
 		AllowIncompleteFrame bool   `help:"_Make a group for incomplete frames"`
+		OnlyExecutedDraws    bool   `help:"Only show executed draw calls from within command buffers"`
 		Observations         ObservationFlags
 		CommandFilterFlags
 		CaptureFileFlags

--- a/gapis/api/cmd_id_group.go
+++ b/gapis/api/cmd_id_group.go
@@ -438,6 +438,21 @@ func (c *SubCmdRoot) Insert(r []uint64, nameLookUp *SubCmdIdxTrie) {
 	}
 }
 
+func (c *SubCmdRoot) InsertWithFilter(r []uint64, nameLookUp *SubCmdIdxTrie, filter func(CmdID) bool) {
+	childRoot := c.newChildSubCmdRoots(r[0:len(r)-1], nameLookUp)
+	// Add subcommands one-by-one to the SubCmdRoot and its subgroups/child
+	// SubCmdRoots
+	id := r[len(r)-1]
+	if CmdID(id) > childRoot.SubGroup.Range.End {
+		childRoot.SubGroup.Range.End = CmdID(id + 1)
+	}
+	for i := CmdID(0); i < CmdID(id); i++ {
+		if filter(i) {
+			childRoot.SubGroup.AddCommand(i)
+		}
+	}
+}
+
 // AddSubCmdMarkerGroups adds the given groups to the target SubCmdRoot
 // with the relative hierarchy specified in r. If the groups are not added as
 // immediate children of the target SubCmdRoot (r is not empty), child

--- a/gapis/service/path/path.proto
+++ b/gapis/service/path/path.proto
@@ -300,6 +300,8 @@ message Field {
 message CommandFilter {
   // thread filters the commands to those with the specified threads.
   repeated uint64 threads = 2;
+  // If true, only shows draw calls from inside a command buffer
+  bool only_executed_draws = 3;
 }
 
 // CommandTree is a path to a hierarchy of command tree nodes.


### PR DESCRIPTION
This option creates a command tree of just draw calls and their parent queue submits. Needed to create a screenshot swarming test. Gapit also filters out the queue submits to only show the draw calls. 

Bug: b/161536617