### PR TITLE
Fix a NPE in Performance tab when returning a Double object.

### DIFF
--- a/gapic/src/main/com/google/gapid/models/Profile.java
+++ b/gapic/src/main/com/google/gapid/models/Profile.java
@@ -204,10 +204,8 @@ public class Profile
 
     public Double getGpuPerformance(List<Long> commandIndex, int metricId) {
       CommandIndex indexStr = new CommandIndex(commandIndex);
-      if (!perfLookup.containsKey(indexStr)) {
-        return Double.NaN;
-      }
-      return perfLookup.get(indexStr).get(metricId);
+      Map<Integer, Double> metrics = perfLookup.get(indexStr);
+      return (metrics == null) ? Double.NaN : metrics.getOrDefault(metricId, Double.NaN);
     }
 
     public Duration getDuration(Path.Commands range) {


### PR DESCRIPTION
 Check data availability and return Double.NAN when possible, avoid
 returning null.

 Bug: N/A.