### PR TITLE
Add a mean to retrieve subCmd in MutateSubcommands

### DIFF
--- a/gapis/api/sync/sync.go
+++ b/gapis/api/sync/sync.go
@@ -58,9 +58,10 @@ type SynchronizedAPI interface {
 	// MutateSubcommands mutates the given Cmd and calls callbacks for subcommands
 	// attached to that Cmd. preSubCmdCallback and postSubCmdCallback will be
 	// called before and after executing each subcommand callback.
-	// Both preSubCmdCallback() and postSubCmdCallback() receive the top command as a
-	// api.Cmd, the complete subcommand index, and an interface that enables to
-	// retrieve the actual subcommand via API-specific primitives.
+	// Both preSubCmdCallback() and postSubCmdCallback() receive the parent command
+	// as an api.Cmd, the complete subcommand index, and an interface that allows
+	// to retrieve the actual subcommand via API-specific primitives. In Vulkan,
+	// this interface{} is a CommandReferenceʳ that can be used in GetCommandArgs().
 	MutateSubcommands(ctx context.Context, id api.CmdID, cmd api.Cmd, s *api.GlobalState,
 		preSubCmdCallback func(*api.GlobalState, api.SubCmdIdx, api.Cmd, interface{}),
 		postSubCmdCallback func(*api.GlobalState, api.SubCmdIdx, api.Cmd, interface{})) error

--- a/gapis/api/sync/sync.go
+++ b/gapis/api/sync/sync.go
@@ -58,9 +58,12 @@ type SynchronizedAPI interface {
 	// MutateSubcommands mutates the given Cmd and calls callbacks for subcommands
 	// attached to that Cmd. preSubCmdCallback and postSubCmdCallback will be
 	// called before and after executing each subcommand callback.
+	// Both preSubCmdCallback() and postSubCmdCallback() receive the top command as a
+	// api.Cmd, the complete subcommand index, and an interface that enables to
+	// retrieve the actual subcommand via API-specific primitives.
 	MutateSubcommands(ctx context.Context, id api.CmdID, cmd api.Cmd, s *api.GlobalState,
-		preSubCmdCallback func(*api.GlobalState, api.SubCmdIdx, api.Cmd),
-		postSubCmdCallback func(*api.GlobalState, api.SubCmdIdx, api.Cmd)) error
+		preSubCmdCallback func(*api.GlobalState, api.SubCmdIdx, api.Cmd, interface{}),
+		postSubCmdCallback func(*api.GlobalState, api.SubCmdIdx, api.Cmd, interface{})) error
 
 	// FlattenSubcommandIdx returns the flatten command id for the subcommand
 	// specified by the given SubCmdIdx. If flattening succeeded, the flatten
@@ -174,8 +177,8 @@ func MutationCmdsFor(ctx context.Context, c *path.Capture, data *Data, cmds []ap
 // before and after calling each subcommand callback function.
 func MutateWithSubcommands(ctx context.Context, c *path.Capture, cmds []api.Cmd,
 	postCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd),
-	preSubCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd),
-	postSubCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd)) error {
+	preSubCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd, interface{}),
+	postSubCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd, interface{})) error {
 
 	ctx = status.Start(ctx, "Sync.MutateWithSubcommands")
 	defer status.Finish(ctx)

--- a/gapis/api/sync/sync.go
+++ b/gapis/api/sync/sync.go
@@ -63,8 +63,8 @@ type SynchronizedAPI interface {
 	// to retrieve the actual subcommand via API-specific primitives. In Vulkan,
 	// this interface{} is a CommandReferenceʳ that can be used in GetCommandArgs().
 	MutateSubcommands(ctx context.Context, id api.CmdID, cmd api.Cmd, s *api.GlobalState,
-		preSubCmdCallback func(*api.GlobalState, api.SubCmdIdx, api.Cmd, interface{}),
-		postSubCmdCallback func(*api.GlobalState, api.SubCmdIdx, api.Cmd, interface{})) error
+		preSubCmdCallback func(s *api.GlobalState, idx api.SubCmdIdx, cmd api.Cmd, subCmdRef interface{}),
+		postSubCmdCallback func(s *api.GlobalState, idx api.SubCmdIdx, cmd api.Cmd, subCmdRef interface{})) error
 
 	// FlattenSubcommandIdx returns the flatten command id for the subcommand
 	// specified by the given SubCmdIdx. If flattening succeeded, the flatten
@@ -178,8 +178,8 @@ func MutationCmdsFor(ctx context.Context, c *path.Capture, data *Data, cmds []ap
 // before and after calling each subcommand callback function.
 func MutateWithSubcommands(ctx context.Context, c *path.Capture, cmds []api.Cmd,
 	postCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd),
-	preSubCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd, interface{}),
-	postSubCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd, interface{})) error {
+	preSubCmdCb func(s *api.GlobalState, idx api.SubCmdIdx, cmd api.Cmd, subCmdRef interface{}),
+	postSubCmdCb func(s *api.GlobalState, idx api.SubCmdIdx, cmd api.Cmd, subCmdRef interface{})) error {
 
 	ctx = status.Start(ctx, "Sync.MutateWithSubcommands")
 	defer status.Finish(ctx)

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -463,17 +463,17 @@ func (API) GetTerminator(ctx context.Context, c *path.Capture) (terminator.Termi
 }
 
 func (API) MutateSubcommands(ctx context.Context, id api.CmdID, cmd api.Cmd,
-	s *api.GlobalState, preSubCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd, interface{}),
-	postSubCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd, interface{})) error {
+	s *api.GlobalState, preSubCmdCb func(s *api.GlobalState, idx api.SubCmdIdx, cmd api.Cmd, subCmdRef interface{}),
+	postSubCmdCb func(s *api.GlobalState, idx api.SubCmdIdx, cmd api.Cmd, subCmdRef interface{})) error {
 	c := GetState(s)
 	if postSubCmdCb != nil {
-		c.PostSubcommand = func(i interface{}) {
-			postSubCmdCb(s, append(api.SubCmdIdx{uint64(id)}, c.SubCmdIdx...), cmd, i)
+		c.PostSubcommand = func(subCmdRef interface{}) {
+			postSubCmdCb(s, append(api.SubCmdIdx{uint64(id)}, c.SubCmdIdx...), cmd, subCmdRef)
 		}
 	}
 	if preSubCmdCb != nil {
-		c.PreSubcommand = func(i interface{}) {
-			preSubCmdCb(s, append(api.SubCmdIdx{uint64(id)}, c.SubCmdIdx...), cmd, i)
+		c.PreSubcommand = func(subCmdRef interface{}) {
+			preSubCmdCb(s, append(api.SubCmdIdx{uint64(id)}, c.SubCmdIdx...), cmd, subCmdRef)
 		}
 	}
 	if err := cmd.Mutate(ctx, id, s, nil, nil); err != nil {

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -463,17 +463,17 @@ func (API) GetTerminator(ctx context.Context, c *path.Capture) (terminator.Termi
 }
 
 func (API) MutateSubcommands(ctx context.Context, id api.CmdID, cmd api.Cmd,
-	s *api.GlobalState, preSubCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd),
-	postSubCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd)) error {
+	s *api.GlobalState, preSubCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd, interface{}),
+	postSubCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd, interface{})) error {
 	c := GetState(s)
 	if postSubCmdCb != nil {
-		c.PostSubcommand = func(interface{}) {
-			postSubCmdCb(s, append(api.SubCmdIdx{uint64(id)}, c.SubCmdIdx...), cmd)
+		c.PostSubcommand = func(i interface{}) {
+			postSubCmdCb(s, append(api.SubCmdIdx{uint64(id)}, c.SubCmdIdx...), cmd, i)
 		}
 	}
 	if preSubCmdCb != nil {
-		c.PreSubcommand = func(interface{}) {
-			preSubCmdCb(s, append(api.SubCmdIdx{uint64(id)}, c.SubCmdIdx...), cmd)
+		c.PreSubcommand = func(i interface{}) {
+			preSubCmdCb(s, append(api.SubCmdIdx{uint64(id)}, c.SubCmdIdx...), cmd, i)
 		}
 	}
 	if err := cmd.Mutate(ctx, id, s, nil, nil); err != nil {

--- a/gapis/resolve/framebuffer_changes.go
+++ b/gapis/resolve/framebuffer_changes.go
@@ -113,8 +113,8 @@ func (r *FramebufferChangesResolvable) Resolve(ctx context.Context) (interface{}
 		}
 	}
 
-	postSubCmd := func(s *api.GlobalState, subcommandIndex api.SubCmdIdx, cmd api.Cmd, i interface{}) {
-		postCmd(s, subcommandIndex, cmd)
+	postSubCmd := func(s *api.GlobalState, idx api.SubCmdIdx, cmd api.Cmd, subCmdRef interface{}) {
+		postCmd(s, idx, cmd)
 	}
 
 	sync.MutateWithSubcommands(ctx, r.Capture, c.Commands, postCmd, nil, postSubCmd)

--- a/gapis/resolve/framebuffer_changes.go
+++ b/gapis/resolve/framebuffer_changes.go
@@ -75,7 +75,7 @@ func (r *FramebufferChangesResolvable) Resolve(ctx context.Context) (interface{}
 		attachments: make([]framebufferAttachmentChanges, 0),
 	}
 
-	postCmdAndSubCmd := func(s *api.GlobalState, subcommandIndex api.SubCmdIdx, cmd api.Cmd) {
+	postCmd := func(s *api.GlobalState, subcommandIndex api.SubCmdIdx, cmd api.Cmd) {
 		api := cmd.API()
 		fbaInfos, _ := api.GetFramebufferAttachmentInfos(ctx, s)
 		idx := append([]uint64(nil), subcommandIndex...)
@@ -113,6 +113,10 @@ func (r *FramebufferChangesResolvable) Resolve(ctx context.Context) (interface{}
 		}
 	}
 
-	sync.MutateWithSubcommands(ctx, r.Capture, c.Commands, postCmdAndSubCmd, nil, postCmdAndSubCmd)
+	postSubCmd := func(s *api.GlobalState, subcommandIndex api.SubCmdIdx, cmd api.Cmd, i interface{}) {
+		postCmd(s, subcommandIndex, cmd)
+	}
+
+	sync.MutateWithSubcommands(ctx, r.Capture, c.Commands, postCmd, nil, postSubCmd)
 	return out, nil
 }


### PR DESCRIPTION
This change propagates a reference to the subcommand upon which
preSubCmdCallback() and postSubCmdCallback() are called.

Each of these two callbacks, used in MutateSubcommands() and
MutateWithSubcommands(), currently receives as argument:

- the complete api.SubCmdIdx of the subcommand

- the api.Cmd corresponding to the **parent** command

While there are ways to retrieve the actual subcommand from these two
arguments, it would be often a lot of work.

However, these callbacks are actually called in a context where we do
have a vulkan.CommandReferenceʳ to the subcommand, see
e.g. gapis/vulkan/api/externs.go:onPostSubcommand(). This reference is
being passed as an interface{} because it is API-specific, while
MutateSubcommands() is API-agnostic. This change makes sure that this
command reference is made accessible to the callbacks.

Currently, the only user of MutateWithSubcommands() is
FramebufferChangesResolvable.Resolve(), and it does not need this
command reference, but the upcoming framegraph code will require it.

Bug: b/171719615