### PR TITLE
Fix propagation of replay fatal error notifications

### DIFF
--- a/gapis/replay/BUILD.bazel
+++ b/gapis/replay/BUILD.bazel
@@ -60,6 +60,7 @@ go_library(
         "//gapis/resolve/initialcmds:go_default_library",
         "//gapis/service:go_default_library",
         "//gapis/service/path:go_default_library",
+        "//gapis/service/severity:go_default_library",
         "//gapis/stringtable:go_default_library",
         "//gapis/trace:go_default_library",
         "//tools/build/third_party/perfetto:config_go_proto",

--- a/gapis/replay/executor.go
+++ b/gapis/replay/executor.go
@@ -117,7 +117,7 @@ func (e executor) HandleNotification(ctx context.Context, notification *gapir.No
 	// However notifications are handled, never survive a fatal error
 	errMsg := notification.GetErrorMsg()
 	if errMsg != nil && errMsg.Severity == severity.Severity_FatalLevel {
-		return log.Errf(ctx, fmt.Errorf("%s", errMsg.Msg), "Received a fatal error during replay")
+		return fmt.Errorf("Replay failed with a fatal error notification: %v", errMsg.Msg)
 	}
 	return nil
 }

--- a/gapis/replay/executor.go
+++ b/gapis/replay/executor.go
@@ -16,6 +16,7 @@ package replay
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/gapid/core/app/status"
 	"github.com/google/gapid/core/data/id"
@@ -25,6 +26,7 @@ import (
 	gapirClient "github.com/google/gapid/gapir/client"
 	"github.com/google/gapid/gapis/database"
 	"github.com/google/gapid/gapis/replay/builder"
+	"github.com/google/gapid/gapis/service/severity"
 )
 
 type executor struct {
@@ -112,6 +114,11 @@ func (e executor) HandlePostData(ctx context.Context, postData *gapir.PostData) 
 // HandleNotification implements gapir.ReplayResponseHandler interface.
 func (e executor) HandleNotification(ctx context.Context, notification *gapir.Notification) error {
 	e.handleNotification(notification)
+	// However notifications are handled, never survive a fatal error
+	errMsg := notification.GetErrorMsg()
+	if errMsg != nil && errMsg.Severity == severity.Severity_FatalLevel {
+		return log.Errf(ctx, fmt.Errorf("%s", errMsg.Msg), "Received a fatal error during replay")
+	}
 	return nil
 }
 


### PR DESCRIPTION
The replayer can send replay notifications to GAPIS, and the handling
of these notification can be customized for different kinds of
replays (e.g. report replays collect validation errors this way).

However, when a fatal error message notification is sent by the
replayer (e.g. because it has failed to create a Vulkan instance),
GAPIS should always treat this as an error, independently from the
custom notification handling.

In particular, this caused the frame profiling to hang when the replay
failed due to not being able to create a Vulkan instance.

Bug: b/172447447, b/173510056
Test: manual