### PR TITLE
Add scaffolding for the framegraph feature

### DIFF
--- a/cmd/gapit/BUILD.bazel
+++ b/cmd/gapit/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "dump_shaders.go",
         "export_replay.go",
         "flags.go",
+        "framegraph.go",
         "inputs.go",
         "main.go",
         "make_doc.go",

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -434,6 +434,11 @@ type (
 		Format string `help:"output format of the graph: 'pbtxt' (Tensorboard) or 'dot' (Graphviz)"`
 	}
 
+	FramegraphFlags struct {
+		Gapis GapisFlags
+		Out   string `help:"path to save framegraph DOT file (default: framegraph.dot)"`
+	}
+
 	SmokeTestsFlags struct {
 	}
 

--- a/cmd/gapit/framegraph.go
+++ b/cmd/gapit/framegraph.go
@@ -1,0 +1,102 @@
+// Copyright (C) 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/service"
+)
+
+// Default output file name.
+const defaultOutFilename = "framegraph.dot"
+
+type framegraphVerb struct{ FramegraphFlags }
+
+func init() {
+	verb := &framegraphVerb{}
+	app.AddVerb(&app.Verb{
+		Name:      "framegraph",
+		ShortHelp: "Create frame graph (in DOT format) from capture",
+		Action:    verb,
+	})
+}
+
+// Run is the main logic for the 'gapit framegraph' command.
+func (verb *framegraphVerb) Run(ctx context.Context, flags flag.FlagSet) error {
+	if flags.NArg() != 1 {
+		app.Usage(ctx, "Exactly one gfx trace file expected, got %d", flags.NArg())
+		return nil
+	}
+
+	captureFilename := flags.Arg(0)
+
+	client, capture, err := getGapisAndLoadCapture(ctx, verb.Gapis, GapirFlags{}, captureFilename, CaptureFileFlags{})
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	framegraph, err := client.GetFramegraph(ctx, capture)
+	if err != nil {
+		return log.Errf(ctx, err, "GetFramegraph(%v)", capture)
+	}
+
+	dot := framegraph2dot(framegraph, captureFilename)
+
+	// Write the DOT representation of the framegraph into a file
+	filePath := verb.Out
+	if filePath == "" {
+		filePath = defaultOutFilename
+	}
+	file, err := os.Create(filePath)
+	if err != nil {
+		return log.Errf(ctx, err, "Creating file (%v)", filePath)
+	}
+	defer file.Close()
+	bytesWritten, err := fmt.Fprint(file, dot)
+	if err != nil {
+		return log.Errf(ctx, err, "Error after writing %d bytes to file", bytesWritten)
+	}
+
+	return nil
+}
+
+// framegraph2dot formats a framegraph in the Graphviz DOT format.
+// https://graphviz.org/doc/info/lang.html
+func framegraph2dot(framegraph *service.Framegraph, captureFilename string) string {
+	s := "digraph agiFramegraph {\n"
+	// Graph title: use capture filename, on top
+	s += "label = \"" + captureFilename + "\";\n"
+	s += "labelloc = \"t\";\n"
+	// Use monospace font everywhere
+	s += "node [fontname = \"Monospace\"];\n"
+	s += "\n"
+	// Node IDs cannot start with a digit, so use "n<node.Id>", e.g. n0 n1 n2
+	for _, node := range framegraph.Nodes {
+		s += fmt.Sprintf("n%v [label=\"%s\"];\n", node.Id, node.Text)
+	}
+	s += "\n"
+	for _, edge := range framegraph.Edges {
+		s += fmt.Sprintf("n%v -> n%v;\n", edge.Origin, edge.Destination)
+	}
+	s += "}\n"
+	return s
+}

--- a/gapis/api/service.proto
+++ b/gapis/api/service.proto
@@ -507,3 +507,18 @@ message SparseBinding {
   // The offset into the buffer of the binding
   uint64 offset = 1;
 }
+
+// Framegraph
+// Minimal "scaffolding" version: nodes and edges are untyped, in the sense that
+// all of a node info is conveyed in a string, and an edge has no more info than
+// the two nodes it connects. In the future, both FramegraphNode and
+// FramegraphEdge messages are meant to gain more fields to describe their info
+// in more details.
+message FramegraphNode {
+  uint64 id = 1;
+  string text = 2;
+}
+message FramegraphEdge {
+  uint64 origin = 1;
+  uint64 destination = 2;
+}

--- a/gapis/client/client.go
+++ b/gapis/client/client.go
@@ -550,6 +550,19 @@ func (c *client) GetGraphVisualization(ctx context.Context, capture *path.Captur
 	return res.GetGraphVisualization(), nil
 }
 
+func (c *client) GetFramegraph(ctx context.Context, capture *path.Capture) (*service.Framegraph, error) {
+	res, err := c.client.GetFramegraph(ctx, &service.FramegraphRequest{
+		Capture: capture,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := res.GetError(); err != nil {
+		return nil, err.Get()
+	}
+	return res.GetFramegraph(), nil
+}
+
 func (c *client) PerfettoQuery(ctx context.Context, capture *path.Capture, query string) (*perfetto.QueryResult, error) {
 	res, err := c.client.PerfettoQuery(ctx, &service.PerfettoQueryRequest{
 		Capture: capture,

--- a/gapis/framegraph/BUILD.bazel
+++ b/gapis/framegraph/BUILD.bazel
@@ -1,0 +1,27 @@
+# Copyright (C) 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["framegraph.go"],
+    importpath = "github.com/google/gapid/gapis/framegraph",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//core/log:go_default_library",
+        "//gapis/service:go_default_library",
+        "//gapis/service/path:go_default_library",
+    ],
+)

--- a/gapis/framegraph/framegraph.go
+++ b/gapis/framegraph/framegraph.go
@@ -1,0 +1,29 @@
+// Copyright (C) 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framegraph
+
+import (
+	"context"
+
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/service"
+	"github.com/google/gapid/gapis/service/path"
+)
+
+// GetFramegraph creates and returns the framegraph of a capture.
+func GetFramegraph(ctx context.Context, p *path.Capture) (*service.Framegraph, error) {
+	log.W(ctx, "Framegraph feature is under construction")
+	return &service.Framegraph{}, nil
+}

--- a/gapis/resolve/resolvables.proto
+++ b/gapis/resolve/resolvables.proto
@@ -146,3 +146,7 @@ message DeleteResolvable {
   path.Any path = 1;
   path.ResolveConfig config = 2;
 }
+
+message FramegraphResolvable {
+  path.Capture capture = 1;
+}

--- a/gapis/server/BUILD.bazel
+++ b/gapis/server/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//gapis/capture:go_default_library",
         "//gapis/config:go_default_library",
         "//gapis/database:go_default_library",
+        "//gapis/framegraph:go_default_library",
         "//gapis/messages:go_default_library",
         "//gapis/perfetto/service:go_default_library",
         "//gapis/replay:go_default_library",

--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -514,6 +514,15 @@ func (s *grpcServer) GetGraphVisualization(ctx xctx.Context, req *service.GraphV
 	return &service.GraphVisualizationResponse{Res: &service.GraphVisualizationResponse_GraphVisualization{GraphVisualization: graphVisualization}}, nil
 }
 
+func (s *grpcServer) GetFramegraph(ctx xctx.Context, req *service.FramegraphRequest) (*service.FramegraphResponse, error) {
+	defer s.inRPC()()
+	framegraph, err := s.handler.GetFramegraph(s.bindCtx(ctx), req.Capture)
+	if err := service.NewError(err); err != nil {
+		return &service.FramegraphResponse{Res: &service.FramegraphResponse_Error{Error: err}}, nil
+	}
+	return &service.FramegraphResponse{Res: &service.FramegraphResponse_Framegraph{Framegraph: framegraph}}, nil
+}
+
 func (s *grpcServer) GetDevices(ctx xctx.Context, req *service.GetDevicesRequest) (*service.GetDevicesResponse, error) {
 	defer s.inRPC()()
 	devices, err := s.handler.GetDevices(s.bindCtx(ctx))

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -45,6 +45,7 @@ import (
 	"github.com/google/gapid/core/os/file"
 	"github.com/google/gapid/gapis/capture"
 	"github.com/google/gapid/gapis/config"
+	"github.com/google/gapid/gapis/framegraph"
 	"github.com/google/gapid/gapis/messages"
 	perfetto "github.com/google/gapid/gapis/perfetto/service"
 	"github.com/google/gapid/gapis/replay"
@@ -384,6 +385,18 @@ func (s *server) GetGraphVisualization(ctx context.Context, p *path.Capture, for
 		return []byte{}, log.Errf(ctx, err, "The file size for graph visualization exceeds %d bytes", FILE_SIZE_LIMIT_IN_BYTES)
 	}
 	return graphVisualization, nil
+}
+
+func (s *server) GetFramegraph(ctx context.Context, p *path.Capture) (*service.Framegraph, error) {
+	ctx = status.Start(ctx, "RPC GetFramegraph")
+	defer status.Finish(ctx)
+	ctx = log.Enter(ctx, "GetFramegraph")
+
+	framegraph, err := framegraph.GetFramegraph(ctx, p)
+	if err != nil {
+		return nil, err
+	}
+	return framegraph, nil
 }
 
 func (s *server) GetDevices(ctx context.Context) ([]*path.Device, error) {

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -90,6 +90,9 @@ type Service interface {
 
 	GetGraphVisualization(ctx context.Context, capture *path.Capture, format GraphFormat) ([]byte, error)
 
+	// GetFramegraph returns the capture's framegraph.
+	GetFramegraph(ctx context.Context, capture *path.Capture) (*Framegraph, error)
+
 	// GetDevices returns the full list of replay devices available to the server.
 	// These include local replay devices and any connected Android devices.
 	// This list may change over time, as devices are connected and disconnected.

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -393,6 +393,21 @@ message GraphVisualizationResponse {
   }
 }
 
+// Framegraph
+message Framegraph {
+  repeated api.FramegraphNode nodes = 1;
+  repeated api.FramegraphEdge edges = 2;
+}
+message FramegraphRequest {
+  path.Capture capture = 1;
+}
+message FramegraphResponse {
+  oneof res {
+    Framegraph framegraph = 1;
+    Error error = 2;
+  }
+}
+
 message GetDevicesRequest {
 }
 message GetDevicesResponse {
@@ -645,6 +660,11 @@ service Gapid {
   rpc GetGraphVisualization(GraphVisualizationRequest)
       returns (GraphVisualizationResponse) {
   }
+
+  // GetFramegraph returns the framegraph of the requested capture.
+  rpc GetFramegraph(FramegraphRequest) returns (FramegraphResponse) {
+  }
+
   // GetDevices returns the full list of replay devices avaliable to the server.
   // These include local replay devices and any connected Android devices.
   // This list may change over time, as devices are connected and disconnected.


### PR DESCRIPTION
This adds the scaffolding code to start working on the framegraph
feature: a gapit framegraph verb, a GetFramegraph RPC, and a
framegraph module.

The code here always returns an empty framegraph: this is on purpose,
the actual creation of a meaningful framegraph will be added in
subsequent changes, once this scaffolding is in place.

Bug: b/171694399