### PR TITLE
Adjust the log level of the print C++ macro.

### DIFF
--- a/gapis/api/templates/api_spy.cpp.tmpl
+++ b/gapis/api/templates/api_spy.cpp.tmpl
@@ -480,5 +480,5 @@
 {{define "Print"}}
   {{AssertType $ "Print"}}
 
-  GAPID_DEBUG({{Macro "C++.ReadListAsCallArgument" $.Arguments}});
+  GAPID_INFO({{Macro "C++.ReadListAsCallArgument" $.Arguments}});
 {{end}}


### PR DESCRIPTION
Adjusts the log level to match that of the Go macro. Print statements in the API files are only meant for debugging and will not be checked into the codebase, so this is OK and makes it easier, since by default the C++ debug level does nothing.