### PR TITLE
Update Mesa driver workaround

### DIFF
--- a/core/cc/linux/get_vulkan_proc_address.cpp
+++ b/core/cc/linux/get_vulkan_proc_address.cpp
@@ -38,7 +38,7 @@ typedef size_t VkInstance;
 struct MesaLLVMOpener {
   MesaLLVMOpener() {
     char name[512];
-    for (int i = 3; i <= 9; i++) {
+    for (int i = 3; i <= 12; i++) {
       snprintf(name, sizeof(name), "libLLVM-%d.0.so.1", i);
       dlopen(name, RTLD_LAZY | RTLD_DEEPBIND);
       snprintf(name, sizeof(name), "libLLVM-%d.so.1", i);

--- a/core/cc/linux/get_vulkan_proc_address.cpp
+++ b/core/cc/linux/get_vulkan_proc_address.cpp
@@ -38,7 +38,7 @@ typedef size_t VkInstance;
 struct MesaLLVMOpener {
   MesaLLVMOpener() {
     char name[512];
-    for (int i = 3; i <= 12; i++) {
+    for (int i = 3; i <= 20; i++) {
       snprintf(name, sizeof(name), "libLLVM-%d.0.so.1", i);
       dlopen(name, RTLD_LAZY | RTLD_DEEPBIND);
       snprintf(name, sizeof(name), "libLLVM-%d.so.1", i);


### PR DESCRIPTION
The current workaround for a problem with the Mesa driver is limited to LLVM 9, and needs an update for the new LLVM 10.
See https://github.com/google/gapid/issues/1707

Fixes b/172372007