### PR TITLE
Updated glslang lib and building doc for gcc-10 on Windows

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -55,9 +55,9 @@ Using the msys64 shell (installed by choco at `C:\tools\msys64\mingw64`):
 1. Update MSYS with: `pacman -Syu`.
 2. If the update ends with “close the window and run it again”, close and reopen the window and repeat 1.
 3. Fetch required tools with: `pacman -S curl git zip unzip patch`
-4. Download gcc with: `curl -O http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-9.2.0-2-any.pkg.tar.xz`
-5. Download gcc-libs with: `curl -O http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-9.2.0-2-any.pkg.tar.xz`
-6. Install gcc with: `pacman -U mingw-w64-x86_64-gcc*-9.2.0-2-any.pkg.tar.xz`
+4. Download gcc with: `curl -O http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst`
+5. Download gcc-libs with: `curl -O http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst`
+6. Install gcc with: `pacman -U mingw-w64-x86_64-gcc*-10.2.0-5-any.pkg.tar.zst`
 7. Close the MSYS terminal
 
 ### Install Java Development Kit 1.8

--- a/gapis/shadertools/cc/libmanager.cpp
+++ b/gapis/shadertools/cc/libmanager.cpp
@@ -118,6 +118,7 @@ const TBuiltInResource DefaultTBuiltInResource = {
     /* .maxTaskWorkGroupSizeY_NV = */ 1,
     /* .maxTaskWorkGroupSizeZ_NV = */ 1,
     /* .maxMeshViewCountNV = */ 4,
+    /* .maxDualSourceDrawBuffersEXT = */ 1,
     /* .limits = */
     {
         /* .nonInductiveForLoops = */ 1,

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -145,8 +145,8 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
         locals = locals,
         organization = "KhronosGroup",
         project = "glslang",
-        commit = "3ee5f2f1d3316e228916788b300d786bb574d337",  # SDK-candidate-26-Jul-2020
-        sha256 = "8f4ebd7ff348a7f752e4646e43d4e41b4747323d635f5ae49096771d5c64fb31",
+        commit = "740ae9f60b009196662bad811924788cee56133a",  # 10-11.0.0
+        sha256 = "c015e7d81c0a248562c25a1e484fb8528eb6a765312cf5de3bdb658b03562b3f",
     )
 
     maybe_repository(

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -351,7 +351,6 @@ def _grpc_deps(locals):
         locals = locals,
         # on the master-with-bazel branch
         url = "https://boringssl.googlesource.com/boringssl/+archive/afc30d43eef92979b05776ec0963c9cede5fb80f.tar.gz",
-        sha256 = "3a6f02a350be914dd9db98afe56463f22b5628c0952758eb9bde705ba786a527",
     )
 
     maybe_repository(github_repository,

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -145,8 +145,8 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
         locals = locals,
         organization = "KhronosGroup",
         project = "glslang",
-        commit = "8db9eccc0baf30c9d22c496ab28db0fe1e4e97c5",  # 8.13.3559
-        sha256 = "5c11a228d41ec011918b9c8beb60b6556745d30c8c856ec622beab5c5469152d",
+        commit = "3ee5f2f1d3316e228916788b300d786bb574d337",  # SDK-candidate-26-Jul-2020
+        sha256 = "8f4ebd7ff348a7f752e4646e43d4e41b4747323d635f5ae49096771d5c64fb31",
     )
 
     maybe_repository(
@@ -182,7 +182,7 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
         remote = "https://chromium.googlesource.com/linux-syscall-support",
         commit = "fd00dbbd0c06a309c657d89e9430143b179ff6db",
         build_file = "@gapid//tools/build/third_party:lss.BUILD",
-       shallow_since = "1583885669 +0000",
+        shallow_since = "1583885669 +0000",
     )
 
     maybe_repository(
@@ -351,6 +351,7 @@ def _grpc_deps(locals):
         locals = locals,
         # on the master-with-bazel branch
         url = "https://boringssl.googlesource.com/boringssl/+archive/afc30d43eef92979b05776ec0963c9cede5fb80f.tar.gz",
+        sha256 = "3a6f02a350be914dd9db98afe56463f22b5628c0952758eb9bde705ba786a527",
     )
 
     maybe_repository(github_repository,


### PR DESCRIPTION
If you follow the AGI build doc for Windows currently, building gcc_wrapper ends up with internal compiler error. My guess is that gcc 9.2.0 doesn't like that MSYS2 installs gcc-libs 10.2.0, which is a requirement for many other packages. A workaround could be to require developers to maintain an outdated version of MSYS2, which would be a burden if they use MSYS2 for anything else than building AGI. The better solution is to compile AGI with gcc-10, which coincidentally also fixes the crash in Perfetto when building AGI not optimized (this is not fixed by the recent Perfetto update!).

This PR updates the glslang lib to a version which includes a [commit](https://github.com/KhronosGroup/glslang/commit/8486b2e0db150a3e0761db6930a7b41cc7a8c83f#diff-8bfb66f7619ec31ff49b6934cb5cca06b5a459852c6f6d3562d065ea4000de22) that fixes a compile error with gcc-10, and it updates the building doc to use gcc-10 for Windows.

It also fixes a minor wrong indent.

The compiler used by the Windows CI should also be updated to gcc-10 once this PR is approved.

Fixes b/173712032 and b/162405255.