### PR TITLE
Error Handling Cleanup and Ignore Profiling Support when Tracing

### DIFF
--- a/cmd/launch_producer/main.cpp
+++ b/cmd/launch_producer/main.cpp
@@ -26,7 +26,7 @@
 
 #define _LOG(lvl, name, msg, ...)                        \
   do {                                                   \
-    fprintf(stdout, name ": " msg "\n", ##__VA_ARGS__);  \
+    fprintf(stderr, name ": " msg "\n", ##__VA_ARGS__);  \
     __android_log_print(lvl, "AGI", msg, ##__VA_ARGS__); \
   } while (false)
 

--- a/gapii/client/adb.go
+++ b/gapii/client/adb.go
@@ -76,9 +76,9 @@ func Start(ctx context.Context, p *android.InstalledPackage, a *android.Activity
 		return nil, nil, log.Err(ctx, nil, "Invalid activity information.")
 	}
 
-	supported, _, cleanup, err := d.PrepareGpuProfiling(ctx, a.Package)
-	if err != nil || !supported {
-		return nil, cleanup.Invoke(ctx), log.Err(ctx, err, "GPU profiling is not supported.")
+	_, _, cleanup, err := d.PrepareGpuProfiling(ctx, a.Package)
+	if err != nil {
+		return nil, cleanup.Invoke(ctx), log.Err(ctx, err, "Failed to prepare GPU profiling")
 	}
 
 	// TODO: Need to clean this up and get it working

--- a/gapis/perfetto/android/trace.go
+++ b/gapis/perfetto/android/trace.go
@@ -176,8 +176,7 @@ func Start(ctx context.Context, d adb.Device, a *android.ActivityAction, opts *s
 	// since the producer was last started (e.g. at device discovery time). This should
 	// be a very rare circumstance and can be fixed by restarting AGI.
 	if err := gapidapk.EnsurePerfettoProducerLaunched(ctx, d); err != nil {
-		log.E(ctx, "Failed to start perfetto data producer: %v", err)
-		return nil, cleanup.Invoke(ctx), log.Err(ctx, err, "Failed to startperfetto data producer.")
+		return nil, cleanup.Invoke(ctx), err
 	}
 
 	// With the comsumer protocol, in Android 10 it causes a stall when

--- a/gapis/perfetto/android/trace.go
+++ b/gapis/perfetto/android/trace.go
@@ -133,10 +133,10 @@ func Start(ctx context.Context, d adb.Device, a *android.ActivityAction, opts *s
 		}.Bind(ctx)
 
 		packages := []string{}
-		supported, packageName, nextCleanup, err := d.PrepareGpuProfiling(ctx, a.Package)
+		_, packageName, nextCleanup, err := d.PrepareGpuProfiling(ctx, a.Package)
 		cleanup = cleanup.Then(nextCleanup)
-		if err != nil || !supported {
-			return nil, cleanup.Invoke(ctx), log.Err(ctx, err, "GPU profiling is not supported")
+		if err != nil {
+			return nil, cleanup.Invoke(ctx), log.Err(ctx, err, "Failed to prepare GPU profiling")
 		}
 		if packageName != "" {
 			packages = append(packages, packageName)


### PR DESCRIPTION
Cleans up a bunch of error handling in the producer launcher and ignores profiling support, when tracing. Profiling support is already guarded by device validation. This just allows people off the supported path to capture traces.

Bug: http://b/168758265