### PR TITLE
Framegraph/dependency graph: fix memory read/write recording and reporting

### DIFF
--- a/gapis/api/vulkan/framegraph.go
+++ b/gapis/api/vulkan/framegraph.go
@@ -334,6 +334,7 @@ func (helpers *framegraphInfoHelpers) processSubCommand(ctx context.Context, dep
 				Base: memAccess.Span.Start,
 				Size: memAccess.Span.End - memAccess.Span.Start,
 			}
+
 			for _, image := range helpers.lookupImages(memAccess.Pool, memRange) {
 				imgAcc, ok := helpers.rpInfo.imageAccesses[image.VulkanHandle()]
 				if !ok {
@@ -342,15 +343,15 @@ func (helpers *framegraphInfoHelpers) processSubCommand(ctx context.Context, dep
 					}
 					helpers.rpInfo.imageAccesses[image.VulkanHandle()] = imgAcc
 				}
-				switch memAccess.Mode {
-				case dependencygraph2.ACCESS_READ:
+				if memAccess.Mode&dependencygraph2.ACCESS_PLAIN_READ != 0 {
 					imgAcc.Read = true
-				case dependencygraph2.ACCESS_WRITE:
+				}
+				if memAccess.Mode&dependencygraph2.ACCESS_PLAIN_WRITE != 0 {
 					imgAcc.Write = true
 				}
 			}
-			buffers := helpers.lookupBuffers(memAccess.Pool, memRange)
-			for _, buffer := range buffers {
+
+			for _, buffer := range helpers.lookupBuffers(memAccess.Pool, memRange) {
 				bufAcc, ok := helpers.rpInfo.bufferAccesses[buffer.VulkanHandle()]
 				if !ok {
 					bufAcc = &api.FramegraphBufferAccess{
@@ -358,10 +359,10 @@ func (helpers *framegraphInfoHelpers) processSubCommand(ctx context.Context, dep
 					}
 					helpers.rpInfo.bufferAccesses[buffer.VulkanHandle()] = bufAcc
 				}
-				switch memAccess.Mode {
-				case dependencygraph2.ACCESS_READ:
+				if memAccess.Mode&dependencygraph2.ACCESS_PLAIN_READ != 0 {
 					bufAcc.Read = true
-				case dependencygraph2.ACCESS_WRITE:
+				}
+				if memAccess.Mode&dependencygraph2.ACCESS_PLAIN_WRITE != 0 {
 					bufAcc.Write = true
 				}
 			}

--- a/gapis/resolve/dependencygraph2/dependency_graph_builder.go
+++ b/gapis/resolve/dependencygraph2/dependency_graph_builder.go
@@ -52,12 +52,24 @@ type NodeStats struct {
 	UniqueDeps          uint64
 }
 
+// AccessMode is a bitfield that records read/write accesses
 type AccessMode uint
 
 const (
-	ACCESS_READ       AccessMode = 1 << 0
-	ACCESS_WRITE      AccessMode = 1 << 1
-	ACCESS_READ_WRITE AccessMode = ACCESS_READ | ACCESS_WRITE
+	// For memory accesses, we need to distinguish "PLAIN" memory accesses that
+	// are just recording read/write accesses (relevant for e.g. the framegraph)
+	// and "DEP" accesses that are more subtely managed for the tracking of
+	// dependencies to properly handle e.g. read-after-write by the same command.
+
+	// PLAIN: just plain read/write accesses
+	ACCESS_PLAIN_READ AccessMode = 1 << iota
+	ACCESS_PLAIN_WRITE
+	// DEP: read/write relevant for dependencies
+	ACCESS_DEP_READ
+	ACCESS_DEP_WRITE
+	// Combined values
+	ACCESS_READ  AccessMode = ACCESS_DEP_READ | ACCESS_PLAIN_READ
+	ACCESS_WRITE AccessMode = ACCESS_DEP_WRITE | ACCESS_PLAIN_WRITE
 )
 
 // The data needed to build a dependency graph by iterating through the commands in a trace

--- a/gapis/resolve/dependencygraph2/memory_intervals.go
+++ b/gapis/resolve/dependencygraph2/memory_intervals.go
@@ -159,9 +159,14 @@ func (l *memoryAccessList) AddRead(s interval.U64Span) {
 		if x == nil {
 			return ACCESS_READ
 		}
+		// There is already an access. Always mark the plain read, but be
+		// careful about the dependency read: if the same node already accessed
+		// before with a write, then the read is not relevant for dependency
+		// since it will be reading what the very same node just wrote.
 		m := x.(AccessMode)
-		if m&ACCESS_WRITE == 0 {
-			m |= ACCESS_READ
+		m |= ACCESS_PLAIN_READ
+		if m&ACCESS_DEP_WRITE == 0 {
+			m |= ACCESS_DEP_READ
 		}
 		return m
 	}


### PR DESCRIPTION
This PR is made of two commits:

1. Dependency graph: distinguish plain/dependency reads and writes

   Document the handling of read/writes for memory dependencies. Always
   record the plain read/writes, while keeping to process in a relevant way the
   reads and writes related to dependency.

2. Framegraph: fix memory access read/write lookups

    Use the PLAIN memory access mode to report image and buffer memory
    accesses.


Bug: b/173027794
Test: manual, on several traces