### PR TITLE
Fix unstable profile result with empty GPU slices.

### DIFF
--- a/gapis/perfetto/android/trace.go
+++ b/gapis/perfetto/android/trace.go
@@ -292,7 +292,7 @@ func (p *Process) captureWithClientApi(ctx context.Context, start task.Signal, s
 		}
 	}
 
-	// TODO Find a way to reliably know when Perfetto/producers are ready (b/147388497)
+	// TODO(b/147388497): Find a way to reliably know when Perfetto/producers are ready.
 	delayedReady := task.Delay(ready, 250*time.Millisecond)
 
 	atomic.StoreInt64(written, 1)

--- a/gapis/perfetto/android/trace.go
+++ b/gapis/perfetto/android/trace.go
@@ -291,12 +291,16 @@ func (p *Process) captureWithClientApi(ctx context.Context, start task.Signal, s
 			return 0, log.Err(ctx, nil, "Timed out in waiting for trace session ready")
 		}
 	}
+
+	// TODO Find a way to reliably know when Perfetto/producers are ready (b/147388497)
+	delayedReady := task.Delay(ready, 250*time.Millisecond)
+
 	atomic.StoreInt64(written, 1)
 	if p.deferred && !start.Wait(ctx) {
 		ts.Stop(ctx)
 		return 0, log.Err(ctx, nil, "Cancelled")
 	}
-	ready(ctx)
+	delayedReady(ctx)
 	ts.Start(ctx)
 	wait := make(chan error, 1)
 	crash.Go(func() {


### PR DESCRIPTION
 - The UI representation of this bug is an error string of "GPU profiling is not
 supported on this device or for this capture." in Profile tab and empty columns
 in Performance tab.
 - The bug is introduced by render stage producer not being ready sometimes, when
 we are trying to replay 1 frame and record the perfetto trace in frame profiler.
 - Add the 250ms delay workaround into the new perfetto tracing implementation
 with perfetto client, which is the same as in the previous implementation with CLI.
 - Bug: b/171098363.
 - Test: preferbly captures with smaller apps, e.g. AGI apk, or SW samples.