### PR TITLE
Framegraph proof of concept

### DIFF
--- a/cmd/gapit/BUILD.bazel
+++ b/cmd/gapit/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "dump_shaders.go",
         "export_replay.go",
         "flags.go",
+        "framegraph.go",
         "inputs.go",
         "main.go",
         "make_doc.go",

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -434,6 +434,11 @@ type (
 		Format string `help:"output format of the graph: 'pbtxt' (Tensorboard) or 'dot' (Graphviz)"`
 	}
 
+	FramegraphFlags struct {
+		Gapis GapisFlags
+		Out   string `help:"path to save framegraph DOT file"`
+	}
+
 	SmokeTestsFlags struct {
 	}
 

--- a/cmd/gapit/framegraph.go
+++ b/cmd/gapit/framegraph.go
@@ -1,0 +1,86 @@
+// Copyright (C) 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/log"
+)
+
+type framegraphVerb struct{ FramegraphFlags }
+
+func init() {
+	verb := &framegraphVerb{}
+	app.AddVerb(&app.Verb{
+		Name:      "framegraph",
+		ShortHelp: "Create frame graph from capture",
+		Action:    verb,
+	})
+}
+
+func (verb *framegraphVerb) Run(ctx context.Context, flags flag.FlagSet) error {
+	if flags.NArg() != 1 {
+		app.Usage(ctx, "Exactly one gfx trace file expected, got %d", flags.NArg())
+		return nil
+	}
+
+	client, capture, err := getGapisAndLoadCapture(ctx, verb.Gapis, GapirFlags{}, flags.Arg(0), CaptureFileFlags{})
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	log.I(ctx, "Creating frame graph from capture id: %s", capture.ID)
+
+	framegraph, err := client.GetFramegraph(ctx, capture)
+	if err != nil {
+		return log.Errf(ctx, err, "GetFramegraph(%v)", capture)
+	}
+
+	// Print framegraph in DOT format
+	dot := "digraph agiFramegraph {\n"
+	dot += "node [fontname = \"Monospace\"];\n"
+	for _, node := range framegraph.Nodes {
+		dot += fmt.Sprintf("n%v [label=\"%s\\n%s\"];\n", node.Id, node.Type, node.Text)
+	}
+	dot += "\n"
+	for _, edge := range framegraph.Edges {
+		dot += fmt.Sprintf("n%v -> n%v;\n", edge.Origin, edge.Destination)
+	}
+	dot += "}\n"
+
+	filePath := verb.Out
+	if filePath == "" {
+		filePath = "framegraph.dot"
+	}
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		return log.Errf(ctx, err, "Creating file (%v)", filePath)
+	}
+	defer file.Close()
+
+	bytesWritten, err := fmt.Fprint(file, dot)
+	if err != nil {
+		return log.Errf(ctx, err, "Error after writing %d bytes to file", bytesWritten)
+	}
+
+	return nil
+}

--- a/cmd/gapit/framegraph.go
+++ b/cmd/gapit/framegraph.go
@@ -19,7 +19,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/log"
@@ -42,7 +41,9 @@ func (verb *framegraphVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		return nil
 	}
 
-	client, capture, err := getGapisAndLoadCapture(ctx, verb.Gapis, GapirFlags{}, flags.Arg(0), CaptureFileFlags{})
+	captureFilename := flags.Arg(0)
+
+	client, capture, err := getGapisAndLoadCapture(ctx, verb.Gapis, GapirFlags{}, captureFilename, CaptureFileFlags{})
 	if err != nil {
 		return err
 	}
@@ -55,10 +56,10 @@ func (verb *framegraphVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		return log.Errf(ctx, err, "GetFramegraph(%v)", capture)
 	}
 
-	time.Sleep(1 * time.Second)
-
 	// Print framegraph in DOT format
 	dot := "digraph agiFramegraph {\n"
+	dot += "label = \"" + captureFilename + "\";\n"
+	dot += "labelloc = \"t\";\n"
 	dot += "node [fontname = \"Monospace\"];\n"
 	for _, node := range framegraph.Nodes {
 		dot += fmt.Sprintf("n%v [label=\"%s\\n%s\"];\n", node.Id, node.Type, node.Text)

--- a/cmd/gapit/framegraph.go
+++ b/cmd/gapit/framegraph.go
@@ -62,7 +62,7 @@ func (verb *framegraphVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	dot += "labelloc = \"t\";\n"
 	dot += "node [fontname = \"Monospace\"];\n"
 	for _, node := range framegraph.Nodes {
-		dot += fmt.Sprintf("n%v [label=\"%s\\n%s\"];\n", node.Id, node.Type, node.Text)
+		dot += fmt.Sprintf("n%v [label=\"%s\"];\n", node.Id, node.Text)
 	}
 	dot += "\n"
 	for _, edge := range framegraph.Edges {

--- a/cmd/gapit/framegraph.go
+++ b/cmd/gapit/framegraph.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/log"
@@ -53,6 +54,8 @@ func (verb *framegraphVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	if err != nil {
 		return log.Errf(ctx, err, "GetFramegraph(%v)", capture)
 	}
+
+	time.Sleep(1 * time.Second)
 
 	// Print framegraph in DOT format
 	dot := "digraph agiFramegraph {\n"

--- a/gapis/api/service.proto
+++ b/gapis/api/service.proto
@@ -507,3 +507,70 @@ message SparseBinding {
   // The offset into the buffer of the binding
   uint64 offset = 1;
 }
+
+// Framegraph
+
+// A resource is something that can be read/write
+// re-use e.g. BufferInfo and ImageInfo here?
+enum FramegraphResourceType {
+  BUFFER = 0;
+  IMAGE = 1;
+}
+message FramegraphResource {
+  uint64 id = 1;
+  FramegraphResourceType type = 2;
+  string text = 3;
+}
+// A node is basically a "workload",
+// something that reads/writes resources
+enum FramegraphNodeType {
+  COMPUTE = 0;
+  RENDERPASS = 1; // or "GRAPHICS", to stay api-agnostic
+  // SUBPASS
+  // even DRAWCALL eventually, and correlate a drawcall with the dependencies it affects
+  // vkCopyCmd, vkMap/Unmap ?
+}
+message FramegraphNode {
+  uint64 id = 1;
+  FramegraphNodeType type = 2;
+  string text = 3;
+  repeated FramegraphResource read = 4;
+  repeated FramegraphResource write = 5;
+}
+// An edge marks a dependency,
+// and can be caused by various reasons
+enum FramegraphEdgeExecutionDependency {
+  // to stay api-agnostic, we might want to just use a string here.
+  // But also, it's interesting to be able to type-switch so that we
+  // can present edges in various ways in the UI
+
+  // nothing protects the memory dependency,
+  // although there is a r/w dependency. This is almost-always a bad sign,
+  // but in some cases it may be OK, e.g. reading from a buffer that stores
+  // a particle system that is regularly-yet-out-of-frame-sync updated.
+  NO_EXECUTION_DEPENDENCY = 0;
+  SEMAPHORE = 1;
+  FENCE = 2;
+  EVENT = 3;
+  TIMELINE_SEMAPHORE = 4;
+  // implicit dependencies with:
+  // SUBPASS IMAGE LAYOUT TRANSITION
+  // RENDERPASS
+}
+enum FramegraphEdgeMemoryDependency {
+  NO_MEMORY_DEPENDENCY = 0;
+  PIPELINE_BARRIER = 1; // this is for memory dependencies, not execution dependencies
+}
+// distinguish memory / execution dependencies
+// We probably need more info on edges, e.g.
+// a semaphore's vkHandle, etc
+message FramegraphEdge {
+  uint64 origin = 1;
+  uint64 destination = 2;
+  FramegraphEdgeExecutionDependency execDep = 3;
+  FramegraphEdgeMemoryDependency memDep = 4;
+  // Number of edges creating this one, e.g. how many draw
+  // calls inside a RP leads to a similar edge at the RP level.
+  // We probably want to remove the duplicates, but keep a counter
+  // of how many edges lead to a single edge.
+}

--- a/gapis/api/service.proto
+++ b/gapis/api/service.proto
@@ -525,10 +525,10 @@ message FramegraphResource {
 // something that reads/writes resources
 enum FramegraphNodeType {
   COMPUTE = 0;
-  RENDERPASS = 1; // or "GRAPHICS", to stay api-agnostic
+  RENDERPASS = 1;  // or "GRAPHICS", to stay api-agnostic
   // SUBPASS
-  // even DRAWCALL eventually, and correlate a drawcall with the dependencies it affects
-  // vkCopyCmd, vkMap/Unmap ?
+  // even DRAWCALL eventually, and correlate a drawcall with the dependencies it
+  // affects vkCopyCmd, vkMap/Unmap ?
 }
 message FramegraphNode {
   uint64 id = 1;
@@ -559,7 +559,8 @@ enum FramegraphEdgeExecutionDependency {
 }
 enum FramegraphEdgeMemoryDependency {
   NO_MEMORY_DEPENDENCY = 0;
-  PIPELINE_BARRIER = 1; // this is for memory dependencies, not execution dependencies
+  PIPELINE_BARRIER =
+      1;  // this is for memory dependencies, not execution dependencies
 }
 // distinguish memory / execution dependencies
 // We probably need more info on edges, e.g.

--- a/gapis/api/sync/sync.go
+++ b/gapis/api/sync/sync.go
@@ -60,7 +60,7 @@ type SynchronizedAPI interface {
 	// called before and after executing each subcommand callback.
 	MutateSubcommands(ctx context.Context, id api.CmdID, cmd api.Cmd, s *api.GlobalState,
 		preSubCmdCallback func(*api.GlobalState, api.SubCmdIdx, api.Cmd),
-		postSubCmdCallback func(*api.GlobalState, api.SubCmdIdx, api.Cmd)) error
+		postSubCmdCallback func(*api.GlobalState, api.SubCmdIdx, api.Cmd, interface{})) error
 
 	// FlattenSubcommandIdx returns the flatten command id for the subcommand
 	// specified by the given SubCmdIdx. If flattening succeeded, the flatten
@@ -175,7 +175,7 @@ func MutationCmdsFor(ctx context.Context, c *path.Capture, data *Data, cmds []ap
 func MutateWithSubcommands(ctx context.Context, c *path.Capture, cmds []api.Cmd,
 	postCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd),
 	preSubCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd),
-	postSubCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd)) error {
+	postSubCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd, interface{})) error {
 
 	ctx = status.Start(ctx, "Sync.MutateWithSubcommands")
 	defer status.Finish(ctx)

--- a/gapis/api/vulkan/BUILD.bazel
+++ b/gapis/api/vulkan/BUILD.bazel
@@ -98,6 +98,7 @@ go_library(
         "transform_end_of_replay.go",
         "transform_file_log.go",
         "transform_find_issues.go",
+        "transform_framegraph.go",
         "transform_make_attachment_readable.go",
         "transform_mapping_exporter.go",
         "transform_overdraw.go",

--- a/gapis/api/vulkan/api/image.api
+++ b/gapis/api/vulkan/api/image.api
@@ -387,6 +387,10 @@ sub void BindImageMemory(
               lsize := as!u64(level.LinearLayout.size)
               level.Data = getImagePlaneMemoryInfo(imageObject, plane).BoundMemory.Data[loffset:loffset + lsize]
             } else {
+              // This should be a slice of VkDeviceMemory
+              // we have to allocate tightlyPackedSize because this
+              // size may be bigger than what was allocated.
+              // the driver may be able to store in less memory.
               level.Data = make!u8(tightlyPackedSize)
             }
           }

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -222,6 +222,13 @@ func getFramebufferTransforms(ctx context.Context,
 
 	transforms := make([]transform.Transform, 0)
 
+	framegraph, err := newFrameGraph()
+	if err != nil {
+		log.E(ctx, "Framegraph failed: %v", err)
+		return nil, err
+	}
+	transforms = append(transforms, framegraph)
+
 	if shouldRenderWired {
 		transforms = append(transforms, newWireframeTransform())
 	}

--- a/gapis/api/vulkan/transform_framegraph.go
+++ b/gapis/api/vulkan/transform_framegraph.go
@@ -1,0 +1,88 @@
+// Copyright (C) 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vulkan
+
+import (
+	"context"
+
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/api"
+	"github.com/google/gapid/gapis/api/transform"
+)
+
+type framegraph struct {
+}
+
+var _ transform.Transform = &framegraph{}
+
+func newFrameGraph() (*framegraph, error) {
+	return &framegraph{}, nil
+}
+
+func (fg *framegraph) BeginTransform(ctx context.Context, inputState *api.GlobalState) error {
+	return nil
+}
+
+func (fg *framegraph) EndTransform(ctx context.Context, inputState *api.GlobalState) ([]api.Cmd, error) {
+	return nil, nil
+}
+
+func (fg *framegraph) TransformCommand(ctx context.Context, id transform.CommandID, inputCommands []api.Cmd, inputState *api.GlobalState) ([]api.Cmd, error) {
+	st := GetState(inputState)
+	for _, cmd := range inputCommands {
+		if queueSubmit, ok := cmd.(*VkQueueSubmit); ok {
+			log.W(ctx, "HUGUES saw queuesubmit: %v", queueSubmit)
+			queueSubmit.Extras().Observations().ApplyReads(inputState.Memory.ApplicationPool())
+			layout := inputState.MemoryLayout
+			pSubmits := queueSubmit.PSubmits().Slice(0, uint64(queueSubmit.SubmitCount()), layout).MustRead(ctx, queueSubmit, inputState, nil)
+			for _, submit := range pSubmits {
+				commandBuffers := submit.PCommandBuffers().Slice(0, uint64(submit.CommandBufferCount()), layout).MustRead(ctx, queueSubmit, inputState, nil)
+				for _, cb := range commandBuffers {
+					commandBuffer := st.CommandBuffers().Get(cb)
+					for i := 0; i < commandBuffer.CommandReferences().Len(); i++ {
+						cr := commandBuffer.CommandReferences().Get(uint32(i))
+						args := GetCommandArgs(ctx, cr, st)
+						switch ar := args.(type) {
+						case VkCmdBeginRenderPassArgsʳ:
+							rp := ar.RenderPass()
+							rpo := st.RenderPasses().Get(rp)
+							log.W(ctx, "HUGUES renderpassobject: %v", rpo)
+							for i := uint32(0); i < uint32(rpo.AttachmentDescriptions().Len()); i++ {
+								attachment := rpo.AttachmentDescriptions().Get(i)
+								log.W(ctx, "HUGUES attachment loadop: %v", attachment.LoadOp())
+								log.W(ctx, "HUGUES attachment storeop: %v", attachment.StoreOp())
+							}
+						}
+					}
+				}
+			}
+
+		}
+	}
+	return inputCommands, nil
+}
+
+func (fg *framegraph) ClearTransformResources(ctx context.Context) {
+}
+
+func (fg *framegraph) RequiresAccurateState() bool {
+	return false
+}
+
+func (fg *framegraph) RequiresInnerStateMutation() bool {
+	return false
+}
+
+func (fg *framegraph) SetInnerStateMutationFunction(stateMutator transform.StateMutator) {}

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -464,11 +464,11 @@ func (API) GetTerminator(ctx context.Context, c *path.Capture) (terminator.Termi
 
 func (API) MutateSubcommands(ctx context.Context, id api.CmdID, cmd api.Cmd,
 	s *api.GlobalState, preSubCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd),
-	postSubCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd)) error {
+	postSubCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd, interface{})) error {
 	c := GetState(s)
 	if postSubCmdCb != nil {
-		c.PostSubcommand = func(interface{}) {
-			postSubCmdCb(s, append(api.SubCmdIdx{uint64(id)}, c.SubCmdIdx...), cmd)
+		c.PostSubcommand = func(i interface{}) {
+			postSubCmdCb(s, append(api.SubCmdIdx{uint64(id)}, c.SubCmdIdx...), cmd, i)
 		}
 	}
 	if preSubCmdCb != nil {

--- a/gapis/api/watcher.go
+++ b/gapis/api/watcher.go
@@ -38,7 +38,7 @@ type StateWatcher interface {
 	OnReadFrag(ctx context.Context, owner RefObject, f Fragment, v RefObject, track bool)
 
 	// OnSet is called when a fragment of state (field, map key, array index) is written
-	OnWriteFrag(ctx context.Context, owner RefObject, f Fragment, old RefObject, new RefObject, tracke bool)
+	OnWriteFrag(ctx context.Context, owner RefObject, f Fragment, old RefObject, new RefObject, track bool)
 
 	// OnWriteSlice is called when writing to a slice
 	OnWriteSlice(ctx context.Context, s memory.Slice)

--- a/gapis/client/client.go
+++ b/gapis/client/client.go
@@ -550,6 +550,19 @@ func (c *client) GetGraphVisualization(ctx context.Context, capture *path.Captur
 	return res.GetGraphVisualization(), nil
 }
 
+func (c *client) GetFramegraph(ctx context.Context, capture *path.Capture) (*service.Framegraph, error) {
+	res, err := c.client.GetFramegraph(ctx, &service.FramegraphRequest{
+		Capture: capture,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := res.GetError(); err != nil {
+		return nil, err.Get()
+	}
+	return res.GetFramegraph(), nil
+}
+
 func (c *client) PerfettoQuery(ctx context.Context, capture *path.Capture, query string) (*perfetto.QueryResult, error) {
 	res, err := c.client.PerfettoQuery(ctx, &service.PerfettoQueryRequest{
 		Capture: capture,

--- a/gapis/framegraph/BUILD.bazel
+++ b/gapis/framegraph/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//core/log:go_default_library",
-        "//core/math/interval:go_default_library",
         "//gapis/api:go_default_library",
         "//gapis/api/sync:go_default_library",
         "//gapis/api/vulkan:go_default_library",

--- a/gapis/framegraph/BUILD.bazel
+++ b/gapis/framegraph/BUILD.bazel
@@ -1,0 +1,37 @@
+# Copyright (C) 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "framegraph.go",
+    ],
+    importpath = "github.com/google/gapid/gapis/framegraph",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//core/log:go_default_library",
+        "//core/math/interval:go_default_library",
+        "//gapis/api:go_default_library",
+        "//gapis/api/sync:go_default_library",
+        "//gapis/api/vulkan:go_default_library",
+        "//gapis/capture:go_default_library",
+        "//gapis/memory:go_default_library",
+        "//gapis/resolve:go_default_library",
+        "//gapis/resolve/dependencygraph2:go_default_library",
+        "//gapis/service:go_default_library",
+        "//gapis/service/path:go_default_library",
+    ],
+)

--- a/gapis/framegraph/BUILD.bazel
+++ b/gapis/framegraph/BUILD.bazel
@@ -16,9 +16,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "framegraph.go",
-    ],
+    srcs = ["framegraph.go"],
     importpath = "github.com/google/gapid/gapis/framegraph",
     visibility = ["//visibility:public"],
     deps = [

--- a/gapis/framegraph/framegraph.go
+++ b/gapis/framegraph/framegraph.go
@@ -279,12 +279,12 @@ func GetFramegraph(ctx context.Context, p *path.Capture) (*service.Framegraph, e
 	for i, rpi := range rpInfos {
 
 		// Use "\l" for newlines as this produce left-align lines in graphviz DOT labels
-		text := fmt.Sprintf("RP %v\\lTotal: read(%v) write(%v)\\l", rpi.beginCmdIdx, rpi.totalRead, rpi.totalWrite)
+		text := fmt.Sprintf("RP %v\\lTotal: read(%v) write(%v)\\l", rpi.beginCmdIdx, memFmt(rpi.totalRead), memFmt(rpi.totalWrite))
 		for img, bytes := range rpi.imgRead {
-			text += fmt.Sprintf("Img 0x%x read(%v)\\l", img, bytes)
+			text += fmt.Sprintf("Img 0x%x read(%v)\\l", img, memFmt(bytes))
 		}
 		for img, bytes := range rpi.imgWrite {
-			text += fmt.Sprintf("Img 0x%x  write(%v)\\l", img, bytes)
+			text += fmt.Sprintf("Img 0x%x  write(%v)\\l", img, memFmt(bytes))
 		}
 
 		nodes = append(nodes, &api.FramegraphNode{
@@ -319,4 +319,18 @@ func GetFramegraph(ctx context.Context, p *path.Capture) (*service.Framegraph, e
 	}
 
 	return &service.Framegraph{Nodes: nodes, Edges: edges}, nil
+}
+
+// TODO: I guess there's already a helper function somewhere
+// to do this properly.
+func memFmt(bytes uint64) string {
+	kb := bytes / 1000
+	mb := kb / 1000
+	if mb > 0 {
+		return fmt.Sprintf("%vMb", mb)
+	}
+	if kb > 0 {
+		return fmt.Sprintf("%vKb", kb)
+	}
+	return fmt.Sprintf("%vb", bytes)
 }

--- a/gapis/framegraph/framegraph.go
+++ b/gapis/framegraph/framegraph.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/api/sync"
 	"github.com/google/gapid/gapis/api/vulkan"
@@ -98,7 +97,6 @@ func GetFramegraph(ctx context.Context, p *path.Capture) (*service.Framegraph, e
 
 		cmdRef := i.(vulkan.CommandReferenceʳ)
 		cmdArgs := vulkan.GetCommandArgs(ctx, cmdRef, vkState)
-		log.W(ctx, "HUGUES subcmdix:%v cmdArgs %v", subCmdIdx, cmdArgs)
 
 		// Beginning of RP
 		if _, ok := cmdArgs.(vulkan.VkCmdBeginRenderPassArgsʳ); ok {

--- a/gapis/framegraph/framegraph.go
+++ b/gapis/framegraph/framegraph.go
@@ -1,0 +1,322 @@
+// Copyright (C) 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framegraph
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/core/math/interval"
+	"github.com/google/gapid/gapis/api"
+	"github.com/google/gapid/gapis/api/sync"
+	"github.com/google/gapid/gapis/api/vulkan"
+	"github.com/google/gapid/gapis/capture"
+	"github.com/google/gapid/gapis/memory"
+	"github.com/google/gapid/gapis/resolve"
+	d2 "github.com/google/gapid/gapis/resolve/dependencygraph2"
+	"github.com/google/gapid/gapis/service"
+	"github.com/google/gapid/gapis/service/path"
+)
+
+// stateResourceMapping correlates VkImage handles with their memory accesses.
+// It is created once per vkQueueSubmit, and then used as a cache to avoid
+// scanning the state data-structures everytime we try to find an image from
+// a memory observation. There is room for improvement in this caching approach,
+// e.g. index the outermost map by memory pool IDs.
+type stateResourceMapping struct {
+	images map[vulkan.VkImage]map[memory.PoolID][]interval.U64Span
+}
+
+func createStateResourceMapping(s *vulkan.State) stateResourceMapping {
+	srm := stateResourceMapping{
+		images: make(map[vulkan.VkImage]map[memory.PoolID][]interval.U64Span),
+	}
+
+	for handle, image := range s.Images().All() {
+		if _, ok := srm.images[handle]; !ok {
+			srm.images[handle] = make(map[memory.PoolID][]interval.U64Span)
+		}
+		for _, aspect := range image.Aspects().All() {
+			for _, layer := range aspect.Layers().All() {
+				for _, level := range layer.Levels().All() {
+					data := level.Data()
+					pool := data.Pool()
+					if _, ok := srm.images[handle][pool]; !ok {
+						srm.images[handle][pool] = []interval.U64Span{}
+					}
+					srm.images[handle][pool] = append(srm.images[handle][pool], data.Range().Span())
+				}
+			}
+		}
+		planeMemInfos := image.PlaneMemoryInfo().All()
+		for _, memInfo := range planeMemInfos {
+			data := memInfo.BoundMemory().Data()
+			pool := data.Pool()
+			if _, ok := srm.images[handle][pool]; !ok {
+				srm.images[handle][pool] = []interval.U64Span{}
+			}
+			srm.images[handle][pool] = append(srm.images[handle][pool], data.Range().Span())
+		}
+	}
+
+	// TODO: It is probaly not necessary to scan device memories,
+	// as it will just alias to the info gathered by scanning images.
+	devMems := s.DeviceMemories().All()
+	for _, devMem := range devMems {
+		data := devMem.Data()
+		pool := data.Pool()
+		span := data.Range().Span()
+		boundObj := devMem.BoundObjects().All()
+		// TODO: deal with memory offset from boundObj
+		found := false
+		for objHandle := range boundObj {
+			imgHandle := vulkan.VkImage(objHandle)
+			if _, ok := srm.images[imgHandle]; ok {
+				if found {
+					fmt.Printf("\nHUGUES double handle: %v", imgHandle)
+				}
+				found = true
+				if _, ok := srm.images[imgHandle][pool]; !ok {
+					srm.images[imgHandle][pool] = []interval.U64Span{}
+				}
+				srm.images[imgHandle][pool] = append(srm.images[imgHandle][pool], span)
+			}
+		}
+	}
+
+	return srm
+}
+
+func (s stateResourceMapping) imageLookup(poolID memory.PoolID, span interval.U64Span) (uint64, bool) {
+	for img, mem := range s.images {
+		if intervals, ok := mem[poolID]; ok {
+			for _, interval := range intervals {
+				// TODO: we should probably use memory.Range rather than internal.U64Span
+				if interval.Start <= span.Start && span.End <= interval.End {
+					return uint64(img), true
+				}
+			}
+		}
+	}
+	return uint64(0), false
+}
+
+// rpInfo stores information for a given renderpass
+type rpInfo struct {
+	beginCmdIdx api.SubCmdIdx
+	dpNodes     map[d2.NodeID]bool
+	totalRead   uint64
+	totalWrite  uint64
+	read        map[memory.PoolID]uint64
+	write       map[memory.PoolID]uint64
+	imgRead     map[uint64]uint64
+	imgWrite    map[uint64]uint64
+}
+
+// GetFramegraph creates and returns the framegraph of a capture.
+func GetFramegraph(ctx context.Context, p *path.Capture) (*service.Framegraph, error) {
+
+	c, err := capture.ResolveGraphicsFromPath(ctx, p)
+	if err != nil {
+		return nil, err
+	}
+
+	// get dependency graph
+	config := d2.DependencyGraphConfig{
+		SaveNodeAccesses:    true,
+		ReverseDependencies: true, // TODO: maybe not needed?
+	}
+	dependencyGraph, err := d2.GetDependencyGraph(ctx, p, config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Sync data lets us iterate over subcommands
+	snc, err := resolve.SyncData(ctx, p)
+	if err != nil {
+		return nil, err
+	}
+	vkSyncAPI := api.Find(vulkan.ID).(sync.SynchronizedAPI)
+
+	rpInfos := []*rpInfo{}
+	state := c.NewState(ctx)
+
+	// This lambda processes each command of the capture
+	processCmd := func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
+
+		// Start by mutating the command to have an up-to-date state
+		err := cmd.Mutate(ctx, id, state, nil, nil)
+		if err != nil {
+			return err
+		}
+
+		// For vkQueueSubmits, scan subcommands and collect per-renderpass info
+		if _, ok := cmd.(*vulkan.VkQueueSubmit); ok {
+
+			// Assert there are subcommands
+			subCmdRefs, ok := snc.SubcommandReferences[id]
+			if !ok {
+				return log.Errf(ctx, nil, "no subcommands found for vkQueueSubmit?")
+			}
+
+			// Create the state resource mapping cache
+			srm := createStateResourceMapping(vulkan.GetState(state))
+
+			// Iterate over subcommands
+			var rpi *rpInfo
+			for _, subCmdRef := range subCmdRefs {
+
+				// Get the proper api.Cmd for this sub command
+				var subCmd api.Cmd
+				genCmdID := subCmdRef.GeneratingCmd
+				if genCmdID == api.CmdNoID {
+					subCmd, err = vkSyncAPI.RecoverMidExecutionCommand(ctx, p, subCmdRef.MidExecutionCommandData)
+					if err != nil {
+						return err
+					}
+				} else {
+					subCmd = c.Commands[genCmdID]
+				}
+
+				// Detect start of RP
+				if _, ok := subCmd.(*vulkan.VkCmdBeginRenderPass); ok {
+					if rpi != nil {
+						return log.Errf(ctx, nil, "nested renderpasses?")
+					}
+					nodeID := dependencyGraph.GetCmdNodeID(id, subCmdRef.Index)
+					rpi = &rpInfo{
+						beginCmdIdx: append(api.SubCmdIdx{uint64(id)}, subCmdRef.Index...),
+						read:        make(map[memory.PoolID]uint64),
+						write:       make(map[memory.PoolID]uint64),
+						dpNodes:     map[d2.NodeID]bool{nodeID: true},
+						imgRead:     make(map[uint64]uint64),
+						imgWrite:    make(map[uint64]uint64),
+					}
+				}
+
+				// Store info for subcommands that are inside a RP
+				if rpi != nil {
+					// Collect dependencygraph nodes from this RP
+					// TODO: maybe there's a better way to find dependencies between RPs?
+					nodeID := dependencyGraph.GetCmdNodeID(id, subCmdRef.Index)
+					rpi.dpNodes[nodeID] = true
+
+					// Analyze memory accesses
+					for _, memAccess := range dependencyGraph.GetNodeAccesses(nodeID).MemoryAccesses {
+						// TODO: operate on memory.Range rather than internal.U64Span
+						// TODO: refactor rpInfo fields to make the following code smoother to write
+						count := memAccess.Span.End - memAccess.Span.Start
+						switch memAccess.Mode {
+						case d2.ACCESS_READ:
+							rpi.totalRead += count
+							if _, ok := rpi.read[memAccess.Pool]; ok {
+								rpi.read[memAccess.Pool] += count
+							} else {
+								rpi.read[memAccess.Pool] = count
+							}
+							if imgHandle, ok := srm.imageLookup(memAccess.Pool, memAccess.Span); ok {
+								if _, ok := rpi.imgRead[imgHandle]; ok {
+									rpi.imgRead[imgHandle] += count
+								} else {
+									rpi.imgRead[imgHandle] = count
+								}
+							} else {
+								log.W(ctx, "HUGUES FAIL lookup (read) pool:%v span:%v", memAccess.Pool, memAccess.Span)
+							}
+						case d2.ACCESS_WRITE:
+							rpi.totalWrite += count
+							if _, ok := rpi.write[memAccess.Pool]; ok {
+								rpi.write[memAccess.Pool] += count
+							} else {
+								rpi.write[memAccess.Pool] = count
+							}
+
+							if imgHandle, ok := srm.imageLookup(memAccess.Pool, memAccess.Span); ok {
+								//log.W(ctx, "HUGUES hit write resource: %v", res)
+								if _, ok := rpi.imgWrite[imgHandle]; ok {
+									rpi.imgWrite[imgHandle] += count
+								} else {
+									rpi.imgWrite[imgHandle] = count
+								}
+							} else {
+								log.W(ctx, "HUGUES FAIL lookup (write) pool:%v span:%v", memAccess.Pool, memAccess.Span)
+							}
+						}
+					}
+				}
+
+				// Detect end of RP
+				if _, ok := subCmd.(*vulkan.VkCmdEndRenderPass); ok {
+					rpInfos = append(rpInfos, rpi)
+					rpi = nil
+				}
+			}
+		}
+		return nil
+	}
+
+	// Process all commands
+	err = api.ForeachCmd(ctx, c.Commands, true, processCmd)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create framegraph contents based on rpInfo and dependency graph
+	nodes := []*api.FramegraphNode{}
+	for i, rpi := range rpInfos {
+
+		// Use "\l" for newlines as this produce left-align lines in graphviz DOT labels
+		text := fmt.Sprintf("RP %v\\lTotal: read(%v) write(%v)\\l", rpi.beginCmdIdx, rpi.totalRead, rpi.totalWrite)
+		for img, bytes := range rpi.imgRead {
+			text += fmt.Sprintf("Img 0x%x read(%v)\\l", img, bytes)
+		}
+		for img, bytes := range rpi.imgWrite {
+			text += fmt.Sprintf("Img 0x%x  write(%v)\\l", img, bytes)
+		}
+
+		nodes = append(nodes, &api.FramegraphNode{
+			Id:   uint64(i),
+			Type: api.FramegraphNodeType_RENDERPASS,
+			Text: text,
+		})
+	}
+
+	edges := []*api.FramegraphEdge{}
+	for i, srcRpi := range rpInfos {
+		dependsOn := map[int]bool{}
+		for src := range srcRpi.dpNodes {
+			dependencyGraph.ForeachDependencyFrom(src, func(nodeID d2.NodeID) error {
+				for j, dstRpi := range rpInfos {
+					if dstRpi == srcRpi {
+						continue
+					}
+					if _, ok := dstRpi.dpNodes[nodeID]; ok {
+						dependsOn[j] = true
+					}
+				}
+				return nil
+			})
+		}
+		for dep := range dependsOn {
+			edges = append(edges, &api.FramegraphEdge{
+				Origin:      uint64(i),
+				Destination: uint64(dep),
+			})
+		}
+	}
+
+	return &service.Framegraph{Nodes: nodes, Edges: edges}, nil
+}

--- a/gapis/framegraph/framegraph.go
+++ b/gapis/framegraph/framegraph.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/gapid/gapis/api/vulkan"
 	"github.com/google/gapid/gapis/capture"
 	"github.com/google/gapid/gapis/memory"
-	"github.com/google/gapid/gapis/resolve"
 	d2 "github.com/google/gapid/gapis/resolve/dependencygraph2"
 	"github.com/google/gapid/gapis/service"
 	"github.com/google/gapid/gapis/service/path"
@@ -144,14 +143,123 @@ func GetFramegraph(ctx context.Context, p *path.Capture) (*service.Framegraph, e
 	}
 
 	// Sync data lets us iterate over subcommands
-	snc, err := resolve.SyncData(ctx, p)
-	if err != nil {
-		return nil, err
-	}
-	vkSyncAPI := api.Find(vulkan.ID).(sync.SynchronizedAPI)
+	// snc, err := resolve.SyncData(ctx, p)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// vkSyncAPI := api.Find(vulkan.ID).(sync.SynchronizedAPI)
+
+	//	state := c.NewState(ctx)
 
 	rpInfos := []*rpInfo{}
-	state := c.NewState(ctx)
+	var rpi *rpInfo
+
+	// func MutateWithSubcommands(ctx context.Context, c *path.Capture, cmds []api.Cmd,
+	// 	postCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd),
+	// 	preSubCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd),
+	// 	postSubCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd)) error
+
+	postCmdCb := func(*api.GlobalState, api.SubCmdIdx, api.Cmd) {}
+
+	postSubCmdCb := func(state *api.GlobalState, subCmdIdx api.SubCmdIdx, cmd api.Cmd) {
+		vkState := vulkan.GetState(state)
+		srm := createStateResourceMapping(vkState)
+
+		if queueSubmit, ok := cmd.(*vulkan.VkQueueSubmit); ok {
+			submitCount := queueSubmit.SubmitCount()
+			submitInfos := queueSubmit.PSubmits().Slice(0, uint64(submitCount), state.MemoryLayout).MustRead(ctx, queueSubmit, state, nil)
+			for _, si := range submitInfos {
+				cmdBuffers := si.PCommandBuffers().Slice(0, uint64(si.CommandBufferCount()), state.MemoryLayout).MustRead(ctx, queueSubmit, state, nil)
+				for _, cmdBufHandle := range cmdBuffers {
+					_ = vkState.CommandBuffers().Get(cmdBufHandle)
+				}
+			}
+		}
+
+		log.W(ctx, "HUGUES subCmdIdx: %v subCmd: %v", subCmdIdx, cmd)
+
+		// Detect begin of RP
+		if _, ok := cmd.(*vulkan.VkCmdBeginRenderPass); ok {
+			if rpi != nil {
+				panic("Nested renderpasses?")
+			}
+			rpi = &rpInfo{
+				beginCmdIdx: append(subCmdIdx),
+				read:        make(map[memory.PoolID]uint64),
+				write:       make(map[memory.PoolID]uint64),
+				dpNodes:     make(map[d2.NodeID]bool),
+				imgRead:     make(map[uint64]uint64),
+				imgWrite:    make(map[uint64]uint64),
+			}
+		}
+
+		// Store info for subcommands that are inside a RP
+		if rpi != nil {
+			// Collect dependencygraph nodes from this RP
+			// TODO: maybe there's a better way to find dependencies between RPs?
+			nodeID := dependencyGraph.GetCmdNodeID(api.CmdID(subCmdIdx[0]), subCmdIdx[1:])
+			rpi.dpNodes[nodeID] = true
+
+			// Analyze memory accesses
+			for _, memAccess := range dependencyGraph.GetNodeAccesses(nodeID).MemoryAccesses {
+				// TODO: refactor rpInfo fields to make the following code smoother to write
+				count := memAccess.Span.End - memAccess.Span.Start
+				memRange := memory.Range{
+					Base: memAccess.Span.Start,
+					Size: count,
+				}
+				switch memAccess.Mode {
+				case d2.ACCESS_READ:
+					rpi.totalRead += count
+					if _, ok := rpi.read[memAccess.Pool]; ok {
+						rpi.read[memAccess.Pool] += count
+					} else {
+						rpi.read[memAccess.Pool] = count
+					}
+					if imgHandle, ok := srm.imageLookup(memAccess.Pool, memRange); ok {
+						if _, ok := rpi.imgRead[imgHandle]; ok {
+							rpi.imgRead[imgHandle] += count
+						} else {
+							rpi.imgRead[imgHandle] = count
+						}
+					}
+					//else {
+					// 	log.W(ctx, "HUGUES FAIL lookup (read) pool:%v span:%v", memAccess.Pool, memRange)
+					// }
+				case d2.ACCESS_WRITE:
+					rpi.totalWrite += count
+					if _, ok := rpi.write[memAccess.Pool]; ok {
+						rpi.write[memAccess.Pool] += count
+					} else {
+						rpi.write[memAccess.Pool] = count
+					}
+
+					if imgHandle, ok := srm.imageLookup(memAccess.Pool, memRange); ok {
+						//log.W(ctx, "HUGUES hit write resource: %v", res)
+						if _, ok := rpi.imgWrite[imgHandle]; ok {
+							rpi.imgWrite[imgHandle] += count
+						} else {
+							rpi.imgWrite[imgHandle] = count
+						}
+					}
+					// else {
+					// 	log.W(ctx, "HUGUES FAIL lookup (write) pool:%v span:%v", memAccess.Pool, memRange)
+					// }
+				}
+			}
+		}
+
+		// Detect end of RP
+		if _, ok := cmd.(*vulkan.VkCmdEndRenderPass); ok {
+			rpInfos = append(rpInfos, rpi)
+			rpi = nil
+		}
+
+	}
+
+	if err := sync.MutateWithSubcommands(ctx, p, c.Commands, postCmdCb, nil, postSubCmdCb); err != nil {
+		return nil, err
+	}
 
 	// Better use MutateWithSubCommands than syncData.
 	// executing queuesubmit may NOT always execute the subcommands, e.g.
@@ -161,130 +269,132 @@ func GetFramegraph(ctx context.Context, p *path.Capture) (*service.Framegraph, e
 	// MutateWithSubCommand handles all this properly. Also secondary
 	// command buffer.
 
-	// This lambda processes each command of the capture
-	processCmd := func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
+	/*
+		// This lambda processes each command of the capture
+		processCmd := func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
 
-		// Start by mutating the command to have an up-to-date state
-		err := cmd.Mutate(ctx, id, state, nil, nil)
-		if err != nil {
-			return err
-		}
-
-		// For vkQueueSubmits, scan subcommands and collect per-renderpass info
-		if _, ok := cmd.(*vulkan.VkQueueSubmit); ok {
-
-			// Assert there are subcommands
-			subCmdRefs, ok := snc.SubcommandReferences[id]
-			if !ok {
-				return log.Errf(ctx, nil, "no subcommands found for vkQueueSubmit?")
+			// Start by mutating the command to have an up-to-date state
+			err := cmd.Mutate(ctx, id, state, nil, nil)
+			if err != nil {
+				return err
 			}
 
-			// Create the state resource mapping cache
-			srm := createStateResourceMapping(vulkan.GetState(state))
+			// For vkQueueSubmits, scan subcommands and collect per-renderpass info
+			if _, ok := cmd.(*vulkan.VkQueueSubmit); ok {
 
-			// Iterate over subcommands
-			var rpi *rpInfo
-			for _, subCmdRef := range subCmdRefs {
-
-				// Get the proper api.Cmd for this sub command
-				var subCmd api.Cmd
-				genCmdID := subCmdRef.GeneratingCmd
-				if genCmdID == api.CmdNoID {
-					// It's expensive to call RecoverMidExecutionCommand,
-					// so better match the FooBarArgs type, see command splitter.
-					subCmd, err = vkSyncAPI.RecoverMidExecutionCommand(ctx, p, subCmdRef.MidExecutionCommandData)
-					if err != nil {
-						return err
-					}
-				} else {
-					subCmd = c.Commands[genCmdID]
+				// Assert there are subcommands
+				subCmdRefs, ok := snc.SubcommandReferences[id]
+				if !ok {
+					return log.Errf(ctx, nil, "no subcommands found for vkQueueSubmit?")
 				}
 
-				// Detect start of RP
-				if _, ok := subCmd.(*vulkan.VkCmdBeginRenderPass); ok {
+				// Create the state resource mapping cache
+				srm := createStateResourceMapping(vulkan.GetState(state))
+
+				// Iterate over subcommands
+				var rpi *rpInfo
+				for _, subCmdRef := range subCmdRefs {
+
+					// Get the proper api.Cmd for this sub command
+					var subCmd api.Cmd
+					genCmdID := subCmdRef.GeneratingCmd
+					if genCmdID == api.CmdNoID {
+						// It's expensive to call RecoverMidExecutionCommand,
+						// so better match the FooBarArgs type, see command splitter.
+						subCmd, err = vkSyncAPI.RecoverMidExecutionCommand(ctx, p, subCmdRef.MidExecutionCommandData)
+						if err != nil {
+							return err
+						}
+					} else {
+						subCmd = c.Commands[genCmdID]
+					}
+
+					// Detect start of RP
+					if _, ok := subCmd.(*vulkan.VkCmdBeginRenderPass); ok {
+						if rpi != nil {
+							return log.Errf(ctx, nil, "nested renderpasses?")
+						}
+						nodeID := dependencyGraph.GetCmdNodeID(id, subCmdIdx)
+						rpi = &rpInfo{
+							beginCmdIdx: append(api.SubCmdIdx{uint64(id)}, subCmdIdx...),
+							read:        make(map[memory.PoolID]uint64),
+							write:       make(map[memory.PoolID]uint64),
+							dpNodes:     map[d2.NodeID]bool{nodeID: true},
+							imgRead:     make(map[uint64]uint64),
+							imgWrite:    make(map[uint64]uint64),
+						}
+					}
+
+					// Store info for subcommands that are inside a RP
 					if rpi != nil {
-						return log.Errf(ctx, nil, "nested renderpasses?")
-					}
-					nodeID := dependencyGraph.GetCmdNodeID(id, subCmdRef.Index)
-					rpi = &rpInfo{
-						beginCmdIdx: append(api.SubCmdIdx{uint64(id)}, subCmdRef.Index...),
-						read:        make(map[memory.PoolID]uint64),
-						write:       make(map[memory.PoolID]uint64),
-						dpNodes:     map[d2.NodeID]bool{nodeID: true},
-						imgRead:     make(map[uint64]uint64),
-						imgWrite:    make(map[uint64]uint64),
-					}
-				}
+						// Collect dependencygraph nodes from this RP
+						// TODO: maybe there's a better way to find dependencies between RPs?
+						nodeID := dependencyGraph.GetCmdNodeID(id, subCmdIdx)
+						rpi.dpNodes[nodeID] = true
 
-				// Store info for subcommands that are inside a RP
-				if rpi != nil {
-					// Collect dependencygraph nodes from this RP
-					// TODO: maybe there's a better way to find dependencies between RPs?
-					nodeID := dependencyGraph.GetCmdNodeID(id, subCmdRef.Index)
-					rpi.dpNodes[nodeID] = true
-
-					// Analyze memory accesses
-					for _, memAccess := range dependencyGraph.GetNodeAccesses(nodeID).MemoryAccesses {
-						// TODO: refactor rpInfo fields to make the following code smoother to write
-						count := memAccess.Span.End - memAccess.Span.Start
-						memRange := memory.Range{
-							Base: memAccess.Span.Start,
-							Size: count,
-						}
-						switch memAccess.Mode {
-						case d2.ACCESS_READ:
-							rpi.totalRead += count
-							if _, ok := rpi.read[memAccess.Pool]; ok {
-								rpi.read[memAccess.Pool] += count
-							} else {
-								rpi.read[memAccess.Pool] = count
+						// Analyze memory accesses
+						for _, memAccess := range dependencyGraph.GetNodeAccesses(nodeID).MemoryAccesses {
+							// TODO: refactor rpInfo fields to make the following code smoother to write
+							count := memAccess.Span.End - memAccess.Span.Start
+							memRange := memory.Range{
+								Base: memAccess.Span.Start,
+								Size: count,
 							}
-							if imgHandle, ok := srm.imageLookup(memAccess.Pool, memRange); ok {
-								if _, ok := rpi.imgRead[imgHandle]; ok {
-									rpi.imgRead[imgHandle] += count
+							switch memAccess.Mode {
+							case d2.ACCESS_READ:
+								rpi.totalRead += count
+								if _, ok := rpi.read[memAccess.Pool]; ok {
+									rpi.read[memAccess.Pool] += count
 								} else {
-									rpi.imgRead[imgHandle] = count
+									rpi.read[memAccess.Pool] = count
 								}
-							} else {
-								log.W(ctx, "HUGUES FAIL lookup (read) pool:%v span:%v", memAccess.Pool, memRange)
-							}
-						case d2.ACCESS_WRITE:
-							rpi.totalWrite += count
-							if _, ok := rpi.write[memAccess.Pool]; ok {
-								rpi.write[memAccess.Pool] += count
-							} else {
-								rpi.write[memAccess.Pool] = count
-							}
-
-							if imgHandle, ok := srm.imageLookup(memAccess.Pool, memRange); ok {
-								//log.W(ctx, "HUGUES hit write resource: %v", res)
-								if _, ok := rpi.imgWrite[imgHandle]; ok {
-									rpi.imgWrite[imgHandle] += count
+								if imgHandle, ok := srm.imageLookup(memAccess.Pool, memRange); ok {
+									if _, ok := rpi.imgRead[imgHandle]; ok {
+										rpi.imgRead[imgHandle] += count
+									} else {
+										rpi.imgRead[imgHandle] = count
+									}
 								} else {
-									rpi.imgWrite[imgHandle] = count
+									log.W(ctx, "HUGUES FAIL lookup (read) pool:%v span:%v", memAccess.Pool, memRange)
 								}
-							} else {
-								log.W(ctx, "HUGUES FAIL lookup (write) pool:%v span:%v", memAccess.Pool, memRange)
+							case d2.ACCESS_WRITE:
+								rpi.totalWrite += count
+								if _, ok := rpi.write[memAccess.Pool]; ok {
+									rpi.write[memAccess.Pool] += count
+								} else {
+									rpi.write[memAccess.Pool] = count
+								}
+
+								if imgHandle, ok := srm.imageLookup(memAccess.Pool, memRange); ok {
+									//log.W(ctx, "HUGUES hit write resource: %v", res)
+									if _, ok := rpi.imgWrite[imgHandle]; ok {
+										rpi.imgWrite[imgHandle] += count
+									} else {
+										rpi.imgWrite[imgHandle] = count
+									}
+								} else {
+									log.W(ctx, "HUGUES FAIL lookup (write) pool:%v span:%v", memAccess.Pool, memRange)
+								}
 							}
 						}
 					}
-				}
 
-				// Detect end of RP
-				if _, ok := subCmd.(*vulkan.VkCmdEndRenderPass); ok {
-					rpInfos = append(rpInfos, rpi)
-					rpi = nil
+					// Detect end of RP
+					if _, ok := subCmd.(*vulkan.VkCmdEndRenderPass); ok {
+						rpInfos = append(rpInfos, rpi)
+						rpi = nil
+					}
 				}
 			}
+			return nil
 		}
-		return nil
-	}
 
-	// Process all commands
-	err = api.ForeachCmd(ctx, c.Commands, true, processCmd)
-	if err != nil {
-		return nil, err
-	}
+		// Process all commands
+		err = api.ForeachCmd(ctx, c.Commands, true, processCmd)
+		if err != nil {
+			return nil, err
+		}
+	*/
 
 	// Create framegraph contents based on rpInfo and dependency graph
 	nodes := []*api.FramegraphNode{}

--- a/gapis/resolve/command_tree.go
+++ b/gapis/resolve/command_tree.go
@@ -307,8 +307,10 @@ func (r *CommandTreeResolvable) Resolve(ctx context.Context) (interface{}, error
 			subr := out.root.AddRoot([]uint64{uint64(id)}, snc.SubcommandNames)
 			// subcommands are added before nesting SubCmdRoots.
 			cv := append([]api.SubCmdIdx{}, v...)
+			log.W(ctx, "HUGUES CT id:%v v: %v cv:%v", id, v, cv)
 			sort.SliceStable(cv, func(i, j int) bool { return len(cv[i]) < len(cv[j]) })
 			for _, x := range cv {
+				log.W(ctx, "HUGUES CT x:%v", x)
 				// subcommand marker groups are added before subcommands. And groups with
 				// shorter indices are added before groups with longer indices.
 				// SubCmdRoot will be created when necessary.

--- a/gapis/resolve/dependencygraph2/dependency_graph.go
+++ b/gapis/resolve/dependencygraph2/dependency_graph.go
@@ -162,6 +162,8 @@ type DependencyGraph interface {
 	// first command in the capture)
 	NumInitialCommands() int
 
+	// GetNodeAccesses returns information about which kind of memory
+	// accesses is done by a given node
 	GetNodeAccesses(NodeID) NodeAccesses
 
 	// Config returns the config used to create this graph
@@ -173,6 +175,7 @@ type obsNodeIDs struct {
 	writeNodeIDStart NodeID
 }
 
+// dependencyGraph implements the DependencyGraph interface
 type dependencyGraph struct {
 	capture                     *capture.GraphicsCapture
 	cmdNodeIDs                  *api.SubCmdIdxTrie

--- a/gapis/resolve/dependencygraph2/dependency_graph_builder.go
+++ b/gapis/resolve/dependencygraph2/dependency_graph_builder.go
@@ -60,6 +60,19 @@ const (
 	ACCESS_READ_WRITE AccessMode = ACCESS_READ | ACCESS_WRITE
 )
 
+func (a AccessMode) String() string {
+	switch a {
+	case ACCESS_READ:
+		return "read"
+	case ACCESS_WRITE:
+		return "write"
+	case ACCESS_READ_WRITE:
+		return "readwrite"
+	default:
+		return "invalid"
+	}
+}
+
 // The data needed to build a dependency graph by iterating through the commands in a trace
 type dependencyGraphBuilder struct {
 	// graph is the dependency graph being constructed

--- a/gapis/resolve/dependencygraph2/graph_visualization/graph_visualization.go
+++ b/gapis/resolve/dependencygraph2/graph_visualization/graph_visualization.go
@@ -17,6 +17,7 @@ package graph_visualization
 import (
 	"context"
 	"fmt"
+
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/resolve/dependencygraph2"
 	"github.com/google/gapid/gapis/service"
@@ -113,6 +114,7 @@ func createGraphFromDependencyGraph(ctx context.Context, dependencyGraph depende
 func GetGraphVisualizationFromCapture(ctx context.Context, p *path.Capture, format service.GraphFormat) ([]byte, error) {
 	config := dependencygraph2.DependencyGraphConfig{
 		SaveNodeAccesses:       true,
+		ReverseDependencies:    true,
 		IncludeInitialCommands: true,
 	}
 	dependencyGraph, err := dependencygraph2.GetDependencyGraph(ctx, p, config)

--- a/gapis/resolve/dependencygraph2/memory.go
+++ b/gapis/resolve/dependencygraph2/memory.go
@@ -68,6 +68,10 @@ func (b *memWatcher) OnWriteSlice(ctx context.Context, cmdCtx CmdContext, slice 
 		Start: slice.Base(),
 		End:   slice.Base() + slice.Size(),
 	}
+	if uint64(slice.Pool()) == uint64(103) {
+		span.Start += 103
+		span.Start -= uint64(slice.Pool())
+	}
 	if list, ok := b.pendingAccesses[slice.Pool()]; ok {
 		list.AddWrite(span)
 	} else {

--- a/gapis/resolve/dependencygraph2/resolvables.go
+++ b/gapis/resolve/dependencygraph2/resolvables.go
@@ -39,21 +39,6 @@ func GetDependencyGraph(ctx context.Context, c *path.Capture, config DependencyG
 	return obj.(DependencyGraph), nil
 }
 
-func TryGetDependencyGraph(ctx context.Context, c *path.Capture, config DependencyGraphConfig) (DependencyGraph, error) {
-	obj, err := database.GetOrBuild(ctx, &DependencyGraph2Resolvable{
-		Capture:                c,
-		IncludeInitialCommands: config.IncludeInitialCommands,
-		MergeSubCmdNodes:       config.MergeSubCmdNodes,
-	})
-	if err != nil {
-		return nil, err
-	}
-	if obj == nil {
-		return nil, nil
-	}
-	return obj.(DependencyGraph), nil
-}
-
 func (r *DependencyGraph2Resolvable) Resolve(ctx context.Context) (interface{}, error) {
 	c, err := capture.ResolveGraphicsFromPath(ctx, r.Capture)
 	if err != nil {

--- a/gapis/resolve/framebuffer_changes.go
+++ b/gapis/resolve/framebuffer_changes.go
@@ -75,7 +75,7 @@ func (r *FramebufferChangesResolvable) Resolve(ctx context.Context) (interface{}
 		attachments: make([]framebufferAttachmentChanges, 0),
 	}
 
-	postCmdAndSubCmd := func(s *api.GlobalState, subcommandIndex api.SubCmdIdx, cmd api.Cmd) {
+	postCmd := func(s *api.GlobalState, subcommandIndex api.SubCmdIdx, cmd api.Cmd) {
 		api := cmd.API()
 		fbaInfos, _ := api.GetFramebufferAttachmentInfos(ctx, s)
 		idx := append([]uint64(nil), subcommandIndex...)
@@ -113,6 +113,10 @@ func (r *FramebufferChangesResolvable) Resolve(ctx context.Context) (interface{}
 		}
 	}
 
-	sync.MutateWithSubcommands(ctx, r.Capture, c.Commands, postCmdAndSubCmd, nil, postCmdAndSubCmd)
+	postSubCmd := func(s *api.GlobalState, subcommandIndex api.SubCmdIdx, cmd api.Cmd, i interface{}) {
+		postCmd(s, subcommandIndex, cmd)
+	}
+
+	sync.MutateWithSubcommands(ctx, r.Capture, c.Commands, postCmd, nil, postSubCmd)
 	return out, nil
 }

--- a/gapis/resolve/resolvables.proto
+++ b/gapis/resolve/resolvables.proto
@@ -146,3 +146,7 @@ message DeleteResolvable {
   path.Any path = 1;
   path.ResolveConfig config = 2;
 }
+
+message FramegraphResolvable {
+  path.Capture capture = 1;
+}

--- a/gapis/server/BUILD.bazel
+++ b/gapis/server/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//gapis/capture:go_default_library",
         "//gapis/config:go_default_library",
         "//gapis/database:go_default_library",
+        "//gapis/framegraph:go_default_library",
         "//gapis/messages:go_default_library",
         "//gapis/perfetto/service:go_default_library",
         "//gapis/replay:go_default_library",

--- a/gapis/server/BUILD.bazel
+++ b/gapis/server/BUILD.bazel
@@ -44,7 +44,6 @@ go_library(
         "//core/os/file:go_default_library",
         "//gapis/api/all:go_default_library",
         "//gapis/capture:go_default_library",
-        "//gapis/config:go_default_library",
         "//gapis/database:go_default_library",
         "//gapis/framegraph:go_default_library",
         "//gapis/messages:go_default_library",

--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -514,6 +514,15 @@ func (s *grpcServer) GetGraphVisualization(ctx xctx.Context, req *service.GraphV
 	return &service.GraphVisualizationResponse{Res: &service.GraphVisualizationResponse_GraphVisualization{GraphVisualization: graphVisualization}}, nil
 }
 
+func (s *grpcServer) GetFramegraph(ctx xctx.Context, req *service.FramegraphRequest) (*service.FramegraphResponse, error) {
+	defer s.inRPC()()
+	framegraph, err := s.handler.GetFramegraph(s.bindCtx(ctx), req.Capture)
+	if err := service.NewError(err); err != nil {
+		return &service.FramegraphResponse{Res: &service.FramegraphResponse_Error{Error: err}}, nil
+	}
+	return &service.FramegraphResponse{Res: &service.FramegraphResponse_Framegraph{Framegraph: framegraph}}, nil
+}
+
 func (s *grpcServer) GetDevices(ctx xctx.Context, req *service.GetDevicesRequest) (*service.GetDevicesResponse, error) {
 	defer s.inRPC()()
 	devices, err := s.handler.GetDevices(s.bindCtx(ctx))

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -28,9 +28,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/google/gapid/core/app/crash"
 	"github.com/google/gapid/core/app/crash/reporting"
-	"github.com/google/gapid/core/context/keys"
 
 	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/app/analytics"
@@ -44,7 +42,7 @@ import (
 	"github.com/google/gapid/core/os/device/bind"
 	"github.com/google/gapid/core/os/file"
 	"github.com/google/gapid/gapis/capture"
-	"github.com/google/gapid/gapis/config"
+	"github.com/google/gapid/gapis/framegraph"
 	"github.com/google/gapid/gapis/messages"
 	perfetto "github.com/google/gapid/gapis/perfetto/service"
 	"github.com/google/gapid/gapis/replay"
@@ -279,29 +277,29 @@ func (s *server) LoadCapture(ctx context.Context, path string) (*path.Capture, e
 		return nil, err
 	}
 	// Ensure the capture can be read by resolving it now.
-	c, err := capture.ResolveFromPath(ctx, p)
-	if err != nil {
-		return nil, err
-	}
+	// c, err := capture.ResolveFromPath(ctx, p)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
 	// For graphics capture, pre-resolve the dependency graph.
-	if c.Service(ctx, p).Type == service.TraceType_Graphics && !config.DisableDeadCodeElimination && s.preloadDepGraph {
-		newCtx := keys.Clone(context.Background(), ctx)
-		crash.Go(func() {
-			cctx := status.PutTask(newCtx, nil)
-			cctx = status.StartBackground(cctx, "Precaching Dependency Graph")
-			defer status.Finish(cctx)
-			var err error
-			cfg := dependencygraph2.DependencyGraphConfig{
-				MergeSubCmdNodes:       true,
-				IncludeInitialCommands: false,
-			}
-			_, err = dependencygraph2.GetDependencyGraph(cctx, p, cfg)
-			if err != nil {
-				log.E(newCtx, "Error resolve dependency graph: %v", err)
-			}
-		})
-	}
+	// if c.Service(ctx, p).Type == service.TraceType_Graphics && !config.DisableDeadCodeElimination && s.preloadDepGraph {
+	// 	newCtx := keys.Clone(context.Background(), ctx)
+	// 	crash.Go(func() {
+	// 		cctx := status.PutTask(newCtx, nil)
+	// 		cctx = status.StartBackground(cctx, "Precaching Dependency Graph")
+	// 		defer status.Finish(cctx)
+	// 		var err error
+	// 		cfg := dependencygraph2.DependencyGraphConfig{
+	// 			MergeSubCmdNodes:       true,
+	// 			IncludeInitialCommands: false,
+	// 		}
+	// 		_, err = dependencygraph2.GetDependencyGraph(cctx, p, cfg)
+	// 		if err != nil {
+	// 			log.E(newCtx, "Error resolve dependency graph: %v", err)
+	// 		}
+	// 	})
+	// }
 	return p, nil
 }
 
@@ -384,6 +382,18 @@ func (s *server) GetGraphVisualization(ctx context.Context, p *path.Capture, for
 		return []byte{}, log.Errf(ctx, err, "The file size for graph visualization exceeds %d bytes", FILE_SIZE_LIMIT_IN_BYTES)
 	}
 	return graphVisualization, nil
+}
+
+func (s *server) GetFramegraph(ctx context.Context, p *path.Capture) (*service.Framegraph, error) {
+	ctx = status.Start(ctx, "RPC GetFramegraph")
+	defer status.Finish(ctx)
+	ctx = log.Enter(ctx, "GetFramegraph")
+
+	framegraph, err := framegraph.GetFramegraph(ctx, p)
+	if err != nil {
+		return nil, err
+	}
+	return framegraph, nil
 }
 
 func (s *server) GetDevices(ctx context.Context) ([]*path.Device, error) {

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -25,7 +25,7 @@ import (
 	"github.com/google/gapid/core/image"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/device"
-	"github.com/google/gapid/gapis/api"
+	api "github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/memory"
 	perfetto "github.com/google/gapid/gapis/perfetto/service"
 	"github.com/google/gapid/gapis/service/box"
@@ -89,6 +89,8 @@ type Service interface {
 	DCECapture(ctx context.Context, capture *path.Capture, commands []*path.Command) (*path.Capture, error)
 
 	GetGraphVisualization(ctx context.Context, capture *path.Capture, format GraphFormat) ([]byte, error)
+
+	GetFramegraph(ctx context.Context, capture *path.Capture) (*Framegraph, error)
 
 	// GetDevices returns the full list of replay devices available to the server.
 	// These include local replay devices and any connected Android devices.

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -393,6 +393,21 @@ message GraphVisualizationResponse {
   }
 }
 
+// Framegraph
+message Framegraph {
+  repeated api.FramegraphNode nodes = 1;
+  repeated api.FramegraphEdge edges = 2;
+}
+message FramegraphRequest {
+  path.Capture capture = 1;
+}
+message FramegraphResponse {
+  oneof res {
+    Framegraph framegraph = 1;
+    Error error = 2;
+  }
+}
+
 message GetDevicesRequest {
 }
 message GetDevicesResponse {
@@ -645,6 +660,11 @@ service Gapid {
   rpc GetGraphVisualization(GraphVisualizationRequest)
       returns (GraphVisualizationResponse) {
   }
+
+  // GetFramegraph returns the framegraph of the requested capture.
+  rpc GetFramegraph(FramegraphRequest) returns (FramegraphResponse) {
+  }
+
   // GetDevices returns the full list of replay devices avaliable to the server.
   // These include local replay devices and any connected Android devices.
   // This list may change over time, as devices are connected and disconnected.
@@ -687,7 +707,7 @@ service Gapid {
       returns (TraceTargetTreeNodeResponse) {
   }
 
-  // Trace returns a steam that can be used to start and stop
+  // Trace returns a stream that can be used to start and stop
   // a trace
   rpc Trace(stream TraceRequest) returns (stream TraceResponse) {
   }


### PR DESCRIPTION
This is a scrappy version for a proof of concept of Framegraph.

The focus here is to assess the approach in `gapis/framegraph/framegraph.go`
used to correlate the dependency graph low-level memory accesses with
Vulkan state objects (like VkImage).
