### PR TITLE
Link a Profile tab's GPU slice to corresponding renderpass command node.

### DIFF
--- a/gapic/src/main/com/google/gapid/util/Paths.java
+++ b/gapic/src/main/com/google/gapid/util/Paths.java
@@ -118,11 +118,12 @@ public class Paths {
         .build();
   }
 
-  public static Path.Any commandTree(Path.ID tree, Path.Command command) {
+  public static Path.Any commandTreeNodeForCommand(Path.ID tree, Path.Command command, boolean preferGroup) {
     return Path.Any.newBuilder()
         .setCommandTreeNodeForCommand(Path.CommandTreeNodeForCommand.newBuilder()
             .setTree(tree)
-            .setCommand(command))
+            .setCommand(command)
+            .setPreferGroup(preferGroup))
         .build();
   }
 

--- a/gapic/src/main/com/google/gapid/views/CommandTree.java
+++ b/gapic/src/main/com/google/gapid/views/CommandTree.java
@@ -238,7 +238,7 @@ public class CommandTree extends Composite
 
   @Override
   public void onCommandsSelected(CommandIndex index) {
-    selectionHandler.updateSelectionFromModel(() -> models.commands.getTreePath(index).get(), tree::setSelection);
+    selectionHandler.updateSelectionFromModel(() -> models.commands.getTreePath(index.getNode()).get(), tree::setSelection);
   }
 
   @Override

--- a/gapic/src/main/com/google/gapid/views/PerformanceView.java
+++ b/gapic/src/main/com/google/gapid/views/PerformanceView.java
@@ -137,7 +137,7 @@ public class PerformanceView extends Composite
 
   @Override
   public void onCommandsSelected(CommandIndex index) {
-    selectionHandler.updateSelectionFromModel(() -> models.commands.getTreePath(index).get(), tree::setSelection);
+    selectionHandler.updateSelectionFromModel(() -> models.commands.getTreePath(index.getNode()).get(), tree::setSelection);
   }
 
   @Override

--- a/gapic/src/main/com/google/gapid/views/ProfileView.java
+++ b/gapic/src/main/com/google/gapid/views/ProfileView.java
@@ -21,6 +21,7 @@ import static com.google.gapid.perfetto.views.StyleConstants.TITLE_HEIGHT;
 import static com.google.gapid.perfetto.views.StyleConstants.colors;
 import static com.google.gapid.util.Loadable.MessageType.Error;
 import static com.google.gapid.util.Loadable.MessageType.Loading;
+import static java.util.logging.Level.WARNING;
 import static java.util.stream.Collectors.toList;
 
 import com.google.common.collect.Lists;
@@ -29,6 +30,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gapid.models.Analytics;
 import com.google.gapid.models.Capture;
+import com.google.gapid.models.CommandStream;
 import com.google.gapid.models.CommandStream.CommandIndex;
 import com.google.gapid.models.Models;
 import com.google.gapid.models.Perfetto;
@@ -52,13 +54,18 @@ import com.google.gapid.perfetto.views.State;
 import com.google.gapid.perfetto.views.TraceComposite;
 import com.google.gapid.perfetto.views.TrackPanel;
 import com.google.gapid.proto.service.Service;
+import com.google.gapid.rpc.Rpc;
+import com.google.gapid.rpc.RpcException;
+import com.google.gapid.rpc.UiCallback;
 import com.google.gapid.util.Loadable;
 import com.google.gapid.util.Messages;
+import com.google.gapid.util.MoreFutures;
 import com.google.gapid.util.Scheduler;
 import com.google.gapid.widgets.LoadablePanel;
 import com.google.gapid.widgets.Theme;
 import com.google.gapid.widgets.Widgets;
 
+import java.util.concurrent.ExecutionException;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -159,7 +166,31 @@ public class ProfileView extends Composite implements Tab, Capture.Listener, Pro
       if (firstGroupId != -1) {
         for (Service.ProfilingData.GpuSlices.Group group : models.profile.getData().getSlices().getGroupsList()) {
           if (firstGroupId == group.getId()) {
-            models.commands.selectCommands(CommandIndex.forCommand(group.getLink()), false);
+            // Use a real CommandStream.Node's CommandIndex to trigger the command selection, rather
+            // than using a CommandIndex stitched together on the spot. In this way the selection
+            // behavior aligns to what happens when selection is from the UI side, where the resource
+            // tabs' loading result is based on a "representation" command in the grouping node.
+            ListenableFuture<CommandStream.Node> node = MoreFutures.transformAsync(
+                models.commands.getGroupingNodePath(group.getLink()),
+                models.commands::findNode);
+            Rpc.listen(node, new UiCallback<CommandStream.Node, CommandStream.Node>(traceUi, LOG) {
+              @Override
+              protected CommandStream.Node onRpcThread(Rpc.Result<CommandStream.Node> result)
+                  throws RpcException, ExecutionException {
+                return result.get();
+              }
+
+              @Override
+              protected void onUiThread(CommandStream.Node node) {
+                if (node == null) {
+                  // A fallback.
+                  LOG.log(WARNING, "Profile View: failed to find the CommandStream.Node for command index: %s", group.getLink());
+                  models.commands.selectCommands(CommandIndex.forCommand(group.getLink()), false);
+                } else {
+                  models.commands.selectCommands(node.getIndex(), false);
+                }
+              }
+            });
             break;
           }
         }

--- a/gapis/resolve/command_tree.go
+++ b/gapis/resolve/command_tree.go
@@ -74,7 +74,7 @@ func (t *commandTree) index(indices []uint64) (api.SpanItem, api.SubCmdIdx) {
 	return group, subCmdRootID
 }
 
-func (t *commandTree) indices(idx []uint64) []uint64 {
+func (t *commandTree) indices(idx []uint64, preferGroup bool) []uint64 {
 	out := []uint64{}
 	group := t.root
 
@@ -89,6 +89,9 @@ func (t *commandTree) indices(idx []uint64) []uint64 {
 			switch item := group.Index(i).(type) {
 			case api.CmdIDGroup:
 				group = item
+				if preferGroup {
+					brk = true
+				}
 			case api.SubCmdRoot:
 				group = item.SubGroup
 				brk = true
@@ -177,7 +180,7 @@ func CommandTreeNodeForCommand(ctx context.Context, p *path.CommandTreeNodeForCo
 
 	return &path.CommandTreeNode{
 		Tree:    p.Tree,
-		Indices: cmdTree.indices(p.Command.Indices),
+		Indices: cmdTree.indices(p.Command.Indices, p.PreferGroup),
 	}, nil
 }
 

--- a/gapis/service/path/path.proto
+++ b/gapis/service/path/path.proto
@@ -360,6 +360,7 @@ message CommandTreeNodeForCommand {
   ID tree = 1;
   // The command path.
   Command command = 2;
+  bool preferGroup = 3;
 }
 
 // ImageInfo is a path that refers to a image.Info.


### PR DESCRIPTION
 - Instead of linking it to the vkCmdBeginRenderPass command.
 - Provide a "preferGroup" option when resolving path.CommandTreeNodeForCommand,
 if two CommandTreeNodes share the same command index, but one is a CmdIDGroup and one
 is a command, by this toggle, we could control which CommandTreeNode should be
 returned by the server.
 - Bug: b/170310168.