### PR TITLE
 Image conversion crash fix

### DIFF
--- a/core/stream/convert.go
+++ b/core/stream/convert.go
@@ -497,7 +497,6 @@ func ftou(count int, dst, src buf, min, max float64) error {
 	dstMask := (1 << dstBits) - 1
 	sourceStream := binary.BitStream{Data: src.bytes, ReadPos: src.offset}
 	destStream := binary.BitStream{Data: dst.bytes, WritePos: dst.offset}
-
 	switch {
 	case srcIsF16:
 		scale := float32(dstMask)

--- a/core/stream/curve.go
+++ b/core/stream/curve.go
@@ -37,7 +37,7 @@ func (m *mapping) transform(count int, f func(float64) float64) error {
 			stride: 64,
 		},
 	}
-	if err := tmp.conv(count, 0, 0); err != nil {
+	if err := tmp.conv(count); err != nil {
 		return err
 	}
 	r := endian.Reader(bytes.NewReader(data), device.LittleEndian)

--- a/core/stream/curve.go
+++ b/core/stream/curve.go
@@ -37,7 +37,7 @@ func (m *mapping) transform(count int, f func(float64) float64) error {
 			stride: 64,
 		},
 	}
-	if err := tmp.conv(count); err != nil {
+	if err := tmp.conv(count, 0, 0); err != nil {
 		return err
 	}
 	r := endian.Reader(bytes.NewReader(data), device.LittleEndian)


### PR DESCRIPTION
This commit fixes the crash caused by the bug. And also
     - Prints more information when image conversion is failed
     - Renames the function that reads min and max value from Float src
     - It does reading in the conversion that needs it.

b/161683278