### PR TITLE
Ignore failure to start Perfetto producer for device info.

### DIFF
--- a/gapidapk/deviceinfo.go
+++ b/gapidapk/deviceinfo.go
@@ -128,9 +128,7 @@ func fetchDeviceInfo(ctx context.Context, d adb.Device) error {
 
 		// Start perfetto producer
 		if d.Instance().GetConfiguration().GetOS().GetAPIVersion() >= 29 {
-			if err := EnsurePerfettoProducerLaunched(ctx, d); err != nil {
-				return err
-			}
+			EnsurePerfettoProducerLaunched(ctx, d)
 		}
 	}
 


### PR DESCRIPTION
Failing to start the Perfetto producers shuould not fail device info. Erroring out in the device info means the device will not show up, even when listing unsupported devices.