### PR TITLE
Fix a nil pointer server error when req.Experiments is nil.

### DIFF
--- a/gapis/replay/gpu_profile.go
+++ b/gapis/replay/gpu_profile.go
@@ -98,16 +98,20 @@ func GpuProfile(ctx context.Context, capturePath *path.Capture, device *path.Dev
 		}
 
 		var disabledCmdsIndices [][]uint64
-		if experiments.DisabledCommands != nil {
+		if experiments != nil && experiments.DisabledCommands != nil {
 			disabledCmdsIndices = make([][]uint64, 0, len(experiments.DisabledCommands))
 			for _, cmd := range experiments.DisabledCommands {
 				disabledCmdsIndices = append(disabledCmdsIndices, cmd.Indices)
 			}
 		}
+		var disableAnisotropicFiltering bool
+		if experiments != nil {
+			disableAnisotropicFiltering = experiments.DisableAnisotropicFiltering
+		}
 
 		profilingExperiments := ProfileExperiments{
 			DisabledCmds:                disabledCmdsIndices,
-			DisableAnisotropicFiltering: experiments.DisableAnisotropicFiltering,
+			DisableAnisotropicFiltering: disableAnisotropicFiltering,
 		}
 
 		mgr := GetManager(ctx)


### PR DESCRIPTION
 This bug happens when AGI tries to do a GPU profile replay
 but the experiment config variable is nil.
 Bug: N/A.