### PR TITLE
Avoid adding null into UGD opt in list.

### DIFF
--- a/core/os/android/adb/device.go
+++ b/core/os/android/adb/device.go
@@ -125,10 +125,18 @@ func SetupPrereleaseDriver(ctx context.Context, d Device, p *android.InstalledPa
 	if err != nil {
 		return nil, log.Err(ctx, err, "Failed to get prerelease driver opt in apps.")
 	}
+	// When key is not in the settings global database, a null will be returned.
+	// Avoid using it.
+	if oldOptinApps == "null" {
+		oldOptinApps = ""
+	}
 	if strings.Contains(oldOptinApps, p.Name) {
 		return nil, nil
 	}
-	newOptinApps := oldOptinApps + "," + p.Name
+	newOptinApps := p.Name
+	if oldOptinApps != "" {
+		newOptinApps = oldOptinApps + "," + newOptinApps
+	}
 	// TODO(b/145893290) Check whether application has developer driver enabled once b/145893290 is fixed.
 	if err := d.SetSystemSetting(ctx, "global", settingVariable, newOptinApps); err != nil {
 		return nil, log.Errf(ctx, err, "Failed to set up prerelease driver for app: %v.", p.Name)


### PR DESCRIPTION
At the beginning of the world there's nothing in the settings global database
and hence when queried updatable_driver_prerelease_opt_in_apps, it returns
null. Appending it back to the opt in list may do no harm but we should avoid
it.

Bug: N/A
Test: `adb shell settings put global updatable_driver_prerelease_opt_in_apps com.android.app` and verify it's appended correctly
Test: `adb shell settings delete global updatable_driver_prerelease_opt_in_apps` and verify no `null` is appended