### PR TITLE
Framegraph: add buffer accesses per-renderpass

### DIFF
--- a/cmd/gapit/framegraph.go
+++ b/cmd/gapit/framegraph.go
@@ -151,6 +151,52 @@ func imageAccess2dot(acc *api.FramegraphImageAccess) string {
 	return fmt.Sprintf("%s%s %s", r, w, image2dot(acc.Image))
 }
 
+func buffer2dot(buf *api.FramegraphBuffer) string {
+	usage := ""
+
+	if buf.TransferSrc {
+		usage += " TransferSrc"
+	}
+	if buf.TransferDst {
+		usage += " TransferDst"
+	}
+	if buf.UniformTexel {
+		usage += " UniformTexel"
+	}
+	if buf.StorageTexel {
+		usage += " StorageTexel"
+	}
+	if buf.Uniform {
+		usage += " Uniform"
+	}
+	if buf.Storage {
+		usage += " Storage"
+	}
+	if buf.Index {
+		usage += " Index"
+	}
+	if buf.Vertex {
+		usage += " Vertex"
+	}
+	if buf.Indirect {
+		usage += " Indirect"
+	}
+
+	return fmt.Sprintf("[Buf %v size:%v usage:%v%s]", buf.Handle, buf.Size, buf.Usage, usage)
+}
+
+func bufferAccess2dot(acc *api.FramegraphBufferAccess) string {
+	r := "-"
+	if acc.Read {
+		r = "r"
+	}
+	w := "-"
+	if acc.Write {
+		w = "w"
+	}
+	return fmt.Sprintf("%s%s %s", r, w, buffer2dot(acc.Buffer))
+}
+
 func renderpass2dot(rp *api.FramegraphRenderpass) string {
 	s := fmt.Sprintf("Renderpass %v\\lbegin:%v\\lend:  %v\\lFramebuffer: %vx%vx%v\\l", rp.Handle, rp.BeginSubCmdIdx, rp.EndSubCmdIdx, rp.FramebufferWidth, rp.FramebufferHeight, rp.FramebufferLayers)
 	for i, subpass := range rp.Subpass {
@@ -171,6 +217,13 @@ func renderpass2dot(rp *api.FramegraphRenderpass) string {
 		s += "\\lImage accesses:\\l"
 		for _, acc := range rp.ImageAccess {
 			s += fmt.Sprintf("%s\\l", imageAccess2dot(acc))
+		}
+	}
+
+	if len(rp.BufferAccess) > 0 {
+		s += "\\lBuffer accesses:\\l"
+		for _, acc := range rp.BufferAccess {
+			s += fmt.Sprintf("%s\\l", bufferAccess2dot(acc))
 		}
 	}
 

--- a/gapis/api/service.proto
+++ b/gapis/api/service.proto
@@ -510,6 +510,21 @@ message SparseBinding {
 
 // Framegraph
 
+message FramegraphBuffer {
+  uint64 handle = 1;
+  uint64 size = 2;
+  uint32 usage = 3;
+  bool transferSrc = 4;
+  bool transferDst = 5;
+  bool uniformTexel = 6;
+  bool storageTexel = 7;
+  bool uniform = 8;
+  bool storage = 9;
+  bool index = 10;
+  bool vertex = 11;
+  bool indirect = 12;
+}
+
 enum FramegraphImageNature {
   NONE = 0;
   SWAPCHAIN = 1;
@@ -546,6 +561,12 @@ message FramegraphSubpass {
   FramegraphAttachment depthStencil = 4;
 }
 
+message FramegraphBufferAccess {
+  bool read = 1;
+  bool write = 2;
+  FramegraphBuffer buffer = 3;
+}
+
 message FramegraphImageAccess {
   bool read = 1;
   bool write = 2;
@@ -561,6 +582,7 @@ message FramegraphRenderpass {
   uint32 framebufferHeight = 6;
   uint32 framebufferLayers = 7;
   repeated FramegraphImageAccess imageAccess = 8;
+  repeated FramegraphBufferAccess bufferAccess = 9;
 }
 
 message FramegraphNode {


### PR DESCRIPTION
In the same way we track image accesses, we now track buffer accesses.

Bug: b/172218645
Test: manual, on several traces