### PR TITLE
Add gapis flags to gapit perfetto verb

### DIFF
--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -453,6 +453,7 @@ type (
 	}
 
 	PerfettoFlags struct {
+		Gapis      GapisFlags
 		Mode       PerfettoMode         `help:"Run mode: {metrics|interactive}. Default: metrics."`
 		In         string               `help:"Input file. Refer to documentation for file format."`
 		Categories string               `help:"Comma separated list of metric categories from the input file. Only valid if 'metrics' mode is selected."`

--- a/cmd/gapit/perfetto.go
+++ b/cmd/gapit/perfetto.go
@@ -104,9 +104,9 @@ func (verb *perfettoVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	}
 
 	if verb.Mode == ModeMetrics {
-		return RunMetrics(ctx, trace, input, categories, output, outputFormat)
+		return RunMetrics(ctx, verb.Gapis, trace, input, categories, output, outputFormat)
 	} else if verb.Mode == ModeInteractive {
-		return RunInteractive(ctx, trace, input, output, outputFormat)
+		return RunInteractive(ctx, verb.Gapis, trace, input, output, outputFormat)
 	} else {
 		return ListMetrics(ctx, input, categories)
 	}
@@ -198,7 +198,7 @@ type MetricsInfo struct {
 	MetricCategories []MetricCategory `json:"metrics"`
 }
 
-func RunMetrics(ctx context.Context, trace string, inputPath string, categories map[string]struct{}, outputPath string, format PerfettoOutputFormat) error {
+func RunMetrics(ctx context.Context, gapisFlags GapisFlags, trace string, inputPath string, categories map[string]struct{}, outputPath string, format PerfettoOutputFormat) error {
 	var byteValue []byte
 	if inputPath != "" {
 		metricsFile, err := os.Open(inputPath)
@@ -217,7 +217,7 @@ func RunMetrics(ctx context.Context, trace string, inputPath string, categories 
 	}
 
 	// Load the trace
-	client, capture, err := getGapisAndLoadCapture(ctx, GapisFlags{}, GapirFlags{}, trace, CaptureFileFlags{})
+	client, capture, err := getGapisAndLoadCapture(ctx, gapisFlags, GapirFlags{}, trace, CaptureFileFlags{})
 	if err != nil {
 		return fmt.Errorf("Error while loading the trace file %s: %v.", trace, err)
 	}
@@ -285,7 +285,7 @@ func RunMetrics(ctx context.Context, trace string, inputPath string, categories 
 	return nil
 }
 
-func RunInteractive(ctx context.Context, trace string, inputPath string, outputPath string, format PerfettoOutputFormat) error {
+func RunInteractive(ctx context.Context, gapisFlags GapisFlags, trace string, inputPath string, outputPath string, format PerfettoOutputFormat) error {
 	// Load the preparation queries from input file. For these queries we do not report the output.
 	var prepQueries []string
 	if inputPath != "" {
@@ -313,7 +313,7 @@ func RunInteractive(ctx context.Context, trace string, inputPath string, outputP
 	}
 
 	// Load the trace
-	client, capture, err := getGapisAndLoadCapture(ctx, GapisFlags{}, GapirFlags{}, trace, CaptureFileFlags{})
+	client, capture, err := getGapisAndLoadCapture(ctx, gapisFlags, GapirFlags{}, trace, CaptureFileFlags{})
 	if err != nil {
 		return fmt.Errorf("Error while loading the trace file %s: %v.", trace, err)
 	}


### PR DESCRIPTION
This makes it possible to tell gapis to e.g. not scan devices, since
devices are not used in the process of a perfetto trace.

Bug: b/169060589
Test: manual