### PR TITLE
Be robust to lack of internet connection when reporting a crash

### DIFF
--- a/core/app/crash/reporting/reporting.go
+++ b/core/app/crash/reporting/reporting.go
@@ -107,8 +107,11 @@ func (r Reporter) sendReport(body io.Reader, contentType, endpoint string) (stri
 	if err == nil {
 		defer res.Body.Close()
 	}
-	if err != nil || res.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("Failed to upload report request: %v (%v)", err, res.StatusCode)
+	if err != nil {
+		return "", fmt.Errorf("Failed to upload report request: %v", err)
+	}
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Failed to upload report request: got HTTP status code %v", res.StatusCode)
 	}
 
 	buf := new(bytes.Buffer)


### PR DESCRIPTION
Fix the error handling: if err != nil, then 'res' might be nil,
causing a nil-pointer error in the error message formatting. Properly
handle err != nil and wrong HTTP status code in two separate steps.

Bug: b/169547718
Test: manual (force-crash replay while having internet disconnected)