### PR TITLE
fixes and patches for gcc-10 on Linux

### DIFF
--- a/core/cc/id.h
+++ b/core/cc/id.h
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include <cstring>
 #include <functional>
+#include <string>
 
 namespace core {
 

--- a/core/cc/thread.h
+++ b/core/cc/thread.h
@@ -19,6 +19,7 @@
 
 #include <stdint.h>
 #include <functional>
+#include <string>
 
 namespace core {
 

--- a/tools/build/third_party/breakpad/breakpad.BUILD
+++ b/tools/build/third_party/breakpad/breakpad.BUILD
@@ -90,6 +90,7 @@ cc_library(
         "@gapid//tools/build:linux": [
             "-Wno-maybe-uninitialized",
             "-Wno-deprecated",
+            "-Wno-array-bounds",
         ],
         "@gapid//tools/build:darwin": [],
         "@gapid//tools/build:windows": [

--- a/tools/build/third_party/llvm_fix.patch
+++ b/tools/build/third_party/llvm_fix.patch
@@ -1,0 +1,19 @@
+diff -Naur a/lib/Demangle/MicrosoftDemangleNodes.h b/lib/Demangle/MicrosoftDemangleNodes.h
+--- a/lib/Demangle/MicrosoftDemangleNodes.h	2018-09-13 14:16:38.000000000 +0100
++++ b/lib/Demangle/MicrosoftDemangleNodes.h	2020-11-03 21:21:54.555936492 +0000
+@@ -4,6 +4,8 @@
+ #include "llvm/Demangle/Compiler.h"
+ #include "llvm/Demangle/StringView.h"
+ #include <array>
++#include <cstdint>
++#include <string>
+ 
+ class OutputStream;
+ 
+@@ -694,4 +696,4 @@
+ } // namespace ms_demangle
+ } // namespace llvm
+ 
+-#endif
+\ No newline at end of file
++#endif

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -71,18 +71,18 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
         project = "grpc",
         commit = "c599e6a922a80e40e24a2d3c994a6dd51046796b",  # 1.22.1
         sha256 = "d17ead923510b3c8a03eec623fffe4cba64d43e10b3695f027a1c8f10c03756a",
-	# This patch works around a naming conflict in grpc which leads to
-	# compilation issues in recent gcc/glibc. This issue is fixed on recent
-	# grpc versions (since
-	# https://github.com/grpc/grpc/commit/de6255941a5e1c2fb2d50e57f84e38c09f45023d),
-	# but updating our grpc version leads to errors in compiling the abseil
-	# dependency of grpc
-	# (https://github.com/abseil/abseil-cpp/issues/326). We tried to pull
-	# abseil ourselves and patch it, but abseil also fails to compile with
-	# gcc on windows, so we choose to patch grpc directly. Once grpc has a
-	# version that builds fine on all our targets, we can update grpc and
-	# drop this patch.
-	patch_file = "@gapid//tools/build/third_party/com_github_grpc_grpc:com_github_grpc_grpc_fix.patch",
+        # This patch works around a naming conflict in grpc which leads to
+        # compilation issues in recent gcc/glibc. This issue is fixed on recent
+        # grpc versions (since
+        # https://github.com/grpc/grpc/commit/de6255941a5e1c2fb2d50e57f84e38c09f45023d),
+        # but updating our grpc version leads to errors in compiling the abseil
+        # dependency of grpc
+        # (https://github.com/abseil/abseil-cpp/issues/326). We tried to pull
+        # abseil ourselves and patch it, but abseil also fails to compile with
+        # gcc on windows, so we choose to patch grpc directly. Once grpc has a
+        # version that builds fine on all our targets, we can update grpc and
+        # drop this patch.
+        patch_file = "@gapid//tools/build/third_party/com_github_grpc_grpc:com_github_grpc_grpc_fix.patch",
     )
     _grpc_deps(locals)
 
@@ -158,11 +158,11 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
         commit = "e562960fe303c0ffab6f3458fcdb1544b56fd81e",
         build_file = "@gapid//tools/build/third_party:llvm.BUILD",
         sha256 = "3ef3d905849d547b6481b16d8e7b473a84efafbe90131e7bc90a0c6aae4cd8e6",
-	# This patch fixes missing standard library includes which leads to compilation
-	# issues in recent gcc. This issue is fixed on recent llvm versions (since
-	# https://github.com/llvm-mirror/llvm/commit/e0402b5c9813a2458b8dd3f640883110db280395),
-	# but updating our llvm version leads to other errors.
-	patch_file = "@gapid//tools/build/third_party:llvm_fix.patch",
+        # This patch fixes missing standard library includes which leads to compilation
+        # issues in recent gcc. This issue is fixed on recent llvm versions (since
+        # https://github.com/llvm-mirror/llvm/commit/e0402b5c9813a2458b8dd3f640883110db280395),
+        # but updating our llvm version leads to other errors.
+        patch_file = "@gapid//tools/build/third_party:llvm_fix.patch",
     )
 
     maybe_repository(

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -158,6 +158,11 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
         commit = "e562960fe303c0ffab6f3458fcdb1544b56fd81e",
         build_file = "@gapid//tools/build/third_party:llvm.BUILD",
         sha256 = "3ef3d905849d547b6481b16d8e7b473a84efafbe90131e7bc90a0c6aae4cd8e6",
+	# This patch fixes missing standard library includes which leads to compilation
+	# issues in recent gcc. This issue is fixed on recent llvm versions (since
+	# https://github.com/llvm-mirror/llvm/commit/e0402b5c9813a2458b8dd3f640883110db280395),
+	# but updating our llvm version leads to other errors.
+	patch_file = "@gapid//tools/build/third_party:llvm_fix.patch",
     )
 
     maybe_repository(


### PR DESCRIPTION
This fixes a few missing C++ standard library includes in our code and in LLVM. The latter was fixed with a patch file, as it was much less effort than to update LLVM and to fix all the resulting problems of that.
Also turned off one additional warning in breakpad.

Fixes b/171865830