### PR TITLE
Drop debug utils extension at replay time

### DIFF
--- a/gapir/cc/context.cpp
+++ b/gapir/cc/context.cpp
@@ -231,7 +231,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
           // drop them and try to create VkInstance again.
           if (Vulkan::hasValidationLayers(pCreateInfo->ppEnabledLayerNames,
                                           pCreateInfo->enabledLayerCount) ||
-              Vulkan::hasDebugReportOrDebugUtilsExtension(
+              Vulkan::hasDebugExtension(
                   pCreateInfo->ppEnabledExtensionNames,
                   pCreateInfo->enabledExtensionCount)) {
             onDebugMessage(

--- a/gapir/cc/context.cpp
+++ b/gapir/cc/context.cpp
@@ -231,13 +231,14 @@ void Context::registerCallbacks(Interpreter* interpreter) {
           // drop them and try to create VkInstance again.
           if (Vulkan::hasValidationLayers(pCreateInfo->ppEnabledLayerNames,
                                           pCreateInfo->enabledLayerCount) ||
-              Vulkan::hasDebugReportExtension(
+              Vulkan::hasDebugReportOrDebugUtilsExtension(
                   pCreateInfo->ppEnabledExtensionNames,
                   pCreateInfo->enabledExtensionCount)) {
             onDebugMessage(
                 LOG_LEVEL_WARNING, Vulkan::INDEX,
-                "Failed to create VkInstance with validation layers and "
-                "debug report extension, drop them and try again");
+                "Failed to create VkInstance with validation layers or "
+                "debug report or debug utils extension, drop them and "
+                "try again");
             if (api->replayCreateVkInstanceImpl(stack, pCreateInfo, pAllocator,
                                                 pInstance, true, &result)) {
               // On Android, the replay happens in gapid APK, where any

--- a/gapir/cc/context.cpp
+++ b/gapir/cc/context.cpp
@@ -237,8 +237,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
             onDebugMessage(
                 LOG_LEVEL_WARNING, Vulkan::INDEX,
                 "Failed to create VkInstance with validation layers or "
-                "debug report or debug utils extension, drop them and "
-                "try again");
+                "debug extensions, dropping them and retrying");
             if (api->replayCreateVkInstanceImpl(stack, pCreateInfo, pAllocator,
                                                 pInstance, true, &result)) {
               // On Android, the replay happens in gapid APK, where any

--- a/gapir/cc/context.cpp
+++ b/gapir/cc/context.cpp
@@ -231,9 +231,8 @@ void Context::registerCallbacks(Interpreter* interpreter) {
           // drop them and try to create VkInstance again.
           if (Vulkan::hasValidationLayers(pCreateInfo->ppEnabledLayerNames,
                                           pCreateInfo->enabledLayerCount) ||
-              Vulkan::hasDebugExtension(
-                  pCreateInfo->ppEnabledExtensionNames,
-                  pCreateInfo->enabledExtensionCount)) {
+              Vulkan::hasDebugExtension(pCreateInfo->ppEnabledExtensionNames,
+                                        pCreateInfo->enabledExtensionCount)) {
             onDebugMessage(
                 LOG_LEVEL_WARNING, Vulkan::INDEX,
                 "Failed to create VkInstance with validation layers or "

--- a/gapir/cc/vulkan_gfx_api.inc
+++ b/gapir/cc/vulkan_gfx_api.inc
@@ -154,5 +154,5 @@ static bool replayDebugReportCallback(uint32_t flags, uint32_t objectType,
 static bool hasValidationLayers(const char* const* layers, uint32_t count);
 
 // Returns true if any of the extensions specified by the given extension names
-// is debug report extension, other wise returns false.
-static bool hasDebugReportExtension(const char* const* extensions, uint32_t count);
+// is debug report or debug utils extension, other wise returns false.
+static bool hasDebugReportOrDebugUtilsExtension(const char* const* extensions, uint32_t count);

--- a/gapir/cc/vulkan_gfx_api.inc
+++ b/gapir/cc/vulkan_gfx_api.inc
@@ -154,5 +154,5 @@ static bool replayDebugReportCallback(uint32_t flags, uint32_t objectType,
 static bool hasValidationLayers(const char* const* layers, uint32_t count);
 
 // Returns true if any of the extensions specified by the given extension names
-// is debug report or debug utils extension, other wise returns false.
-static bool hasDebugReportOrDebugUtilsExtension(const char* const* extensions, uint32_t count);
+// is a debug extension, other wise returns false.
+static bool hasDebugExtension(const char* const* extensions, uint32_t count);

--- a/gapis/api/templates/vulkan_gfx_api_extras.tmpl
+++ b/gapis/api/templates/vulkan_gfx_api_extras.tmpl
@@ -66,8 +66,10 @@
     "VK_LAYER_LUNARG_core_validation",
     "VK_LAYER_GOOGLE_unique_objects",
   };
-  const char kDebugReportExtensionName[] = "VK_EXT_debug_report";
-  const char kDebugUtilsExtensionName[] = "VK_EXT_debug_utils";
+  const char* kDebugExtensionNames[] = {
+    "VK_EXT_debug_report",
+    "VK_EXT_debug_utils",
+  };
 
 ¶
   bool isValidationLayerName(const char* layer) {
@@ -77,6 +79,14 @@
                          return std::strcmp(layer, val) == 0;
                        });
   }
+¶
+bool isDebugExtensionName(const char* extension) {
+  return std::any_of(
+    std::begin(kDebugExtensionNames), std::end(kDebugExtensionNames),
+    [extension](const char* e) -> bool {
+      return std::strcmp(extension, e) == 0;
+    });
+}
 ¶
   std::vector<Vulkan::VkPhysicalDevice> getVkPhysicalDevices(§
       LazyResolved<Vulkan::PFNVKENUMERATEPHYSICALDEVICES> vkEnumeratePhysicalDevices, Vulkan::VkInstance instance) {
@@ -108,7 +118,7 @@ bool Vulkan::replayCreateVkInstanceImpl(Stack* stack,
                                         const VkInstanceCreateInfo* pCreateInfo,
                                         VkAllocationCallbacks* pAllocator,
                                         VkInstance* pInstance,
-                                        bool dropValidationLayersAndDebugReportAndDebugUtils,
+                                        bool dropValidationAndDebug,
                                         uint32_t* result) {
   std::vector<const char*> layers(
       pCreateInfo->ppEnabledLayerNames,
@@ -123,14 +133,14 @@ bool Vulkan::replayCreateVkInstanceImpl(Stack* stack,
   layers.erase(
       std::remove_if(
           layers.begin(), layers.end(),
-          [dropValidationLayersAndDebugReportAndDebugUtils](const char* layer) -> bool {
+          [dropValidationAndDebug](const char* layer) -> bool {
             if (strcmp(kGraphicsSpyLayerName, layer) == 0) {
               return true;
             }
             if (strcmp(kVirtualSwapchainLayerName, layer) == 0) {
               return true;
             }
-            if (dropValidationLayersAndDebugReportAndDebugUtils) {
+            if (dropValidationAndDebug) {
               return isValidationLayerName(layer);
             }
             return false;
@@ -139,11 +149,10 @@ bool Vulkan::replayCreateVkInstanceImpl(Stack* stack,
   // Add VirtualSwapchain layer
   layers.push_back(kVirtualSwapchainLayerName);
   // Drop the debug report extension if requested.
-  if (dropValidationLayersAndDebugReportAndDebugUtils) {
+  if (dropValidationAndDebug) {
     extensions.erase(std::remove_if(extensions.begin(), extensions.end(),
                                     [](const char* e) -> bool {
-                                      return (strcmp(kDebugReportExtensionName, e) == 0)
-                                             || (strcmp(kDebugUtilsExtensionName, e) == 0);
+                                      return isDebugExtensionName(e);
                                     }),
                      extensions.end());
   }
@@ -770,11 +779,11 @@ bool Vulkan::hasValidationLayers(const char* const* layers, uint32_t count) {
   });
 }
 ¶
-bool Vulkan::hasDebugReportOrDebugUtilsExtension(const char* const* extensions, uint32_t count) {
+bool Vulkan::hasDebugExtension(const char* const* extensions, uint32_t count) {
   return std::any_of(
-    extensions, extensions + count, [](const char* ext) -> bool {
-      return (strcmp(ext, kDebugReportExtensionName) == 0)
-              || (strcmp(ext, kDebugUtilsExtensionName) == 0);
+    extensions, extensions + count,
+    [](const char* ext) -> bool {
+      return isDebugExtensionName(ext);
     });
 }
 ¶

--- a/gapis/api/templates/vulkan_gfx_api_extras.tmpl
+++ b/gapis/api/templates/vulkan_gfx_api_extras.tmpl
@@ -67,6 +67,7 @@
     "VK_LAYER_GOOGLE_unique_objects",
   };
   const char kDebugReportExtensionName[] = "VK_EXT_debug_report";
+  const char kDebugUtilsExtensionName[] = "VK_EXT_debug_utils";
 
 ¶
   bool isValidationLayerName(const char* layer) {
@@ -107,7 +108,7 @@ bool Vulkan::replayCreateVkInstanceImpl(Stack* stack,
                                         const VkInstanceCreateInfo* pCreateInfo,
                                         VkAllocationCallbacks* pAllocator,
                                         VkInstance* pInstance,
-                                        bool dropValidationLayersAndDebugReport,
+                                        bool dropValidationLayersAndDebugReportAndDebugUtils,
                                         uint32_t* result) {
   std::vector<const char*> layers(
       pCreateInfo->ppEnabledLayerNames,
@@ -122,14 +123,14 @@ bool Vulkan::replayCreateVkInstanceImpl(Stack* stack,
   layers.erase(
       std::remove_if(
           layers.begin(), layers.end(),
-          [dropValidationLayersAndDebugReport](const char* layer) -> bool {
+          [dropValidationLayersAndDebugReportAndDebugUtils](const char* layer) -> bool {
             if (strcmp(kGraphicsSpyLayerName, layer) == 0) {
               return true;
             }
             if (strcmp(kVirtualSwapchainLayerName, layer) == 0) {
               return true;
             }
-            if (dropValidationLayersAndDebugReport) {
+            if (dropValidationLayersAndDebugReportAndDebugUtils) {
               return isValidationLayerName(layer);
             }
             return false;
@@ -138,11 +139,11 @@ bool Vulkan::replayCreateVkInstanceImpl(Stack* stack,
   // Add VirtualSwapchain layer
   layers.push_back(kVirtualSwapchainLayerName);
   // Drop the debug report extension if requested.
-  if (dropValidationLayersAndDebugReport) {
+  if (dropValidationLayersAndDebugReportAndDebugUtils) {
     extensions.erase(std::remove_if(extensions.begin(), extensions.end(),
                                     [](const char* e) -> bool {
-                                      return strcmp(kDebugReportExtensionName,
-                                                    e) == 0;
+                                      return (strcmp(kDebugReportExtensionName, e) == 0)
+                                             || (strcmp(kDebugUtilsExtensionName, e) == 0);
                                     }),
                      extensions.end());
   }
@@ -769,10 +770,11 @@ bool Vulkan::hasValidationLayers(const char* const* layers, uint32_t count) {
   });
 }
 ¶
-bool Vulkan::hasDebugReportExtension(const char* const* extensions, uint32_t count) {
+bool Vulkan::hasDebugReportOrDebugUtilsExtension(const char* const* extensions, uint32_t count) {
   return std::any_of(
     extensions, extensions + count, [](const char* ext) -> bool {
-      return strcmp(ext, kDebugReportExtensionName) == 0;
+      return (strcmp(ext, kDebugReportExtensionName) == 0)
+              || (strcmp(ext, kDebugUtilsExtensionName) == 0);
     });
 }
 ¶


### PR DESCRIPTION
At replay time, if Vulkan instance creation fail and we detect that
the validation layer or the debug report extension is requested, we
have a fallback where we try to create the instance again after
dropping the validation layer and the debug report extension. This
change adds the debug utils extension alongside the debug report
extension.

Note that both of these extensions are provided by the validation
layer. The typical failure is: the app requests the validation layer
at trace time, and one or both of the debug extensions. At replay
time, unless we do a report replay, the validation layer won't be
loaded, hence these extensions are not present.

More generally, we won't support replaying a workload that relies on
extensions provided by a layer, since this layer won't be present at
replay time. The validation layer is a special case since it is the
one layer we may provide at replay time (as it is present in our
APKs). See discussion at b/163754399

Bug: b/172447447
Test: manual