### PR TITLE
Add scaffolding for the framegraph feature

### DIFF
--- a/cmd/gapit/BUILD.bazel
+++ b/cmd/gapit/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "dump_shaders.go",
         "export_replay.go",
         "flags.go",
+        "framegraph.go",
         "inputs.go",
         "main.go",
         "make_doc.go",

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -434,6 +434,11 @@ type (
 		Format string `help:"output format of the graph: 'pbtxt' (Tensorboard) or 'dot' (Graphviz)"`
 	}
 
+	FramegraphFlags struct {
+		Gapis GapisFlags
+		Out   string `help:"path to save framegraph DOT file (default: framegraph.dot)"`
+	}
+
 	SmokeTestsFlags struct {
 	}
 

--- a/cmd/gapit/framegraph.go
+++ b/cmd/gapit/framegraph.go
@@ -1,0 +1,103 @@
+// Copyright (C) 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/api"
+)
+
+// Default output file name.
+const defaultOutFilename = "framegraph.dot"
+
+type framegraphVerb struct{ FramegraphFlags }
+
+func init() {
+	verb := &framegraphVerb{}
+	app.AddVerb(&app.Verb{
+		Name:      "framegraph",
+		ShortHelp: "Create frame graph (in DOT format) from capture",
+		Action:    verb,
+	})
+}
+
+// Run is the main logic for the 'gapit framegraph' command.
+func (verb *framegraphVerb) Run(ctx context.Context, flags flag.FlagSet) error {
+	if flags.NArg() != 1 {
+		app.Usage(ctx, "Exactly one gfx trace file expected, got %d", flags.NArg())
+		return nil
+	}
+
+	captureFilename := flags.Arg(0)
+
+	client, capture, err := getGapisAndLoadCapture(ctx, verb.Gapis, GapirFlags{}, captureFilename, CaptureFileFlags{})
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	boxedFramegraph, err := client.Get(ctx, capture.Framegraph().Path(), nil)
+	if err != nil {
+		return err
+	}
+	framegraph := boxedFramegraph.(*api.Framegraph)
+
+	dot := framegraph2dot(framegraph, captureFilename)
+
+	// Write the DOT representation of the framegraph into a file
+	filePath := verb.Out
+	if filePath == "" {
+		filePath = defaultOutFilename
+	}
+	file, err := os.Create(filePath)
+	if err != nil {
+		return log.Errf(ctx, err, "Creating file (%v)", filePath)
+	}
+	defer file.Close()
+	bytesWritten, err := fmt.Fprint(file, dot)
+	if err != nil {
+		return log.Errf(ctx, err, "Error after writing %d bytes to file", bytesWritten)
+	}
+
+	return nil
+}
+
+// framegraph2dot formats a framegraph in the Graphviz DOT format.
+// https://graphviz.org/doc/info/lang.html
+func framegraph2dot(framegraph *api.Framegraph, captureFilename string) string {
+	s := "digraph agiFramegraph {\n"
+	// Graph title: use capture filename, on top
+	s += "label = \"" + captureFilename + "\";\n"
+	s += "labelloc = \"t\";\n"
+	// Use monospace font everywhere
+	s += "node [fontname = \"Monospace\"];\n"
+	s += "\n"
+	// Node IDs cannot start with a digit, so use "n<node.Id>", e.g. n0 n1 n2
+	for _, node := range framegraph.Nodes {
+		s += fmt.Sprintf("n%v [label=\"%s\"];\n", node.Id, node.Text)
+	}
+	s += "\n"
+	for _, edge := range framegraph.Edges {
+		s += fmt.Sprintf("n%v -> n%v;\n", edge.Origin, edge.Destination)
+	}
+	s += "}\n"
+	return s
+}

--- a/gapis/api/api.go
+++ b/gapis/api/api.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/gapid/core/memory/arena"
 	"github.com/google/gapid/gapil/constset"
 	"github.com/google/gapid/gapis/memory"
+	"github.com/google/gapid/gapis/service/path"
 )
 
 // API is the common interface to a graphics programming api.
@@ -57,6 +58,9 @@ type API interface {
 	// The segments of memory that were used to create these commands are
 	// returned in the rangeList.
 	RebuildState(ctx context.Context, s *GlobalState) ([]Cmd, interval.U64RangeList)
+
+	// GetFramegraph returns the framegraph of the capture.
+	GetFramegraph(ctx context.Context, p *path.Capture) (*Framegraph, error)
 }
 
 // FramebufferAttachmentInfo describes a framebuffer at a given point in the trace

--- a/gapis/api/service.proto
+++ b/gapis/api/service.proto
@@ -507,3 +507,22 @@ message SparseBinding {
   // The offset into the buffer of the binding
   uint64 offset = 1;
 }
+
+// Framegraph
+// Minimal "scaffolding" version: nodes and edges are untyped, in the sense that
+// all of a node info is conveyed in a string, and an edge has no more info than
+// the two nodes it connects. In the future, both FramegraphNode and
+// FramegraphEdge messages are meant to gain more fields to describe their info
+// in more details.
+message FramegraphNode {
+  uint64 id = 1;
+  string text = 2;
+}
+message FramegraphEdge {
+  uint64 origin = 1;
+  uint64 destination = 2;
+}
+message Framegraph {
+  repeated FramegraphNode nodes = 1;
+  repeated FramegraphEdge edges = 2;
+}

--- a/gapis/api/test/test.go
+++ b/gapis/api/test/test.go
@@ -31,6 +31,11 @@ func (API) RebuildState(ctx context.Context, s *api.GlobalState) ([]api.Cmd, int
 	return nil, nil
 }
 
+// GetFramegraph is a no-op to conform to the api.API interface.
+func (API) GetFramegraph(ctx context.Context, p *path.Capture) (*api.Framegraph, error) {
+	return nil, nil
+}
+
 func (API) GetFramebufferAttachmentInfos(
 	ctx context.Context,
 	state *api.GlobalState) ([]api.FramebufferAttachmentInfo, error) {

--- a/gapis/api/vulkan/BUILD.bazel
+++ b/gapis/api/vulkan/BUILD.bazel
@@ -69,6 +69,7 @@ go_library(
         "externs.go",
         "extras.go",
         "frame_loop.go",
+        "framegraph.go",
         "graph_visualization.go",
         "image_primer.go",
         "image_primer_device_copy.go",

--- a/gapis/api/vulkan/framegraph.go
+++ b/gapis/api/vulkan/framegraph.go
@@ -1,0 +1,29 @@
+// Copyright (C) 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vulkan
+
+import (
+	"context"
+
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/api"
+	"github.com/google/gapid/gapis/service/path"
+)
+
+// GetFramegraph creates the framegraph of the given capture.
+func (API) GetFramegraph(ctx context.Context, p *path.Capture) (*api.Framegraph, error) {
+	log.W(ctx, "TODO: implement framegraph creation")
+	return &api.Framegraph{}, nil
+}

--- a/gapis/api/vulkan/framegraph.go
+++ b/gapis/api/vulkan/framegraph.go
@@ -25,5 +25,5 @@ import (
 // GetFramegraph creates the framegraph of the given capture.
 func (API) GetFramegraph(ctx context.Context, p *path.Capture) (*api.Framegraph, error) {
 	log.W(ctx, "TODO: implement framegraph creation")
-	return &api.Framegraph{}, nil
+	return nil, nil
 }

--- a/gapis/resolve/BUILD.bazel
+++ b/gapis/resolve/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "framebuffer_attachment_data.go",
         "framebuffer_changes.go",
         "framebuffer_observation.go",
+        "framegraph.go",
         "get.go",
         "index_limits.go",
         "memory.go",

--- a/gapis/resolve/framegraph.go
+++ b/gapis/resolve/framegraph.go
@@ -1,0 +1,45 @@
+// Copyright (C) 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolve
+
+import (
+	"context"
+
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/capture"
+	"github.com/google/gapid/gapis/database"
+	"github.com/google/gapid/gapis/service/path"
+)
+
+// Framegraph retrieves the framegraph from the database, creating it if need be.
+func Framegraph(ctx context.Context, p *path.Framegraph, r *path.ResolveConfig) (interface{}, error) {
+	obj, err := database.Build(ctx, &FramegraphResolvable{Capture: p.Capture})
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+// Resolve implements the Resolvable interface.
+func (r *FramegraphResolvable) Resolve(ctx context.Context) (interface{}, error) {
+	c, err := capture.ResolveGraphicsFromPath(ctx, r.Capture)
+	if err != nil {
+		return nil, err
+	}
+	if len(c.APIs) != 1 {
+		return nil, log.Errf(ctx, nil, "Framegraph can be obtained only on a capture with a single API, whereas this capture has %v API(s).", len(c.APIs))
+	}
+	return c.APIs[0].GetFramegraph(ctx, r.Capture)
+}

--- a/gapis/resolve/resolvables.proto
+++ b/gapis/resolve/resolvables.proto
@@ -146,3 +146,7 @@ message DeleteResolvable {
   path.Any path = 1;
   path.ResolveConfig config = 2;
 }
+
+message FramegraphResolvable {
+  path.Capture capture = 1;
+}

--- a/gapis/resolve/resolve.go
+++ b/gapis/resolve/resolve.go
@@ -325,6 +325,8 @@ func ResolveInternal(ctx context.Context, p path.Node, r *path.ResolveConfig) (i
 		return FramebufferAttachment(ctx, p, r)
 	case *path.Field:
 		return Field(ctx, p, r)
+	case *path.Framegraph:
+		return Framegraph(ctx, p, r)
 	case *path.GlobalState:
 		return GlobalState(ctx, p, r)
 	case *path.ImageInfo:

--- a/gapis/service/path/path.go
+++ b/gapis/service/path/path.go
@@ -75,6 +75,7 @@ func (n *FramebufferObservation) Path() *Any    { return &Any{Path: &Any_FBO{n}}
 func (n *FramebufferAttachments) Path() *Any    { return &Any{Path: &Any_FramebufferAttachments{n}} }
 func (n *FramebufferAttachment) Path() *Any     { return &Any{Path: &Any_FramebufferAttachment{n}} }
 func (n *Field) Path() *Any                     { return &Any{Path: &Any_Field{n}} }
+func (n *Framegraph) Path() *Any                { return &Any{Path: &Any_Framegraph{n}} }
 func (n *GlobalState) Path() *Any               { return &Any{Path: &Any_GlobalState{n}} }
 func (n *ImageInfo) Path() *Any                 { return &Any{Path: &Any_ImageInfo{n}} }
 func (n *MapIndex) Path() *Any                  { return &Any{Path: &Any_MapIndex{n}} }
@@ -117,6 +118,7 @@ func (n FramebufferObservation) Parent() Node    { return n.Command }
 func (n FramebufferAttachments) Parent() Node    { return n.After }
 func (n FramebufferAttachment) Parent() Node     { return n.After }
 func (n Field) Parent() Node                     { return oneOfNode(n.Struct) }
+func (n Framegraph) Parent() Node                { return n.Capture }
 func (n GlobalState) Parent() Node               { return n.After }
 func (n ImageInfo) Parent() Node                 { return nil }
 func (n MapIndex) Parent() Node                  { return oneOfNode(n.Map) }
@@ -156,6 +158,7 @@ func (n *Events) SetParent(p Node)                    { n.Capture, _ = p.(*Captu
 func (n *FramebufferObservation) SetParent(p Node)    { n.Command, _ = p.(*Command) }
 func (n *FramebufferAttachments) SetParent(p Node)    { n.After, _ = p.(*Command) }
 func (n *FramebufferAttachment) SetParent(p Node)     { n.After, _ = p.(*Command) }
+func (n *Framegraph) SetParent(p Node)                { n.Capture, _ = p.(*Capture) }
 func (n *GlobalState) SetParent(p Node)               { n.After, _ = p.(*Command) }
 func (n *ImageInfo) SetParent(p Node)                 {}
 func (n *Memory) SetParent(p Node)                    { n.After, _ = p.(*Command) }
@@ -237,9 +240,13 @@ func (n FramebufferAttachments) Format(f fmt.State, c rune) {
 	fmt.Fprintf(f, "%v.framebuffer-attachments", n.Parent())
 }
 
+// Format implements fmt.Formatter to print the path.
 func (n FramebufferAttachment) Format(f fmt.State, c rune) {
 	fmt.Fprintf(f, "%v.framevuffer-attachment<%x>", n.Parent(), n.Index)
 }
+
+// Format implements fmt.Formatter to print the path.
+func (n Framegraph) Format(f fmt.State, c rune) { fmt.Fprintf(f, "%v.framegraph", n.Parent()) }
 
 // Format implements fmt.Formatter to print the path.
 func (n GlobalState) Format(f fmt.State, c rune) { fmt.Fprintf(f, "%v.global-state", n.Parent()) }
@@ -666,6 +673,11 @@ func (n *Command) FramebufferAttachmentAfter(index uint32) *FramebufferAttachmen
 // after this command.
 func (n *Command) FramebufferObservation() *FramebufferObservation {
 	return &FramebufferObservation{Command: n}
+}
+
+// Framegraph returns the path node to the capture framegraph.
+func (n *Capture) Framegraph() *Framegraph {
+	return &Framegraph{Capture: n}
 }
 
 // Mesh returns the path node to the mesh of this command.

--- a/gapis/service/path/path.proto
+++ b/gapis/service/path/path.proto
@@ -44,7 +44,6 @@ message Any {
     FramebufferAttachments framebuffer_attachments = 18;
     FramebufferAttachment framebuffer_attachment = 19;
     Field field = 20;
-    Framegraph framegraph = 44;
     GlobalState global_state = 21;
     ImageInfo image_info = 22;
     MapIndex map_index = 23;
@@ -68,6 +67,7 @@ message Any {
     Stats stats = 41;
     Thumbnail thumbnail = 42;
     Type type = 43;
+    Framegraph framegraph = 44;
   }
 }
 

--- a/gapis/service/path/path.proto
+++ b/gapis/service/path/path.proto
@@ -44,6 +44,7 @@ message Any {
     FramebufferAttachments framebuffer_attachments = 18;
     FramebufferAttachment framebuffer_attachment = 19;
     Field field = 20;
+    Framegraph framegraph = 44;
     GlobalState global_state = 21;
     ImageInfo image_info = 22;
     MapIndex map_index = 23;
@@ -294,6 +295,10 @@ message Field {
     GlobalState global_state = 7;
     Parameter parameter = 8;
   }
+}
+
+message Framegraph {
+  Capture capture = 1;
 }
 
 // CommandFilter are the optional filters applied to CommandTrees and Events.

--- a/gapis/service/path/validate.go
+++ b/gapis/service/path/validate.go
@@ -198,6 +198,11 @@ func (n *Field) Validate() error {
 }
 
 // Validate checks the path is valid.
+func (n *Framegraph) Validate() error {
+	return checkNotNilAndValidate(n, n.Capture, "capture")
+}
+
+// Validate checks the path is valid.
 func (n *GlobalState) Validate() error {
 	return checkNotNilAndValidate(n, n.After, "after")
 }

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -293,6 +293,8 @@ func NewValue(v interface{}) *Value {
 		return &Value{Val: &Value_FramebufferAttachments{v}}
 	case *FramebufferAttachment:
 		return &Value{Val: &Value_FramebufferAttachment{v}}
+	case *api.Framegraph:
+		return &Value{Val: &Value_Framegraph{v}}
 	case *DeviceTraceConfiguration:
 		return &Value{Val: &Value_TraceConfig{v}}
 	case *types.Type:

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -94,6 +94,7 @@ message Value {
     api.MultiResourceData multi_resource_data = 34;
     FramebufferAttachments framebuffer_attachments = 35;
     FramebufferAttachment framebuffer_attachment = 36;
+    api.Framegraph framegraph = 37;
 
     image.Info image_info = 40;
 


### PR DESCRIPTION
This adds the scaffolding code to start working on the framegraph
feature: a gapit framegraph verb and a Framegraph path to be resolved
by a Get RPC.

The code here always returns an empty framegraph: this is on purpose,
the actual creation of a meaningful framegraph will be added in
subsequent changes, once this scaffolding is in place.

Bug: b/171694399