### PR TITLE
Update Windows CI to use gcc-10

### DIFF
--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -45,22 +45,22 @@ wget -q https://github.com/msys2/msys2-installer/releases/download/2020-11-09/ms
 .\msys2-base-x86_64-20201109.sfx.exe -y -o%BUILD_ROOT%\
 
 REM Start empty shell to initialize MSYS2.
-%BUILD_ROOT%\msys64\usr\bin\bash -lc " "
+%BUILD_ROOT%\msys64\usr\bin\bash --login -c " "
 
 REM Uncomment the following line to list all packages and versions installed in MSYS2.
-REM %BUILD_ROOT%\msys64\usr\bin\bash -lc "pacman -Q"
+REM %BUILD_ROOT%\msys64\usr\bin\bash --login -c "pacman -Q"
 
 REM Download and install packages required by the build process.
 wget -q http://repo.msys2.org/msys/x86_64/git-2.29.2-1-x86_64.pkg.tar.zst
 wget -q http://repo.msys2.org/msys/x86_64/patch-2.7.6-1-x86_64.pkg.tar.xz
 wget -q http://repo.msys2.org/msys/x86_64/unzip-6.0-2-x86_64.pkg.tar.xz
 wget -q http://repo.msys2.org/msys/x86_64/zip-3.0-3-x86_64.pkg.tar.xz
-%BUILD_ROOT%\msys64\usr\bin\bash -lc "pacman -U --noconfirm /t/src/git-2.29.2-1-x86_64.pkg.tar.zst /t/src/patch-2.7.6-1-x86_64.pkg.tar.xz /t/src/unzip-6.0-2-x86_64.pkg.tar.xz /t/src/zip-3.0-3-x86_64.pkg.tar.xz"
+%BUILD_ROOT%\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/git-2.29.2-1-x86_64.pkg.tar.zst /t/src/patch-2.7.6-1-x86_64.pkg.tar.xz /t/src/unzip-6.0-2-x86_64.pkg.tar.xz /t/src/zip-3.0-3-x86_64.pkg.tar.xz"
 
 REM Download and install specific compiler version.
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst
-%BUILD_ROOT%\msys64\usr\bin\bash -lc "pacman -U --noconfirm /t/src/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst /t/src/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst"
+%BUILD_ROOT%\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst /t/src/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst"
 
 REM Configure build process to use the now installed MSYS2.
 set PATH=%BUILD_ROOT%\msys64\mingw64\bin;%BUILD_ROOT%\msys64\usr\bin;%PATH%

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -16,8 +16,7 @@ limitations under the License.
 Windows Build Script.
 
 :start
-dir "%ProgramFiles%"
-dir "%ProgramFiles(x86)%"
+dir "%ProgramFiles(x86)%\WiX Toolset v3.11"
 EXIT /B
 
 set BUILD_ROOT=%cd%

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -53,6 +53,7 @@ wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-10.2.0-5-an
 %BUILD_ROOT%\msys64\usr\bin\bash --login -c "pacman -S --noconfirm git patch"
 %BUILD_ROOT%\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst /t/src/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst"
 set PATH=%BUILD_ROOT%\msys64\mingw64\bin;%BUILD_ROOT%\msys64\usr\bin;%PATH%
+set BAZEL_SH=%BUILD_ROOT%\msys64\usr\bin\bash
 
 REM Manually install only the required MSYS packages. Do NOT do a
 REM system update (pacman -Syu) because it is a moving target.
@@ -73,7 +74,7 @@ REM c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-
 REM wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-crt-git-9.0.0.6029.ecb4ff54-1-any.pkg.tar.zst
 REM c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-crt-git-9.0.0.6029.ecb4ff54-1-any.pkg.tar.zst"
 REM set PATH=c:\tools\msys64\mingw64\bin;c:\tools\msys64\usr\bin;%PATH%
-set BAZEL_SH=c:\tools\msys64\usr\bin\bash
+REM set BAZEL_SH=c:\tools\msys64\usr\bin\bash
 
 REM Get the JDK from our mirror.
 set JDK_BUILD=zulu8.46.0.19-ca

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -16,7 +16,7 @@ limitations under the License.
 Windows Build Script.
 
 :start
-dir "%ProgramFiles(x86)%\WiX Toolset v3.11"
+dir "%ProgramFiles(x86)%\WiX Toolset v3.11\bin"
 EXIT /B
 
 set BUILD_ROOT=%cd%

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -43,7 +43,7 @@ REM Install WiX Toolset.
 REM wget -q https://github.com/wixtoolset/wix3/releases/download/wix311rtm/wix311-binaries.zip
 REM unzip -q -d wix wix311-binaries.zip
 REM set WIX=%cd%\wix
-set WIX="%ProgramFiles(x86)%\WiX Toolset v3.11\bin"
+set WIX=%ProgramFiles(x86)%\WiX Toolset v3.11\bin
 
 wget -q https://github.com/msys2/msys2-installer/releases/download/2020-11-09/msys2-base-x86_64-20201109.sfx.exe
 .\msys2-base-x86_64-20201109.sfx.exe -y -o%BUILD_ROOT%\

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -50,8 +50,12 @@ REM Start empty shell to initialize MSYS2.
 REM Uncomment the following line to list all packages and versions installed in MSYS2.
 REM %BUILD_ROOT%\msys64\usr\bin\bash -lc "pacman -Q"
 
-REM Install packages required by the build process.
-%BUILD_ROOT%\msys64\usr\bin\bash -lc "pacman -S --noconfirm git patch zip unzip"
+REM Download and install packages required by the build process.
+wget -q http://repo.msys2.org/msys/x86_64/git-2.29.2-1-x86_64.pkg.tar.zst
+wget -q http://repo.msys2.org/msys/x86_64/patch-2.7.6-1-x86_64.pkg.tar.xz
+wget -q http://repo.msys2.org/msys/x86_64/unzip-6.0-2-x86_64.pkg.tar.xz
+wget -q http://repo.msys2.org/msys/x86_64/zip-3.0-3-x86_64.pkg.tar.xz
+%BUILD_ROOT%\msys64\usr\bin\bash -lc "pacman -U --noconfirm /t/src/git-2.29.2-1-x86_64.pkg.tar.zst /t/src/patch-2.7.6-1-x86_64.pkg.tar.xz /t/src/unzip-6.0-2-x86_64.pkg.tar.xz /t/src/zip-3.0-3-x86_64.pkg.tar.xz"
 
 REM Download and install specific compiler version.
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -44,15 +44,13 @@ wget -q https://github.com/wixtoolset/wix3/releases/download/wix311rtm/wix311-bi
 unzip -q -d wix wix311-binaries.zip
 set WIX=%cd%\wix
 
-wmic product get name
-
 wget -q https://github.com/msys2/msys2-installer/releases/download/2020-11-09/msys2-base-x86_64-20201109.sfx.exe
 .\msys2-base-x86_64-20201109.sfx.exe -y -o%BUILD_ROOT%\
 
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst
-%BUILDROOT%\msys64\usr\bin\bash --login -c "pacman -Q"
-%BUILDROOT%\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst /t/src/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst"
+%BUILD_ROOT%\msys64\usr\bin\bash --login -c "pacman -Q"
+%BUILD_ROOT%\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst /t/src/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst"
 set PATH=%BUILD_ROOT%\msys64\mingw64\bin;%BUILD_ROOT%\msys64\usr\bin;%PATH%
 
 REM Manually install only the required MSYS packages. Do NOT do a

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -45,10 +45,9 @@ unzip -q -d wix wix311-binaries.zip
 set WIX=%cd%\wix
 
 REM Manually install only the required MSYS packages. Do NOT do a
-REM system update (pacman -Syu) because it is a moving target. In
-REM particular, the pacman installed on default Kokoro VMs is old, and
-REM supports only ".pkg.tar.xz" package archives, it does not support
-REM the more recent ".pkg.tar.zst" packages archives.
+REM system update (pacman -Syu) because it is a moving target.
+REM First update pacman to support packages compressed with zstd.
+c:\tools\msys64\usr\bin\bash --login -c "pacman -Sydd --noconfirm pacman"
 c:\tools\msys64\usr\bin\bash --login -c "pacman -R --noconfirm catgets libcatgets"
 REM Use an old version of patch known to work with the msys runtime
 REM version that comes on Kokoro. Temporarily getting it from an
@@ -56,13 +55,13 @@ REM alternate mirror, since they msys host no longer carries this
 REM version.
 wget -q http://ftp.oregonstate.edu/pub/xbmc/build-deps/win32/msys2/repos/msys2/x86_64/patch-2.7.5-1-x86_64.pkg.tar.xz
 c:\tools\msys64\usr\bin\bash --login -c "pacman -v -U --noconfirm  /t/src/patch-2.7.5-1-x86_64.pkg.tar.xz"
-wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-binutils-2.33.1-1-any.pkg.tar.xz
-c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-binutils-2.33.1-1-any.pkg.tar.xz"
-wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-9.2.0-2-any.pkg.tar.xz
-wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-9.2.0-2-any.pkg.tar.xz
-c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-gcc-9.2.0-2-any.pkg.tar.xz /t/src/mingw-w64-x86_64-gcc-libs-9.2.0-2-any.pkg.tar.xz"
-wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-crt-git-8.0.0.5647.1fe2e62e-1-any.pkg.tar.xz
-c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-crt-git-8.0.0.5647.1fe2e62e-1-any.pkg.tar.xz"
+wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-binutils-2.35.1-3-any.pkg.tar.zst
+c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-binutils-2.35.1-3-any.pkg.tar.zst"
+wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst
+wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst
+c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst /t/src/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst"
+wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-crt-git-9.0.0.6029.ecb4ff54-1-any.pkg.tar.zst
+c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-crt-git-9.0.0.6029.ecb4ff54-1-any.pkg.tar.zst"
 set PATH=c:\tools\msys64\mingw64\bin;c:\tools\msys64\usr\bin;%PATH%
 set BAZEL_SH=c:\tools\msys64\usr\bin\bash
 

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -50,6 +50,7 @@ wget -q https://github.com/msys2/msys2-installer/releases/download/2020-11-09/ms
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst
 %BUILD_ROOT%\msys64\usr\bin\bash --login -c "pacman -Q"
+%BUILD_ROOT%\msys64\usr\bin\bash --login -c "pacman -S --noconfirm git patch"
 %BUILD_ROOT%\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst /t/src/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst"
 set PATH=%BUILD_ROOT%\msys64\mingw64\bin;%BUILD_ROOT%\msys64\usr\bin;%PATH%
 

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -16,9 +16,6 @@ limitations under the License.
 Windows Build Script.
 
 :start
-dir "%ProgramFiles(x86)%\WiX Toolset v3.11\bin"
-EXIT /B
-
 set BUILD_ROOT=%cd%
 set SRC=%cd%\github\agi
 
@@ -43,9 +40,10 @@ unzip -q android-ndk-r21d-windows-x86_64.zip
 set ANDROID_NDK_HOME=%CD%\android-ndk-r21d
 
 REM Install WiX Toolset.
-wget -q https://github.com/wixtoolset/wix3/releases/download/wix311rtm/wix311-binaries.zip
-unzip -q -d wix wix311-binaries.zip
-set WIX=%cd%\wix
+REM wget -q https://github.com/wixtoolset/wix3/releases/download/wix311rtm/wix311-binaries.zip
+REM unzip -q -d wix wix311-binaries.zip
+REM set WIX=%cd%\wix
+set WIX="%ProgramFiles(x86)%\WiX Toolset v3.11\bin"
 
 wget -q https://github.com/msys2/msys2-installer/releases/download/2020-11-09/msys2-base-x86_64-20201109.sfx.exe
 .\msys2-base-x86_64-20201109.sfx.exe -y -o%BUILD_ROOT%\

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -16,6 +16,10 @@ limitations under the License.
 Windows Build Script.
 
 :start
+dir "%ProgramFiles%"
+dir "%ProgramFiles(x86)%"
+EXIT /B
+
 set BUILD_ROOT=%cd%
 set SRC=%cd%\github\agi
 

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -44,25 +44,36 @@ wget -q https://github.com/wixtoolset/wix3/releases/download/wix311rtm/wix311-bi
 unzip -q -d wix wix311-binaries.zip
 set WIX=%cd%\wix
 
+wmic product get name
+
+wget -q https://github.com/msys2/msys2-installer/releases/download/2020-11-09/msys2-base-x86_64-20201109.sfx.exe
+.\msys2-base-x86_64-20201109.sfx.exe -y -o%BUILD_ROOT%\
+
+wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst
+wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst
+%BUILDROOT%\msys64\usr\bin\bash --login -c "pacman -Q"
+%BUILDROOT%\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst /t/src/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst"
+set PATH=%BUILD_ROOT%\msys64\mingw64\bin;%BUILD_ROOT%\msys64\usr\bin;%PATH%
+
 REM Manually install only the required MSYS packages. Do NOT do a
 REM system update (pacman -Syu) because it is a moving target.
 REM First update pacman to support packages compressed with zstd.
-c:\tools\msys64\usr\bin\bash --login -c "pacman -Sydd --noconfirm pacman"
-c:\tools\msys64\usr\bin\bash --login -c "pacman -R --noconfirm catgets libcatgets"
+REM c:\tools\msys64\usr\bin\bash --login -c "pacman -Sydd --noconfirm pacman"
+REM c:\tools\msys64\usr\bin\bash --login -c "pacman -R --noconfirm catgets libcatgets"
 REM Use an old version of patch known to work with the msys runtime
 REM version that comes on Kokoro. Temporarily getting it from an
 REM alternate mirror, since they msys host no longer carries this
 REM version.
-wget -q http://ftp.oregonstate.edu/pub/xbmc/build-deps/win32/msys2/repos/msys2/x86_64/patch-2.7.5-1-x86_64.pkg.tar.xz
-c:\tools\msys64\usr\bin\bash --login -c "pacman -v -U --noconfirm  /t/src/patch-2.7.5-1-x86_64.pkg.tar.xz"
-wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-binutils-2.35.1-3-any.pkg.tar.zst
-c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-binutils-2.35.1-3-any.pkg.tar.zst"
-wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst
-wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst
-c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst /t/src/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst"
-wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-crt-git-9.0.0.6029.ecb4ff54-1-any.pkg.tar.zst
-c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-crt-git-9.0.0.6029.ecb4ff54-1-any.pkg.tar.zst"
-set PATH=c:\tools\msys64\mingw64\bin;c:\tools\msys64\usr\bin;%PATH%
+REM wget -q http://ftp.oregonstate.edu/pub/xbmc/build-deps/win32/msys2/repos/msys2/x86_64/patch-2.7.5-1-x86_64.pkg.tar.xz
+REM c:\tools\msys64\usr\bin\bash --login -c "pacman -v -U --noconfirm  /t/src/patch-2.7.5-1-x86_64.pkg.tar.xz"
+REM wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-binutils-2.35.1-3-any.pkg.tar.zst
+REM c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-binutils-2.35.1-3-any.pkg.tar.zst"
+REM wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst
+REM wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst
+REM c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst /t/src/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst"
+REM wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-crt-git-9.0.0.6029.ecb4ff54-1-any.pkg.tar.zst
+REM c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-crt-git-9.0.0.6029.ecb4ff54-1-any.pkg.tar.zst"
+REM set PATH=c:\tools\msys64\mingw64\bin;c:\tools\msys64\usr\bin;%PATH%
 set BAZEL_SH=c:\tools\msys64\usr\bin\bash
 
 REM Get the JDK from our mirror.

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -47,12 +47,13 @@ set WIX="%ProgramFiles(x86)%\WiX Toolset v3.11\bin"
 
 wget -q https://github.com/msys2/msys2-installer/releases/download/2020-11-09/msys2-base-x86_64-20201109.sfx.exe
 .\msys2-base-x86_64-20201109.sfx.exe -y -o%BUILD_ROOT%\
+%BUILD_ROOT%\msys64\usr\bin\bash -lc " "
+%BUILD_ROOT%\msys64\usr\bin\bash -lc "pacman -Q"
+%BUILD_ROOT%\msys64\usr\bin\bash -lc "pacman -S --noconfirm git patch zip unzip"
 
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst
 wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst
-%BUILD_ROOT%\msys64\usr\bin\bash --login -c "pacman -Q"
-%BUILD_ROOT%\msys64\usr\bin\bash --login -c "pacman -S --noconfirm git patch"
-%BUILD_ROOT%\msys64\usr\bin\bash --login -c "pacman -U --noconfirm /t/src/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst /t/src/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst"
+%BUILD_ROOT%\msys64\usr\bin\bash -lc "pacman -U --noconfirm /t/src/mingw-w64-x86_64-gcc-10.2.0-5-any.pkg.tar.zst /t/src/mingw-w64-x86_64-gcc-libs-10.2.0-5-any.pkg.tar.zst"
 set PATH=%BUILD_ROOT%\msys64\mingw64\bin;%BUILD_ROOT%\msys64\usr\bin;%PATH%
 set BAZEL_SH=%BUILD_ROOT%\msys64\usr\bin\bash
 


### PR DESCRIPTION
 Update Windows CI to use gcc-10 to be in sync with [#570](https://github.com/google/agi/pull/570).