### PR TITLE
Framegraph: add renderpass image accesses

### DIFF
--- a/gapis/memory/range.go
+++ b/gapis/memory/range.go
@@ -58,6 +58,11 @@ func (i Range) Contains(addr uint64) bool {
 	return i.First() <= addr && addr <= i.Last()
 }
 
+// Includes returns true if the Range r is included within the Range i.
+func (i Range) Includes(r Range) bool {
+	return i.First() <= r.First() && r.Last() <= i.Last()
+}
+
 // Overlaps returns true if other overlaps this memory range.
 func (i Range) Overlaps(other Range) bool {
 	a, b := i.Span(), other.Span()


### PR DESCRIPTION
List the images accessed by a renderpass.

Refactor a bit the types to extract imageInfo as a standalone type
from attachmentInfo.

Use a lookup table to find which images match a given memory access.

Bug: b/172218645
Test: manual, on several traces