### PR TITLE
Remove unused function observationSlice()

### DIFF
--- a/gapis/resolve/dependencygraph2/memory.go
+++ b/gapis/resolve/dependencygraph2/memory.go
@@ -17,7 +17,6 @@ package dependencygraph2
 import (
 	"context"
 	"math/bits"
-	"reflect"
 
 	"github.com/google/gapid/core/math/interval"
 	"github.com/google/gapid/gapis/api"
@@ -197,14 +196,6 @@ func (b *memWatcher) addObs(ctx context.Context, cmdCtx CmdContext, obs api.CmdO
 		}}
 }
 
-// observationSlice constructs a Slice from a CmdObservation
-func observationSlice(obs api.CmdObservation) memory.Slice {
-	return memory.NewSlice(obs.Range.Base, obs.Range.Base, obs.Range.Size, obs.Range.Size, obs.Pool, reflect.TypeOf(memory.Char(0)))
-}
-
-// applyMemWrite marks or creates the memoryWrites of wmap ("writeMap") affected
-// by (p, s) as being writes of node n. It returns true if this is a new write
-// by n.
 func applyMemWrite(wmap map[memory.PoolID]*memoryWriteList,
 	p memory.PoolID, n NodeID, s interval.U64Span) bool {
 	if writes, ok := wmap[p]; ok {


### PR DESCRIPTION
This function is a left-over from the early version of
dependencygraph2.

Bug: b/172214201