### PR TITLE
Re-label dispatches as ExecutedDispatches instead of ExecutedDraws

### DIFF
--- a/gapis/api/cmd_flags.go
+++ b/gapis/api/cmd_flags.go
@@ -27,6 +27,7 @@ const (
 	PopUserMarker
 	UserMarker
 	ExecutedDraw
+	ExecutedDispatch
 	Submission
 )
 
@@ -62,6 +63,10 @@ func (f CmdFlags) IsUserMarker() bool { return (f & UserMarker) != 0 }
 // IsExecutedDraw returns true if the command is a draw call that gets executed
 // as a subcommand.
 func (f CmdFlags) IsExecutedDraw() bool { return (f & ExecutedDraw) != 0 }
+
+// IsExecutedDispatch returns true if the command is a dispatch that gets executed
+// as a subcommand.
+func (f CmdFlags) IsExecutedDispatch() bool { return (f & ExecutedDispatch) != 0 }
 
 // IsSubmission returns true if the command is a submission
 func (f CmdFlags) IsSubmission() bool { return (f & Submission) != 0 }

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -1801,8 +1801,8 @@ import (
   }
 
   func (ϟc *{{$name}}) CmdFlags() ϟapi.CmdFlags {
-    {{$names := Strings "draw_call" "transform_feedback" "clear" "frame_start"  "frame_end"  "user_marker" "push_user_marker" "pop_user_marker" "executed_draw" "submission"}}
-    {{$flags := Strings "DrawCall"  "TransformFeedback"  "Clear" "StartOfFrame" "EndOfFrame" "UserMarker"  "PushUserMarker"   "PopUserMarker" "ExecutedDraw" "Submission"}}
+    {{$names := Strings "draw_call" "transform_feedback" "clear" "frame_start"  "frame_end"  "user_marker" "push_user_marker" "pop_user_marker" "executed_draw" "executed_dispatch" "submission"}}
+    {{$flags := Strings "DrawCall"  "TransformFeedback"  "Clear" "StartOfFrame" "EndOfFrame" "UserMarker"  "PushUserMarker"   "PopUserMarker" "ExecutedDraw" "ExecutedDispatch" "Submission"}}
 
     var out ϟapi.CmdFlags
     {{range $i, $name := $names}}

--- a/gapis/api/vulkan/api/draw_commands.api
+++ b/gapis/api/vulkan/api/draw_commands.api
@@ -402,7 +402,7 @@ sub void dovkCmdDispatch(ref!vkCmdDispatchArgs args) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
-@executed_draw
+@executed_dispatch
 @threadsafe
 cmd void vkCmdDispatch(
     VkCommandBuffer commandBuffer,
@@ -446,7 +446,7 @@ sub void dovkCmdDispatchIndirect(ref!vkCmdDispatchIndirectArgs dispatch) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
-@executed_draw
+@executed_dispatch
 @threadsafe
 cmd void vkCmdDispatchIndirect(
     VkCommandBuffer commandBuffer,

--- a/gapis/api/vulkan/extensions/khr_device_group.api
+++ b/gapis/api/vulkan/extensions/khr_device_group.api
@@ -210,7 +210,7 @@ sub void dovkCmdDispatchBaseKHR(ref!vkCmdDispatchBaseKHRArgs args) {
 @extension("VK_KHR_device_group")
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
-@executed_draw
+@executed_dispatch
 @threadsafe
 cmd void vkCmdDispatchBaseKHR(
     VkCommandBuffer                             commandBuffer,
@@ -259,7 +259,7 @@ sub void dovkCmdDispatchBase(ref!vkCmdDispatchBaseArgs args) {
 // Vulkan 1.1
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
-@executed_draw
+@executed_dispatch
 @threadsafe
 cmd void vkCmdDispatchBase(
     VkCommandBuffer                             commandBuffer,

--- a/gapis/resolve/resource_data.go
+++ b/gapis/resolve/resource_data.go
@@ -187,7 +187,7 @@ func Pipelines(ctx context.Context, p *path.Pipelines, r *path.ResolveConfig) (i
 		return nil, err
 	}
 
-	if !cmd.CmdFlags().IsExecutedDraw() || len(p.After.Indices) == 1 {
+	if !(cmd.CmdFlags().IsExecutedDraw() || cmd.CmdFlags().IsExecutedDispatch()) || len(p.After.Indices) == 1 {
 		return nil, &service.ErrDataUnavailable{Reason: messages.ErrNotADrawCall()}
 	}
 


### PR DESCRIPTION
Added IsExecutedDispatch test:
gapis/resolve/resource_data.go

Did not add test:
gapis/api/vulkan/draw_call_mesh.go
gapis/resolve/filter.go
gapis/resolve/stats.go

Bug: b/161536617