### PR TITLE
Framegraph: report data as structured protobuf

### DIFF
--- a/cmd/gapit/BUILD.bazel
+++ b/cmd/gapit/BUILD.bazel
@@ -94,6 +94,7 @@ go_library(
         "//gapis/stringtable:go_default_library",
         "//tools/build/third_party/perfetto:config_go_proto",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
     ],
 )
 

--- a/cmd/gapit/BUILD.bazel
+++ b/cmd/gapit/BUILD.bazel
@@ -93,8 +93,8 @@ go_library(
         "//gapis/service/types:go_default_library",
         "//gapis/stringtable:go_default_library",
         "//tools/build/third_party/perfetto:config_go_proto",
-        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
+        "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )
 

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -437,7 +437,8 @@ type (
 
 	FramegraphFlags struct {
 		Gapis GapisFlags
-		Out   string `help:"path to save framegraph DOT file (default: framegraph.dot)"`
+		Dot   string `help:"Store the framegraph in Graphviz dot format in this file"`
+		Json  string `help:"Store the framegraph in JSON format in this file"`
 	}
 
 	SmokeTestsFlags struct {

--- a/cmd/gapit/framegraph.go
+++ b/cmd/gapit/framegraph.go
@@ -123,17 +123,13 @@ func exportDot(ctx context.Context, framegraph *api.Framegraph, captureFilename 
 }
 
 func image2dot(img *api.FramegraphImage) string {
-	swapchain := ""
-	if img.IsSwapchain {
-		swapchain = " swapchain"
-	}
-	transient := ""
-	if img.IsTransient {
-		transient = " transient"
+	nature := ""
+	if img.Nature != api.FramegraphImageNature_NONE {
+		nature = fmt.Sprintf(" %v", img.Nature)
 	}
 	imgType := strings.TrimPrefix(fmt.Sprintf("%v", img.ImageType), "VK_IMAGE_TYPE_")
 	imgFormat := strings.TrimPrefix(fmt.Sprintf("%v", img.Info.Format.Name), "VK_FORMAT_")
-	return fmt.Sprintf("[Img %v%s%s %s %s %vx%vx%v]", img.Handle, swapchain, transient, imgType, imgFormat, img.Info.Width, img.Info.Height, img.Info.Depth)
+	return fmt.Sprintf("[Img %v%s %s %s %vx%vx%v]", img.Handle, nature, imgType, imgFormat, img.Info.Width, img.Info.Height, img.Info.Depth)
 }
 
 func attachment2dot(att *api.FramegraphAttachment) string {

--- a/cmd/gapit/framegraph.go
+++ b/cmd/gapit/framegraph.go
@@ -19,14 +19,13 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/gapis/api"
 )
-
-// Default output file name.
-const defaultOutFilename = "framegraph.dot"
 
 type framegraphVerb struct{ FramegraphFlags }
 
@@ -34,7 +33,7 @@ func init() {
 	verb := &framegraphVerb{}
 	app.AddVerb(&app.Verb{
 		Name:      "framegraph",
-		ShortHelp: "Create frame graph (in DOT format) from capture",
+		ShortHelp: "Get the frame graph of a capture",
 		Action:    verb,
 	})
 }
@@ -43,6 +42,11 @@ func init() {
 func (verb *framegraphVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	if flags.NArg() != 1 {
 		app.Usage(ctx, "Exactly one gfx trace file expected, got %d", flags.NArg())
+		return nil
+	}
+
+	if verb.Dot == "" && verb.Json == "" {
+		app.Usage(ctx, "At least one of -dot or -json flag is expected")
 		return nil
 	}
 
@@ -60,44 +64,119 @@ func (verb *framegraphVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	}
 	framegraph := boxedFramegraph.(*api.Framegraph)
 
-	dot := framegraph2dot(framegraph, captureFilename)
-
-	// Write the DOT representation of the framegraph into a file
-	filePath := verb.Out
-	if filePath == "" {
-		filePath = defaultOutFilename
+	if verb.Json != "" {
+		err = exportJSON(ctx, framegraph, verb.Json)
 	}
-	file, err := os.Create(filePath)
 	if err != nil {
-		return log.Errf(ctx, err, "Creating file (%v)", filePath)
+		return err
+	}
+
+	if verb.Dot != "" {
+		err = exportDot(ctx, framegraph, captureFilename, verb.Dot)
+	}
+
+	return err
+}
+
+func exportJSON(ctx context.Context, framegraph *api.Framegraph, outFile string) error {
+	file, err := os.Create(outFile)
+	if err != nil {
+		return log.Errf(ctx, err, "Creating file (%v)", outFile)
 	}
 	defer file.Close()
-	bytesWritten, err := fmt.Fprint(file, dot)
-	if err != nil {
-		return log.Errf(ctx, err, "Error after writing %d bytes to file", bytesWritten)
-	}
 
+	m := &jsonpb.Marshaler{
+		EmitDefaults: true,
+		Indent:       " ",
+	}
+	return m.Marshal(file, framegraph)
+}
+
+// exportDot exports the framegraph in the Graphviz DOT format.
+// https://graphviz.org/doc/info/lang.html
+// In node labels we use "\l" as a newline to obtain left-aligned text.
+func exportDot(ctx context.Context, framegraph *api.Framegraph, captureFilename string, outFile string) error {
+	file, err := os.Create(outFile)
+	if err != nil {
+		return log.Errf(ctx, err, "Creating file (%v)", outFile)
+	}
+	defer file.Close()
+
+	fmt.Fprintf(file, "digraph agiFramegraph {\n")
+
+	// Graph title: use capture filename, on top
+	fmt.Fprintf(file, "label = \"%s\";\n", captureFilename)
+	fmt.Fprintf(file, "labelloc = \"t\";\n")
+	// Use monospace font everywhere
+	fmt.Fprintf(file, "node [fontname = \"Monospace\"];\n")
+	fmt.Fprintf(file, "\n")
+	// Node IDs cannot start with a digit, so use "n<node.Id>", e.g. n0 n1 n2
+	for _, node := range framegraph.Nodes {
+		fmt.Fprintf(file, fmt.Sprintf("n%v [label=\"%s\"];\n", node.Id, renderpass2dot(node.GetRenderpass())))
+	}
+	fmt.Fprintf(file, "\n")
+	for _, edge := range framegraph.Edges {
+		fmt.Fprintf(file, fmt.Sprintf("n%v -> n%v;\n", edge.Origin, edge.Destination))
+	}
+	fmt.Fprintf(file, "}\n")
 	return nil
 }
 
-// framegraph2dot formats a framegraph in the Graphviz DOT format.
-// https://graphviz.org/doc/info/lang.html
-func framegraph2dot(framegraph *api.Framegraph, captureFilename string) string {
-	s := "digraph agiFramegraph {\n"
-	// Graph title: use capture filename, on top
-	s += "label = \"" + captureFilename + "\";\n"
-	s += "labelloc = \"t\";\n"
-	// Use monospace font everywhere
-	s += "node [fontname = \"Monospace\"];\n"
-	s += "\n"
-	// Node IDs cannot start with a digit, so use "n<node.Id>", e.g. n0 n1 n2
-	for _, node := range framegraph.Nodes {
-		s += fmt.Sprintf("n%v [label=\"%s\"];\n", node.Id, node.Text)
+func image2dot(img *api.FramegraphImage) string {
+	swapchain := ""
+	if img.IsSwapchain {
+		swapchain = " swapchain"
 	}
-	s += "\n"
-	for _, edge := range framegraph.Edges {
-		s += fmt.Sprintf("n%v -> n%v;\n", edge.Origin, edge.Destination)
+	transient := ""
+	if img.IsTransient {
+		transient = " transient"
 	}
-	s += "}\n"
+	imgType := strings.TrimPrefix(fmt.Sprintf("%v", img.ImageType), "VK_IMAGE_TYPE_")
+	imgFormat := strings.TrimPrefix(fmt.Sprintf("%v", img.Info.Format.Name), "VK_FORMAT_")
+	return fmt.Sprintf("[Img %v%s%s %s %s %vx%vx%v]", img.Handle, swapchain, transient, imgType, imgFormat, img.Info.Width, img.Info.Height, img.Info.Depth)
+}
+
+func attachment2dot(att *api.FramegraphAttachment) string {
+	if att == nil {
+		return "unused"
+	}
+	return fmt.Sprintf("load:%v store:%v %s", att.LoadOp, att.StoreOp, image2dot(att.Image))
+}
+
+func imageAccess2dot(acc *api.FramegraphImageAccess) string {
+	r := "-"
+	if acc.Read {
+		r = "r"
+	}
+	w := "-"
+	if acc.Write {
+		w = "w"
+	}
+	return fmt.Sprintf("%s%s %s", r, w, image2dot(acc.Image))
+}
+
+func renderpass2dot(rp *api.FramegraphRenderpass) string {
+	s := fmt.Sprintf("Renderpass %v\\lbegin:%v\\lend:  %v\\lFramebuffer: %vx%vx%v\\l", rp.Handle, rp.BeginSubCmdIdx, rp.EndSubCmdIdx, rp.FramebufferWidth, rp.FramebufferHeight, rp.FramebufferLayers)
+	for i, subpass := range rp.Subpass {
+		s += fmt.Sprintf("\\lSubpass %v\\l", i)
+		for j, a := range subpass.Input {
+			s += fmt.Sprintf("input(%v): %v\\l", j, attachment2dot(a))
+		}
+		for j, a := range subpass.Color {
+			s += fmt.Sprintf("color(%v): %v\\l", j, attachment2dot(a))
+		}
+		for j, a := range subpass.Resolve {
+			s += fmt.Sprintf("resolve(%v): %v\\l", j, attachment2dot(a))
+		}
+		s += fmt.Sprintf("depth/stencil: %v\\l", attachment2dot(subpass.DepthStencil))
+	}
+
+	if len(rp.ImageAccess) > 0 {
+		s += "\\lImage accesses:\\l"
+		for _, acc := range rp.ImageAccess {
+			s += fmt.Sprintf("%s\\l", imageAccess2dot(acc))
+		}
+	}
+
 	return s
 }

--- a/gapis/api/service.proto
+++ b/gapis/api/service.proto
@@ -526,7 +526,7 @@ message FramegraphImage {
 }
 
 enum LoadStoreOp {
-  DISCARD = 0; // Used for Vulkan DONT_CARE
+  DISCARD = 0;  // Used for Vulkan DONT_CARE
   CLEAR = 1;
   LOAD = 2;
   STORE = 3;

--- a/gapis/api/service.proto
+++ b/gapis/api/service.proto
@@ -509,19 +509,70 @@ message SparseBinding {
 }
 
 // Framegraph
-// Minimal "scaffolding" version: nodes and edges are untyped, in the sense that
-// all of a node info is conveyed in a string, and an edge has no more info than
-// the two nodes it connects. In the future, both FramegraphNode and
-// FramegraphEdge messages are meant to gain more fields to describe their info
-// in more details.
+
+message FramegraphImage {
+  uint64 handle = 1;
+  image.Info info = 2;
+  string imageType = 3;
+  uint32 usage = 4;
+  bool isSwapchain = 5;
+  bool isTransient = 6;
+}
+
+enum LoadOpType {
+  LOAD_OP_LOAD = 0;
+  LOAD_OP_CLEAR = 1;
+  LOAD_OP_DONT_CARE = 2;
+}
+
+enum StoreOpType {
+  STORE_OP_STORE = 0;
+  STORE_OP_DONT_CARE = 1;
+}
+
+message FramegraphAttachment {
+  LoadOpType loadOp = 1;
+  StoreOpType storeOp = 2;
+  uint64      imageViewHandle = 3;
+  FramegraphImage image = 4;
+}
+
+message FramegraphSubpass {
+  repeated FramegraphAttachment input = 1;
+  repeated FramegraphAttachment color = 2;
+  repeated FramegraphAttachment resolve = 3;
+  FramegraphAttachment depthStencil = 4;
+}
+
+message FramegraphImageAccess {
+  bool read = 1;
+  bool write = 2;
+  FramegraphImage image = 3;
+}
+
+message FramegraphRenderpass {
+  uint64 handle = 1;
+  repeated uint64 beginSubCmdIdx = 2;
+  repeated uint64 endSubCmdIdx = 3;
+  repeated FramegraphSubpass subpass = 4;
+  uint32 framebufferWidth = 5;
+  uint32 framebufferHeight = 6;
+  uint32 framebufferLayers = 7;
+  repeated FramegraphImageAccess imageAccess = 8;
+}
+
 message FramegraphNode {
   uint64 id = 1;
-  string text = 2;
+  oneof workload {
+    FramegraphRenderpass renderpass = 2;
+  }
 }
+
 message FramegraphEdge {
   uint64 origin = 1;
   uint64 destination = 2;
 }
+
 message Framegraph {
   repeated FramegraphNode nodes = 1;
   repeated FramegraphEdge edges = 2;

--- a/gapis/api/service.proto
+++ b/gapis/api/service.proto
@@ -533,7 +533,7 @@ enum StoreOpType {
 message FramegraphAttachment {
   LoadOpType loadOp = 1;
   StoreOpType storeOp = 2;
-  uint64      imageViewHandle = 3;
+  uint64 imageViewHandle = 3;
   FramegraphImage image = 4;
 }
 

--- a/gapis/api/service.proto
+++ b/gapis/api/service.proto
@@ -510,29 +510,31 @@ message SparseBinding {
 
 // Framegraph
 
+enum FramegraphImageNature {
+  NONE = 0;
+  SWAPCHAIN = 1;
+  TRANSIENT = 2;
+}
+
 message FramegraphImage {
   uint64 handle = 1;
+  // We reuse image.Info here, but note that its Info.bytes field won't be set.
   image.Info info = 2;
   string imageType = 3;
   uint32 usage = 4;
-  bool isSwapchain = 5;
-  bool isTransient = 6;
+  FramegraphImageNature nature = 5;
 }
 
-enum LoadOpType {
-  LOAD_OP_LOAD = 0;
-  LOAD_OP_CLEAR = 1;
-  LOAD_OP_DONT_CARE = 2;
-}
-
-enum StoreOpType {
-  STORE_OP_STORE = 0;
-  STORE_OP_DONT_CARE = 1;
+enum LoadStoreOp {
+  DISCARD = 0; // Used for Vulkan DONT_CARE
+  CLEAR = 1;
+  LOAD = 2;
+  STORE = 3;
 }
 
 message FramegraphAttachment {
-  LoadOpType loadOp = 1;
-  StoreOpType storeOp = 2;
+  LoadStoreOp loadOp = 1;
+  LoadStoreOp storeOp = 2;
   uint64 imageViewHandle = 3;
   FramegraphImage image = 4;
 }

--- a/gapis/api/vulkan/framegraph.go
+++ b/gapis/api/vulkan/framegraph.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/google/gapid/core/image"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/api/sync"
 	"github.com/google/gapid/gapis/capture"
@@ -28,68 +29,49 @@ import (
 	"github.com/google/gapid/gapis/service/path"
 )
 
-type imageInfo struct {
-	handle           VkImage
-	width            uint32
-	height           uint32
-	depth            uint32
-	usage            VkImageUsageFlags
-	imgType          VkImageType
-	format           VkFormat
-	isSwapchainImage bool
-}
-
-func (img *imageInfo) String() string {
-	swapchain := ""
-	if img.isSwapchainImage {
-		swapchain = " swapchain"
+func newFramegraphImage(img *ImageObjectʳ) *api.FramegraphImage {
+	format, err := getImageFormatFromVulkanFormat(img.Info().Fmt())
+	if err != nil {
+		panic("Unrecognized Vulkan image format")
 	}
-	transient := ""
-	if (img.usage & VkImageUsageFlags(VkImageUsageFlagBits_VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT)) != 0 {
-		transient = " transient"
-	}
-	imgType := strings.TrimPrefix(fmt.Sprintf("%v", img.imgType), "VK_IMAGE_TYPE_")
-	imgFormat := strings.TrimPrefix(fmt.Sprintf("%v", img.format), "VK_FORMAT_")
-	return fmt.Sprintf("[Img %v%s%s %s %s %vx%vx%v]", img.handle, swapchain, transient, imgType, imgFormat, img.width, img.height, img.depth)
-}
-
-func newImageInfo(image *ImageObjectʳ) *imageInfo {
-	return &imageInfo{
-		handle:           image.VulkanHandle(),
-		width:            image.Info().Extent().Width(),
-		height:           image.Info().Extent().Height(),
-		depth:            image.Info().Extent().Depth(),
-		usage:            image.Info().Usage(),
-		imgType:          image.Info().ImageType(),
-		format:           image.Info().Fmt(),
-		isSwapchainImage: image.IsSwapchainImage(),
+	return &api.FramegraphImage{
+		Handle:      uint64(img.VulkanHandle()),
+		Usage:       uint32(img.Info().Usage()),
+		ImageType:   strings.TrimPrefix(fmt.Sprintf("%v", img.Info().ImageType()), "VK_IMAGE_TYPE_"),
+		IsSwapchain: img.IsSwapchainImage(),
+		IsTransient: img.Info().Usage()&VkImageUsageFlags(VkImageUsageFlagBits_VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) != 0,
+		Info: &image.Info{
+			Format: format,
+			Width:  img.Info().Extent().Width(),
+			Height: img.Info().Extent().Height(),
+			Depth:  img.Info().Extent().Depth(),
+		},
 	}
 }
 
-type attachmentInfo struct {
-	loadOp        VkAttachmentLoadOp
-	storeOp       VkAttachmentStoreOp
-	imgViewHandle VkImageView
-	imgViewType   VkImageViewType
-	imgViewFormat VkFormat
-	img           *imageInfo
-}
-
-func (a *attachmentInfo) String() string {
-	if a == nil {
-		return "unused"
+func getLoadOpType(loadOp VkAttachmentLoadOp) api.LoadOpType {
+	switch loadOp {
+	case VkAttachmentLoadOp_VK_ATTACHMENT_LOAD_OP_LOAD:
+		return api.LoadOpType_LOAD_OP_LOAD
+	case VkAttachmentLoadOp_VK_ATTACHMENT_LOAD_OP_CLEAR:
+		return api.LoadOpType_LOAD_OP_CLEAR
+	case VkAttachmentLoadOp_VK_ATTACHMENT_LOAD_OP_DONT_CARE:
+		return api.LoadOpType_LOAD_OP_DONT_CARE
 	}
-
-	load := strings.TrimPrefix(fmt.Sprintf("%v", a.loadOp), "VK_ATTACHMENT_LOAD_OP_")
-	store := strings.TrimPrefix(fmt.Sprintf("%v", a.storeOp), "VK_ATTACHMENT_STORE_OP_")
-	imgViewType := strings.TrimPrefix(fmt.Sprintf("%v", a.imgViewType), "VK_IMAGE_VIEW_TYPE_")
-	imgViewFormat := strings.TrimPrefix(fmt.Sprintf("%v", a.imgViewFormat), "VK_FORMAT_")
-	att := fmt.Sprintf("load:%s store:%s [View %v %s %s]", load, store, a.imgViewHandle, imgViewType, imgViewFormat)
-
-	return fmt.Sprintf("%s %v", att, a.img)
+	panic("Unknown loadOp")
 }
 
-func newAttachmentInfo(desc VkAttachmentDescription, imgView ImageViewObjectʳ, isDepthStencil bool) *attachmentInfo {
+func getStoreOpType(storeOp VkAttachmentStoreOp) api.StoreOpType {
+	switch storeOp {
+	case VkAttachmentStoreOp_VK_ATTACHMENT_STORE_OP_STORE:
+		return api.StoreOpType_STORE_OP_STORE
+	case VkAttachmentStoreOp_VK_ATTACHMENT_STORE_OP_DONT_CARE:
+		return api.StoreOpType_STORE_OP_DONT_CARE
+	}
+	panic("Unknown storeOp")
+}
+
+func newFramegraphAttachment(desc VkAttachmentDescription, imgView ImageViewObjectʳ, isDepthStencil bool) *api.FramegraphAttachment {
 	var loadOp VkAttachmentLoadOp
 	var storeOp VkAttachmentStoreOp
 	if isDepthStencil {
@@ -100,31 +82,24 @@ func newAttachmentInfo(desc VkAttachmentDescription, imgView ImageViewObjectʳ, 
 		storeOp = desc.StoreOp()
 	}
 	imgObj := imgView.Image()
-	return &attachmentInfo{
-		loadOp:        loadOp,
-		storeOp:       storeOp,
-		imgViewHandle: imgView.VulkanHandle(),
-		imgViewType:   imgView.Type(),
-		imgViewFormat: imgView.Fmt(),
-		img:           newImageInfo(&imgObj),
+	return &api.FramegraphAttachment{
+		LoadOp:          getLoadOpType(loadOp),
+		StoreOp:         getStoreOpType(storeOp),
+		ImageViewHandle: uint64(imgView.VulkanHandle()),
+		// imgViewType:   imgView.Type(),
+		// imgViewFormat: imgView.Fmt(),
+		Image: newFramegraphImage(&imgObj),
 	}
 }
 
-type subpassInfo struct {
-	inputAttachments       []*attachmentInfo
-	colorAttachments       []*attachmentInfo
-	resolveAttachments     []*attachmentInfo
-	depthStencilAttachment *attachmentInfo
-}
-
-func newSubpassInfo(subpassDesc SubpassDescription, framebuffer FramebufferObjectʳ, renderpass RenderPassObjectʳ) *subpassInfo {
+func newFramegraphSubpass(subpassDesc SubpassDescription, framebuffer FramebufferObjectʳ, renderpass RenderPassObjectʳ) *api.FramegraphSubpass {
 	inputAtts := subpassDesc.InputAttachments()
 	colorAtts := subpassDesc.ColorAttachments()
 	resolveAtts := subpassDesc.ResolveAttachments()
-	spInfo := &subpassInfo{
-		inputAttachments:   make([]*attachmentInfo, inputAtts.Len()),
-		colorAttachments:   make([]*attachmentInfo, colorAtts.Len()),
-		resolveAttachments: make([]*attachmentInfo, resolveAtts.Len()),
+	sp := &api.FramegraphSubpass{
+		Input:   make([]*api.FramegraphAttachment, inputAtts.Len()),
+		Color:   make([]*api.FramegraphAttachment, colorAtts.Len()),
+		Resolve: make([]*api.FramegraphAttachment, resolveAtts.Len()),
 	}
 
 	// Input attachments
@@ -135,7 +110,7 @@ func newSubpassInfo(subpassDesc SubpassDescription, framebuffer FramebufferObjec
 		}
 		desc := renderpass.AttachmentDescriptions().Get(idx)
 		imgView := framebuffer.ImageAttachments().Get(idx)
-		spInfo.inputAttachments[i] = newAttachmentInfo(desc, imgView, false)
+		sp.Input[i] = newFramegraphAttachment(desc, imgView, false)
 	}
 
 	// Color attachments
@@ -146,7 +121,7 @@ func newSubpassInfo(subpassDesc SubpassDescription, framebuffer FramebufferObjec
 		}
 		desc := renderpass.AttachmentDescriptions().Get(idx)
 		imgView := framebuffer.ImageAttachments().Get(idx)
-		spInfo.colorAttachments[i] = newAttachmentInfo(desc, imgView, false)
+		sp.Color[i] = newFramegraphAttachment(desc, imgView, false)
 	}
 
 	// Resolve attachments
@@ -157,7 +132,7 @@ func newSubpassInfo(subpassDesc SubpassDescription, framebuffer FramebufferObjec
 		}
 		desc := renderpass.AttachmentDescriptions().Get(idx)
 		imgView := framebuffer.ImageAttachments().Get(idx)
-		spInfo.resolveAttachments[i] = newAttachmentInfo(desc, imgView, false)
+		sp.Resolve[i] = newFramegraphAttachment(desc, imgView, false)
 	}
 
 	// DepthStencil attachment
@@ -167,43 +142,31 @@ func newSubpassInfo(subpassDesc SubpassDescription, framebuffer FramebufferObjec
 		if idx != VK_ATTACHMENT_UNUSED {
 			desc := renderpass.AttachmentDescriptions().Get(idx)
 			imgView := framebuffer.ImageAttachments().Get(idx)
-			spInfo.depthStencilAttachment = newAttachmentInfo(desc, imgView, true)
+			sp.DepthStencil = newFramegraphAttachment(desc, imgView, true)
 		}
 	}
 
-	return spInfo
+	return sp
 }
 
 type imageAccessInfo struct {
 	read  bool
 	write bool
-	img   *imageInfo
-}
-
-func (i *imageAccessInfo) String() string {
-	r := "-"
-	if i.read {
-		r = "r"
-	}
-	w := "-"
-	if i.write {
-		w = "w"
-	}
-	return fmt.Sprintf("%s%s %v", r, w, i.img)
+	image *api.FramegraphImage
 }
 
 // renderpassInfo stores a renderpass' info relevant for the framegraph.
 type renderpassInfo struct {
-	id             uint64
-	beginIdx       api.SubCmdIdx
-	endIdx         api.SubCmdIdx
-	nodes          []dependencygraph2.NodeID
-	deps           map[uint64]struct{} // set of renderpasses this renderpass depends on
-	subpasses      []*subpassInfo
-	framebufWidth  uint32
-	framebufHeight uint32
-	framebufLayers uint32
-	imageAccesses  map[VkImage]*imageAccessInfo
+	renderpass *api.FramegraphRenderpass
+	id         uint64
+	nodes      []dependencygraph2.NodeID
+
+	// deps stores the set of renderpasses this renderpass depends on
+	deps map[uint64]struct{}
+
+	// imageAccesses is a temporary set that is eventually sorted and stored in
+	// renderpass.ImageAccess list.
+	imageAccesses map[VkImage]*api.FramegraphImageAccess
 }
 
 // framegraphInfoHelpers contains variables that stores information while
@@ -278,22 +241,25 @@ func (helpers *framegraphInfoHelpers) processSubCommand(ctx context.Context, dep
 		framebuffer := vkState.Framebuffers().Get(args.Framebuffer())
 		renderpass := vkState.RenderPasses().Get(args.RenderPass())
 		subpassesDesc := renderpass.SubpassDescriptions()
-		subpasses := make([]*subpassInfo, subpassesDesc.Len())
+		subpasses := make([]*api.FramegraphSubpass, subpassesDesc.Len())
 		for i := 0; i < len(subpasses); i++ {
 			subpassDesc := subpassesDesc.Get(uint32(i))
-			subpasses[i] = newSubpassInfo(subpassDesc, framebuffer, renderpass)
+			subpasses[i] = newFramegraphSubpass(subpassDesc, framebuffer, renderpass)
 		}
 
 		helpers.rpInfo = &renderpassInfo{
-			id:             helpers.currRpId,
-			beginIdx:       subCmdIdx,
-			nodes:          []dependencygraph2.NodeID{},
-			deps:           make(map[uint64]struct{}),
-			subpasses:      subpasses,
-			framebufWidth:  framebuffer.Width(),
-			framebufHeight: framebuffer.Height(),
-			framebufLayers: framebuffer.Layers(),
-			imageAccesses:  make(map[VkImage]*imageAccessInfo),
+			id:    helpers.currRpId,
+			nodes: []dependencygraph2.NodeID{},
+			deps:  make(map[uint64]struct{}),
+			renderpass: &api.FramegraphRenderpass{
+				Handle:            uint64(renderpass.VulkanHandle()),
+				BeginSubCmdIdx:    []uint64(subCmdIdx),
+				FramebufferWidth:  framebuffer.Width(),
+				FramebufferHeight: framebuffer.Height(),
+				FramebufferLayers: framebuffer.Layers(),
+				Subpass:           subpasses,
+			},
+			imageAccesses: make(map[VkImage]*api.FramegraphImageAccess),
 		}
 		helpers.currRpId++
 	}
@@ -311,16 +277,16 @@ func (helpers *framegraphInfoHelpers) processSubCommand(ctx context.Context, dep
 			for _, image := range helpers.lookupImages(memAccess.Pool, memRange) {
 				imgAcc, ok := helpers.rpInfo.imageAccesses[image.VulkanHandle()]
 				if !ok {
-					imgAcc = &imageAccessInfo{
-						img: newImageInfo(image),
+					imgAcc = &api.FramegraphImageAccess{
+						Image: newFramegraphImage(image),
 					}
 					helpers.rpInfo.imageAccesses[image.VulkanHandle()] = imgAcc
 				}
 				switch memAccess.Mode {
 				case dependencygraph2.ACCESS_READ:
-					imgAcc.read = true
+					imgAcc.Read = true
 				case dependencygraph2.ACCESS_WRITE:
-					imgAcc.write = true
+					imgAcc.Write = true
 				}
 			}
 		}
@@ -331,7 +297,7 @@ func (helpers *framegraphInfoHelpers) processSubCommand(ctx context.Context, dep
 		if helpers.rpInfo == nil {
 			panic("Renderpass ends without having started")
 		}
-		helpers.rpInfo.endIdx = subCmdIdx
+		helpers.rpInfo.renderpass.EndSubCmdIdx = []uint64(subCmdIdx)
 		helpers.rpInfos = append(helpers.rpInfos, helpers.rpInfo)
 		helpers.rpInfo = nil
 	}
@@ -375,37 +341,20 @@ func (API) GetFramegraph(ctx context.Context, p *path.Capture) (*api.Framegraph,
 	// Build the framegraph nodes and edges from collected data.
 	nodes := make([]*api.FramegraphNode, len(helpers.rpInfos))
 	for i, rpInfo := range helpers.rpInfos {
-		// Graphviz DOT: use "\l" as a newline to obtain left-aligned text.
-		text := fmt.Sprintf("Renderpass %v\\lbegin:%v\\lend:  %v\\lFramebuffer: %vx%vx%v\\l", rpInfo.id, rpInfo.beginIdx, rpInfo.endIdx, rpInfo.framebufWidth, rpInfo.framebufHeight, rpInfo.framebufLayers)
-		for i, subpass := range rpInfo.subpasses {
-			text += fmt.Sprintf("\\lSubpass %v\\l", i)
-			for j, a := range subpass.inputAttachments {
-				text += fmt.Sprintf("input(%v): %v\\l", j, a)
-			}
-			for j, a := range subpass.colorAttachments {
-				text += fmt.Sprintf("color(%v): %v\\l", j, a)
-			}
-			for j, a := range subpass.resolveAttachments {
-				text += fmt.Sprintf("resolve(%v): %v\\l", j, a)
-			}
-			text += fmt.Sprintf("depth/stencil: %v\\l", subpass.depthStencilAttachment)
+		rpInfo.renderpass.ImageAccess = make([]*api.FramegraphImageAccess, len(rpInfo.imageAccesses))
+		handles := make([]VkImage, 0, len(rpInfo.imageAccesses))
+		for h := range rpInfo.imageAccesses {
+			handles = append(handles, h)
 		}
-
-		if len(rpInfo.imageAccesses) > 0 {
-			text += "\\lImage accesses:\\l"
-			handles := make([]VkImage, 0, len(rpInfo.imageAccesses))
-			for h := range rpInfo.imageAccesses {
-				handles = append(handles, h)
-			}
-			sort.Slice(handles, func(i, j int) bool { return handles[i] < handles[j] })
-			for _, h := range handles {
-				text += fmt.Sprintf("%v\\l", rpInfo.imageAccesses[h])
-			}
+		sort.Slice(handles, func(i, j int) bool { return handles[i] < handles[j] })
+		for i, h := range handles {
+			// text += fmt.Sprintf("%v\\l", rpInfo.imageAccesses[h])
+			rpInfo.renderpass.ImageAccess[i] = rpInfo.imageAccesses[h]
 		}
 
 		nodes[i] = &api.FramegraphNode{
-			Id:   rpInfo.id,
-			Text: text,
+			Id:       rpInfo.id,
+			Workload: &api.FramegraphNode_Renderpass{Renderpass: rpInfo.renderpass},
 		}
 	}
 


### PR DESCRIPTION
This change refactors the representation of the Framegraph details
from Go types into protobuf messages. As a result:

- there is a new `-json` flag in the gapit framegraph command to
  export the framegraph data as JSON.

- the formatting into a DOT file now happens in gapit.

Bug: b/172853011