### PR TITLE
Only show command nodes with performance values in perftab.

### DIFF
--- a/gapic/src/main/com/google/gapid/models/CommandStream.java
+++ b/gapic/src/main/com/google/gapid/models/CommandStream.java
@@ -412,6 +412,14 @@ public class CommandStream
       return parent.getPath(path).addIndices(index);
     }
 
+    public List<Long> getCommandStart() {
+      return data == null ? null : data.getCommands().getFromList();
+    }
+
+    public List<Long> getCommandEnd() {
+      return data == null ? null : data.getCommands().getToList();
+    }
+
     public CommandIndex getIndex() {
       return (data == null) ? null : CommandIndex.forNode(data.getRepresentation(),
           getPath(Path.CommandTreeNode.newBuilder()).build());

--- a/gapic/src/main/com/google/gapid/models/Models.java
+++ b/gapic/src/main/com/google/gapid/models/Models.java
@@ -82,7 +82,7 @@ public class Models {
     Memory memory = new Memory(shell, analytics, client, devices, commands);
     MemoryTypes types = new MemoryTypes(client, devices, constants);
     Perfetto perfetto = new Perfetto(shell, analytics, client, capture, status);
-    Profile profile = new Profile(shell, analytics, client, capture, devices);
+    Profile profile = new Profile(shell, analytics, client, capture, devices, commands);
     return new Models(settings, analytics, follower, capture, devices, commands, resources, state,
         reports, images, constants, geometries, memory, types, perfetto, profile, status);
   }

--- a/gapic/src/main/com/google/gapid/views/CommandTree.java
+++ b/gapic/src/main/com/google/gapid/views/CommandTree.java
@@ -137,6 +137,7 @@ public class CommandTree extends Composite
             commandIdx.setText(COMMAND_INDEX_DSCRP + node.getIndexString());
             models.commands.selectCommands(index, false);
           }
+          models.profile.linkCommandToGpuGroup(node.getCommandStart());
         }
       }
     };

--- a/gapic/src/main/com/google/gapid/views/PerformanceView.java
+++ b/gapic/src/main/com/google/gapid/views/PerformanceView.java
@@ -16,23 +16,28 @@
 package com.google.gapid.views;
 
 import static com.google.gapid.util.Loadable.MessageType.Error;
+import static com.google.gapid.widgets.Widgets.createTreeColumn;
+import static com.google.gapid.widgets.Widgets.createTreeViewer;
+import static com.google.gapid.widgets.Widgets.packColumns;
 
-import com.google.gapid.models.Analytics.View;
 import com.google.gapid.models.Capture;
 import com.google.gapid.models.CommandStream;
-import com.google.gapid.models.CommandStream.CommandIndex;
 import com.google.gapid.models.Models;
 import com.google.gapid.models.Profile;
+import com.google.gapid.models.Profile.PerfNode;
 import com.google.gapid.perfetto.Unit;
 import com.google.gapid.perfetto.models.CounterInfo;
 import com.google.gapid.proto.service.Service;
-import com.google.gapid.proto.service.Service.ClientAction;
 import com.google.gapid.util.Loadable;
 import com.google.gapid.util.Messages;
-import com.google.gapid.util.SelectionHandler;
 import com.google.gapid.widgets.LoadablePanel;
 import com.google.gapid.widgets.Widgets;
+import java.util.List;
+import java.util.function.Predicate;
 import java.util.logging.Logger;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.TreeViewerColumn;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
@@ -40,8 +45,8 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.Menu;
+import org.eclipse.swt.widgets.TreeColumn;
+import org.eclipse.swt.widgets.TreeItem;
 
 public class PerformanceView extends Composite
     implements Tab, Capture.Listener, CommandStream.Listener, Profile.Listener {
@@ -50,8 +55,8 @@ public class PerformanceView extends Composite
   private final Models models;
   private final LoadablePanel<Composite> loading;
   private final Button button;
-  protected final PerfTree tree;
-  private final SelectionHandler<Control> selectionHandler;
+  private final TreeViewer tree;
+  private boolean showEstimate = true;
 
   public PerformanceView(Composite parent, Models models, Widgets widgets) {
     super(parent, SWT.NONE);
@@ -66,20 +71,48 @@ public class PerformanceView extends Composite
     button = new Button(composite, SWT.PUSH);
     button.setText("Estimate / Confidence Range");
     button.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
+    button.addListener(SWT.Selection, e -> toggleEstimateOrRange());
 
-    tree = new PerfTree(composite, models, widgets);
-    tree.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-    button.addListener(SWT.Selection, e -> tree.toggleEstimateOrRange());
+    tree = createTreeViewer(composite, SWT.NONE);
 
-    Menu popup = new Menu(tree.getControl());
-    Widgets.createMenuItem(popup, "Select in Command Tab", e -> {
-      CommandStream.Node node = tree.getSelection();
-      if (node != null && node.getIndex() != null && models.resources.isLoaded()) {
-        models.commands.selectCommands(node.getIndex(), true);
+    tree.getTree().setHeaderVisible(true);
+    tree.setLabelProvider(new LabelProvider());
+    tree.setContentProvider(new ITreeContentProvider() {
+      @SuppressWarnings("unchecked")
+      @Override
+      public Object[] getElements(Object inputElement) {
+        return ((List<Profile.PerfNode>)inputElement).toArray();
+      }
+
+      @Override
+      public boolean hasChildren(Object element) {
+        return element instanceof Profile.PerfNode && ((Profile.PerfNode)element).hasChildren();
+      }
+
+      @Override
+      public Object getParent(Object element) {
+        return null;
+      }
+
+      @Override
+      public Object[] getChildren(Object element) {
+        if (element instanceof Profile.PerfNode) {
+          return ((Profile.PerfNode)element).getChildren().toArray();
+        } else {
+          return new Object[0];
+        }
       }
     });
-    tree.setPopupMenu(popup, node -> node != null && node.getIndex() != null && models.resources.isLoaded());
 
+    tree.getTree().addListener(SWT.Selection, e -> {
+      TreeItem[] items = tree.getTree().getSelection();
+      if (items.length > 0) {
+        PerfNode selection = cast(items[0].getData());
+        models.profile.linkGpuGroupToCommand(selection.getGroup());
+      }
+    });
+
+    tree.getTree().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
     loading.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
     models.capture.addListener(this);
@@ -90,22 +123,6 @@ public class PerformanceView extends Composite
       models.commands.removeListener(this);
       models.profile.removeListener(this);
     });
-
-    selectionHandler = new SelectionHandler<Control>(LOG, tree.getControl()) {
-      @Override
-      protected void updateModel(Event e) {
-        models.analytics.postInteraction(View.Performance, ClientAction.Select);
-        CommandStream.Node node = tree.getSelection();
-        if (node != null) {
-          CommandIndex index = node.getIndex();
-          if (index == null) {
-            models.commands.load(node, () -> models.commands.selectCommands(node.getIndex(), false));
-          } else {
-            models.commands.selectCommands(index, false);
-          }
-        }
-      }
-    };
   }
 
   @Override
@@ -136,8 +153,11 @@ public class PerformanceView extends Composite
   }
 
   @Override
-  public void onCommandsSelected(CommandIndex index) {
-    selectionHandler.updateSelectionFromModel(() -> models.commands.getTreePath(index.getNode()).get(), tree::setSelection);
+  public void onGroupSelected(Service.ProfilingData.GpuSlices.Group group) {
+    TreeItem item = findItem(tree.getTree().getItems(), n -> group.getId() == n.getGroup().getId());
+    if (item != null) {
+      tree.getTree().setSelection(item);
+    }
   }
 
   @Override
@@ -146,78 +166,86 @@ public class PerformanceView extends Composite
       loading.showMessage(error);
       return;
     }
-    // Create columns for all the performance metrics.
-    for (Service.ProfilingData.GpuCounters.Metric metric :
-        models.profile.getData().getGpuPerformance().getMetricsList()) {
-      tree.addColumnForMetric(metric);
-    }
-    tree.packColumn();
-    tree.refresh();
+    updateTree(false);
   }
 
   private void updateTree(boolean assumeLoading) {
-    if (assumeLoading || !models.commands.isLoaded()) {
+    if (assumeLoading || !models.profile.isLoaded()) {
       loading.startLoading();
       tree.setInput(null);
       return;
     }
-
     loading.stopLoading();
-    tree.setInput(models.commands.getData());
+
+    List<Profile.PerfNode> perf = models.profile.getData().getPerfNodes();
+    for (TreeColumn col : tree.getTree().getColumns()) {
+      col.dispose();
+    }
+    createTreeColumn(tree, "Name", e -> ((Profile.PerfNode)e).getGroup().getName());
+    for (Service.ProfilingData.GpuCounters.Metric metric :
+        models.profile.getData().getGpuPerformance().getMetricsList()) {
+      addColumnForMetric(metric);
+    }
+    tree.setInput(perf);
+    tree.expandAll(true);
+    packColumns(tree.getTree());
+    tree.refresh();
   }
 
-  private static class PerfTree extends CommandTree.Tree {
-    private static final int DURATION_WIDTH = 95;
-    private boolean showEstimate = true;
-
-    public PerfTree(Composite parent, Models models, Widgets widgets) {
-      super(parent, models, widgets);
-    }
-
-    @Override
-    protected void addGpuPerformanceColumn() {
-      // The performance tab's GPU performances are calculated from server's side.
-      // Don't create columns at initialization, the columns will be created after profile is loaded.
-      setUpStateForColumnAdding();
-    }
-
-    @Override
-    protected boolean shouldShowImage(CommandStream.Node node) {
-      return false;
-    }
-
-    public void toggleEstimateOrRange() {
-      showEstimate = !showEstimate;
-      refresh();
-    }
-
-    private void addColumnForMetric(Service.ProfilingData.GpuCounters.Metric metric) {
-      Unit unit = CounterInfo.unitFromString(metric.getUnit());
-      TreeViewerColumn column = addColumn(metric.getName() + "(" + unit.name + ")", node -> {
-        Service.CommandTreeNode data = node.getData();
-        if (data == null) {
-          return "";
-        } else if (!models.profile.isLoaded()) {
-          return "Profiling...";
+  private void addColumnForMetric(Service.ProfilingData.GpuCounters.Metric metric) {
+    Unit unit = CounterInfo.unitFromString(metric.getUnit());
+    TreeViewerColumn column = createTreeColumn(tree, metric.getName() + "(" + unit.name + ")", e -> {
+      Profile.PerfNode node = (Profile.PerfNode)e;
+      if (node == null || node.getPerfs() == null) {
+        return "";
+      } else if (!models.profile.isLoaded()) {
+        return "Profiling...";
+      } else {
+        Service.ProfilingData.GpuCounters.Perf perf = node.getPerfs().get(metric.getId());
+        if (showEstimate) {
+          return perf.getEstimate() < 0 ? "" : unit.format(perf.getEstimate());
         } else {
-          Service.ProfilingData.GpuCounters.Perf perf = models.profile.getData().getGpuPerformance(data.getCommands().getFromList(), metric.getId());
-          if (perf == null) {
-            return "";
-          }
-          if (showEstimate) {
-            return perf.getEstimate() < 0 ? "" : unit.format(perf.getEstimate());
-          } else {
-            String minStr = perf.getMin() < 0 ? "?" : unit.format(perf.getMin());
-            String maxStr = perf.getMax() < 0 ? "?" : unit.format(perf.getMax());
-            return minStr + " ~ " + maxStr;
-          }
+          String minStr = perf.getMin() < 0 ? "?" : unit.format(perf.getMin());
+          String maxStr = perf.getMax() < 0 ? "?" : unit.format(perf.getMax());
+          return minStr + " ~ " + maxStr;
         }
-      }, DURATION_WIDTH);
-      column.getColumn().setAlignment(SWT.RIGHT);
-    }
+      }
+    });
+    column.getColumn().setAlignment(SWT.RIGHT);
+  }
 
-    public void refresh() {
-      refresher.refresh();
+  private void toggleEstimateOrRange() {
+    showEstimate = !showEstimate;
+    packColumns(tree.getTree());
+    tree.refresh();
+  }
+
+  // For a tree-structured TreeItem, do a preorder traversal, to find the PerfNode that meets the
+  // requirement.
+  private TreeItem findItem(TreeItem root, Predicate<PerfNode> requirement) {
+    if (root == null || !(root.getData() instanceof PerfNode)) {
+      return null;
     }
+    PerfNode rootNode = cast(root.getData());
+    if (requirement.test(rootNode)) {
+      return root;
+    }
+    return findItem(root.getItems(), requirement);
+  }
+
+  // For multiple tree-structured TreeItems, do a preorder traversal to each of them, to find the
+  // PerfNode that meets the requirement.
+  private TreeItem findItem(TreeItem[] roots, Predicate<PerfNode> requirement) {
+    for (TreeItem root : roots) {
+      TreeItem result = findItem(root, requirement);
+      if (result != null) {
+        return result;
+      }
+    }
+    return null;
+  }
+
+  private PerfNode cast(Object o) {
+    return (PerfNode)o;
   }
 }

--- a/gapic/src/main/com/google/gapid/views/PerformanceView.java
+++ b/gapic/src/main/com/google/gapid/views/PerformanceView.java
@@ -107,7 +107,7 @@ public class PerformanceView extends Composite
     tree.getTree().addListener(SWT.Selection, e -> {
       TreeItem[] items = tree.getTree().getSelection();
       if (items.length > 0) {
-        PerfNode selection = cast(items[0].getData());
+        PerfNode selection = (PerfNode)items[0].getData();
         models.profile.linkGpuGroupToCommand(selection.getGroup());
       }
     });
@@ -226,7 +226,7 @@ public class PerformanceView extends Composite
     if (root == null || !(root.getData() instanceof PerfNode)) {
       return null;
     }
-    PerfNode rootNode = cast(root.getData());
+    PerfNode rootNode = (PerfNode)root.getData();
     if (requirement.test(rootNode)) {
       return root;
     }
@@ -243,9 +243,5 @@ public class PerformanceView extends Composite
       }
     }
     return null;
-  }
-
-  private PerfNode cast(Object o) {
-    return (PerfNode)o;
   }
 }

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -285,6 +285,11 @@ func (API) ResolveSynchronization(ctx context.Context, d *sync.Data, c *path.Cap
 			case VkCmdBeginRenderPassArgsʳ:
 				rp := st.RenderPasses().Get(args.RenderPass())
 				if id.IsReal() {
+					submissionKey := api.CmdSubmissionKey{order, 0, 0, 0}
+					commandBufferKey := api.CmdSubmissionKey{order, uint64(cb.VulkanHandle()), 0, 0}
+					d.SubmissionIndices[submissionKey] = []api.SubCmdIdx{idx[:len(idx)-1]}
+					d.SubmissionIndices[commandBufferKey] = []api.SubCmdIdx{idx}
+
 					key := api.CmdSubmissionKey{order, uint64(cb.VulkanHandle()), uint64(rp.VulkanHandle()), uint64(args.Framebuffer())}
 					if _, ok := d.SubmissionIndices[key]; ok {
 						d.SubmissionIndices[key] = append(d.SubmissionIndices[key], append(idx, uint64(i)))

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -1256,8 +1256,9 @@ message ProfilingData {
 
     message Group {
       int32 id = 1;
-      int32 parent = 2;  // references Group.id
-      path.Command link = 3;
+      string name = 2;
+      Group parent = 3;
+      path.Command link = 4;
     }
 
     repeated Slice slices = 1;
@@ -1300,7 +1301,7 @@ message ProfilingData {
 
     // Entry contains performance data for a specific command.
     message Entry {
-      repeated uint64 command_index = 1;
+      GpuSlices.Group group = 1;
       map<int32, Perf> metric_to_value = 2;  // Metric.id -> perf value.
     }
 

--- a/gapis/trace/android/adreno/BUILD.bazel
+++ b/gapis/trace/android/adreno/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//gapis/service:go_default_library",
         "//gapis/service/path:go_default_library",
         "//gapis/trace/android/profile:go_default_library",
+        "//gapis/trace/android/utils:go_default_library",
         "//gapis/trace/android/validate:go_default_library",
     ],
 )

--- a/gapis/trace/android/adreno/profiling_data.go
+++ b/gapis/trace/android/adreno/profiling_data.go
@@ -112,7 +112,7 @@ func processGpuSlices(ctx context.Context, processor *perfetto.Processor, captur
 	slicesColumns := slicesQueryResult.GetColumns()
 	numSliceRows := slicesQueryResult.GetNumRecords()
 	slices := make([]*service.ProfilingData_GpuSlices_Slice, numSliceRows)
-	groups := make([]*service.ProfilingData_GpuSlices_Group, 0)
+	groupsMap := map[api.CmdSubmissionKey]*service.ProfilingData_GpuSlices_Group{}
 	groupIds := make([]int32, numSliceRows)
 	var tracks []*service.ProfilingData_GpuSlices_Track
 	// Grab all the column values. Depends on the order of columns selected in slicesQuery
@@ -144,10 +144,13 @@ func processGpuSlices(ctx context.Context, processor *perfetto.Processor, captur
 	subCommandGroupMap := make(map[api.CmdSubmissionKey]int)
 	for i, v := range submissionIds {
 		subOrder, ok := submissionOrdering[v]
+		groupId := int32(-1)
 		if ok {
 			cb := uint64(commandBuffers[i])
 			key := api.CmdSubmissionKey{subOrder, cb, uint64(renderPasses[i]), uint64(renderTargets[i])}
-			if indices, ok := syncData.SubmissionIndices[key]; ok {
+			if group, ok := groupsMap[key]; ok {
+				groupId = group.Id
+			} else if indices, ok := syncData.SubmissionIndices[key]; ok {
 				if names[i] == renderPassSliceName {
 					var idx []uint64
 					if c, ok := subCommandGroupMap[key]; ok {
@@ -157,11 +160,15 @@ func processGpuSlices(ctx context.Context, processor *perfetto.Processor, captur
 						subCommandGroupMap[key] = 0
 					}
 
+					parent := findParentGroup(ctx, subOrder, cb, groupsMap, syncData.SubmissionIndices, capture)
+					groupId = int32(len(groupsMap))
 					group := &service.ProfilingData_GpuSlices_Group{
-						Id:   int32(len(groups)),
-						Link: &path.Command{Capture: capture, Indices: idx},
+						Id:     groupId,
+						Name:   fmt.Sprintf("RenderPass %v", uint64(renderPasses[i])),
+						Parent: parent,
+						Link:   &path.Command{Capture: capture, Indices: idx},
 					}
-					groups = append(groups, group)
+					groupsMap[key] = group
 					subCommandGroupMap[key]++
 				}
 			}
@@ -169,7 +176,11 @@ func processGpuSlices(ctx context.Context, processor *perfetto.Processor, captur
 			log.W(ctx, "Encountered submission ID mismatch %v", v)
 		}
 
-		groupIds[i] = int32(len(groups)) - 1
+		groupIds[i] = groupId
+	}
+	groups := []*service.ProfilingData_GpuSlices_Group{}
+	for _, group := range groupsMap {
+		groups = append(groups, group)
 	}
 
 	for i := uint64(0); i < numSliceRows; i++ {
@@ -293,4 +304,36 @@ func processCounters(ctx context.Context, processor *perfetto.Processor, desc *d
 		}
 	}
 	return counters, nil
+}
+
+// For a renderPass leafy group, find its parent group and return it.
+// If the parent groups are not created yet, create them and store in the map.
+func findParentGroup(ctx context.Context, subOrder, cb uint64, groupsMap map[api.CmdSubmissionKey]*service.ProfilingData_GpuSlices_Group, links map[api.CmdSubmissionKey][]api.SubCmdIdx, capture *path.Capture) *service.ProfilingData_GpuSlices_Group {
+	commandBufferKey := api.CmdSubmissionKey{subOrder, cb, 0, 0}
+	if group, ok := groupsMap[commandBufferKey]; ok {
+		return group
+	} else {
+		submissionKey := api.CmdSubmissionKey{subOrder, 0, 0, 0}
+		var submissionGroup *service.ProfilingData_GpuSlices_Group
+		if g, ok := groupsMap[submissionKey]; ok {
+			submissionGroup = g
+		} else {
+			submissionGroup = &service.ProfilingData_GpuSlices_Group{
+				Id:     int32(len(groupsMap)),
+				Name:   fmt.Sprintf("Submission: %v", subOrder),
+				Parent: nil,
+				Link:   &path.Command{Capture: capture, Indices: links[submissionKey][0]},
+			}
+			groupsMap[submissionKey] = submissionGroup
+		}
+
+		commandBufferGroup := &service.ProfilingData_GpuSlices_Group{
+			Id:     int32(len(groupsMap)),
+			Name:   fmt.Sprintf("Command Buffer: %v", cb),
+			Parent: submissionGroup,
+			Link:   &path.Command{Capture: capture, Indices: links[commandBufferKey][0]},
+		}
+		groupsMap[commandBufferKey] = commandBufferGroup
+		return commandBufferGroup
+	}
 }

--- a/gapis/trace/android/mali/profiling_data.go
+++ b/gapis/trace/android/mali/profiling_data.go
@@ -33,7 +33,7 @@ var (
 	slicesQuery = "" +
 		"SELECT s.context_id, s.render_target, s.frame_id, s.submission_id, s.hw_queue_id, s.command_buffer, s.render_pass, s.ts, s.dur, s.id, s.name, depth, arg_set_id, track_id, t.name " +
 		"FROM gpu_track t LEFT JOIN gpu_slice s " +
-		"ON s.track_id = t.id WHERE t.scope = 'gpu_render_stage' ORDER BY s.ts"
+		"ON s.track_id = t.id WHERE t.scope = 'gpu_render_stage' AND s.render_pass != 0 ORDER BY s.ts"
 	argsQueryFmt = "" +
 		"SELECT key, string_value FROM args WHERE args.arg_set_id = %d"
 	queueSubmitQuery = "" +
@@ -119,7 +119,7 @@ func processGpuSlices(ctx context.Context, processor *perfetto.Processor, captur
 	slicesColumns := slicesQueryResult.GetColumns()
 	numSliceRows := slicesQueryResult.GetNumRecords()
 	slices := make([]*service.ProfilingData_GpuSlices_Slice, numSliceRows)
-	groups := make([]*service.ProfilingData_GpuSlices_Group, 0)
+	groupsMap := map[api.CmdSubmissionKey]*service.ProfilingData_GpuSlices_Group{}
 	groupIds := make([]int32, numSliceRows)
 	var tracks []*service.ProfilingData_GpuSlices_Track
 	// Grab all the column values. Depends on the order of columns selected in slicesQuery
@@ -150,23 +150,35 @@ func processGpuSlices(ctx context.Context, processor *perfetto.Processor, captur
 
 	for i, v := range submissionIds {
 		subOrder, ok := submissionOrdering[v]
+		groupId := int32(-1)
 		if ok {
 			cb := uint64(commandBuffers[i])
 			key := api.CmdSubmissionKey{subOrder, cb, uint64(renderPasses[i]), uint64(renderTargets[i])}
-			if indices, ok := syncData.SubmissionIndices[key]; ok {
+			if group, ok := groupsMap[key]; ok {
+				groupId = group.Id
+			} else if indices, ok := syncData.SubmissionIndices[key]; ok {
 				if names[i] == "vertex" || names[i] == "fragment" {
+					parent := findParentGroup(ctx, subOrder, cb, groupsMap, syncData.SubmissionIndices, capture)
+					groupId = int32(len(groupsMap))
 					group := &service.ProfilingData_GpuSlices_Group{
-						Id:   int32(len(groups)),
-						Link: &path.Command{Capture: capture, Indices: indices[0]},
+						Id:     groupId,
+						Name:   fmt.Sprintf("RenderPass %v", uint64(renderPasses[i])),
+						Parent: parent,
+						Link:   &path.Command{Capture: capture, Indices: indices[0]},
 					}
-					groups = append(groups, group)
+					groupsMap[key] = group
+					names[i] = fmt.Sprintf("%v %v", group.Link.Indices, names[i])
 				}
 			}
 		} else {
 			log.W(ctx, "Encountered submission ID mismatch %v", v)
 		}
 
-		groupIds[i] = int32(len(groups)) - 1
+		groupIds[i] = groupId
+	}
+	groups := []*service.ProfilingData_GpuSlices_Group{}
+	for _, group := range groupsMap {
+		groups = append(groups, group)
 	}
 
 	for i := uint64(0); i < numSliceRows; i++ {
@@ -219,10 +231,6 @@ func processGpuSlices(ctx context.Context, processor *perfetto.Processor, captur
 			Name:  "hwQueueId",
 			Value: &service.ProfilingData_GpuSlices_Slice_Extra_IntValue{IntValue: uint64(hwQueueIds[i])},
 		})
-
-		if (names[i] == "vertex" || names[i] == "fragment") && groupIds[i] != -1 {
-			names[i] = fmt.Sprintf("%v %v", groups[groupIds[i]].Link.Indices, names[i])
-		}
 
 		slices[i] = &service.ProfilingData_GpuSlices_Slice{
 			Ts:      uint64(timestamps[i]),
@@ -290,4 +298,36 @@ func processCounters(ctx context.Context, processor *perfetto.Processor, desc *d
 		}
 	}
 	return counters, nil
+}
+
+// For a renderPass leafy group, find its parent group and return it.
+// If the parent groups are not created yet, create them and store in the map.
+func findParentGroup(ctx context.Context, subOrder, cb uint64, groupsMap map[api.CmdSubmissionKey]*service.ProfilingData_GpuSlices_Group, links map[api.CmdSubmissionKey][]api.SubCmdIdx, capture *path.Capture) *service.ProfilingData_GpuSlices_Group {
+	commandBufferKey := api.CmdSubmissionKey{subOrder, cb, 0, 0}
+	if group, ok := groupsMap[commandBufferKey]; ok {
+		return group
+	} else {
+		submissionKey := api.CmdSubmissionKey{subOrder, 0, 0, 0}
+		var submissionGroup *service.ProfilingData_GpuSlices_Group
+		if g, ok := groupsMap[submissionKey]; ok {
+			submissionGroup = g
+		} else {
+			submissionGroup = &service.ProfilingData_GpuSlices_Group{
+				Id:     int32(len(groupsMap)),
+				Name:   fmt.Sprintf("Submission: %v", subOrder),
+				Parent: nil,
+				Link:   &path.Command{Capture: capture, Indices: links[submissionKey][0]},
+			}
+			groupsMap[submissionKey] = submissionGroup
+		}
+
+		commandBufferGroup := &service.ProfilingData_GpuSlices_Group{
+			Id:     int32(len(groupsMap)),
+			Name:   fmt.Sprintf("Command Buffer: %v", cb),
+			Parent: submissionGroup,
+			Link:   &path.Command{Capture: capture, Indices: links[commandBufferKey][0]},
+		}
+		groupsMap[commandBufferKey] = commandBufferGroup
+		return commandBufferGroup
+	}
 }

--- a/gapis/trace/android/mali/profiling_data.go
+++ b/gapis/trace/android/mali/profiling_data.go
@@ -27,13 +27,14 @@ import (
 	"github.com/google/gapid/gapis/service"
 	"github.com/google/gapid/gapis/service/path"
 	"github.com/google/gapid/gapis/trace/android/profile"
+	"github.com/google/gapid/gapis/trace/android/utils"
 )
 
 var (
 	slicesQuery = "" +
 		"SELECT s.context_id, s.render_target, s.frame_id, s.submission_id, s.hw_queue_id, s.command_buffer, s.render_pass, s.ts, s.dur, s.id, s.name, depth, arg_set_id, track_id, t.name " +
 		"FROM gpu_track t LEFT JOIN gpu_slice s " +
-		"ON s.track_id = t.id WHERE t.scope = 'gpu_render_stage' AND s.render_pass != 0 ORDER BY s.ts"
+		"ON s.track_id = t.id WHERE t.scope = 'gpu_render_stage' ORDER BY s.ts"
 	argsQueryFmt = "" +
 		"SELECT key, string_value FROM args WHERE args.arg_set_id = %d"
 	queueSubmitQuery = "" +
@@ -158,7 +159,7 @@ func processGpuSlices(ctx context.Context, processor *perfetto.Processor, captur
 				groupId = group.Id
 			} else if indices, ok := syncData.SubmissionIndices[key]; ok {
 				if names[i] == "vertex" || names[i] == "fragment" {
-					parent := findParentGroup(ctx, subOrder, cb, groupsMap, syncData.SubmissionIndices, capture)
+					parent := utils.FindParentGroup(ctx, subOrder, cb, groupsMap, syncData.SubmissionIndices, capture)
 					groupId = int32(len(groupsMap))
 					group := &service.ProfilingData_GpuSlices_Group{
 						Id:     groupId,
@@ -298,36 +299,4 @@ func processCounters(ctx context.Context, processor *perfetto.Processor, desc *d
 		}
 	}
 	return counters, nil
-}
-
-// For a renderPass leafy group, find its parent group and return it.
-// If the parent groups are not created yet, create them and store in the map.
-func findParentGroup(ctx context.Context, subOrder, cb uint64, groupsMap map[api.CmdSubmissionKey]*service.ProfilingData_GpuSlices_Group, links map[api.CmdSubmissionKey][]api.SubCmdIdx, capture *path.Capture) *service.ProfilingData_GpuSlices_Group {
-	commandBufferKey := api.CmdSubmissionKey{subOrder, cb, 0, 0}
-	if group, ok := groupsMap[commandBufferKey]; ok {
-		return group
-	} else {
-		submissionKey := api.CmdSubmissionKey{subOrder, 0, 0, 0}
-		var submissionGroup *service.ProfilingData_GpuSlices_Group
-		if g, ok := groupsMap[submissionKey]; ok {
-			submissionGroup = g
-		} else {
-			submissionGroup = &service.ProfilingData_GpuSlices_Group{
-				Id:     int32(len(groupsMap)),
-				Name:   fmt.Sprintf("Submission: %v", subOrder),
-				Parent: nil,
-				Link:   &path.Command{Capture: capture, Indices: links[submissionKey][0]},
-			}
-			groupsMap[submissionKey] = submissionGroup
-		}
-
-		commandBufferGroup := &service.ProfilingData_GpuSlices_Group{
-			Id:     int32(len(groupsMap)),
-			Name:   fmt.Sprintf("Command Buffer: %v", cb),
-			Parent: submissionGroup,
-			Link:   &path.Command{Capture: capture, Indices: links[commandBufferKey][0]},
-		}
-		groupsMap[commandBufferKey] = commandBufferGroup
-		return commandBufferGroup
-	}
 }

--- a/gapis/trace/android/utils/BUILD.bazel
+++ b/gapis/trace/android/utils/BUILD.bazel
@@ -16,23 +16,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "profiling_data.go",
-        "validate.go",
-    ],
-    importpath = "github.com/google/gapid/gapis/trace/android/mali",
+    srcs = ["utils.go"],
+    importpath = "github.com/google/gapid/gapis/trace/android/utils",
     visibility = ["//visibility:public"],
     deps = [
-        "//core/log:go_default_library",
-        "//core/os/device:go_default_library",
         "//gapis/api:go_default_library",
-        "//gapis/api/sync:go_default_library",
-        "//gapis/perfetto:go_default_library",
-        "//gapis/perfetto/service:go_default_library",
         "//gapis/service:go_default_library",
         "//gapis/service/path:go_default_library",
-        "//gapis/trace/android/profile:go_default_library",
-        "//gapis/trace/android/utils:go_default_library",
-        "//gapis/trace/android/validate:go_default_library",
     ],
 )

--- a/gapis/trace/android/utils/utils.go
+++ b/gapis/trace/android/utils/utils.go
@@ -1,0 +1,57 @@
+// Copyright (C) 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/gapid/gapis/api"
+	"github.com/google/gapid/gapis/service"
+	"github.com/google/gapid/gapis/service/path"
+)
+
+// Helper function in the process of grouping GPU slices.
+// For a renderPass leafy group, find its parent group and return it.
+// If the parent groups are not created yet, create them and store them in map.
+func FindParentGroup(ctx context.Context, subOrder, cb uint64, groupsMap map[api.CmdSubmissionKey]*service.ProfilingData_GpuSlices_Group, links map[api.CmdSubmissionKey][]api.SubCmdIdx, capture *path.Capture) *service.ProfilingData_GpuSlices_Group {
+	commandBufferKey := api.CmdSubmissionKey{subOrder, cb, 0, 0}
+	if group, ok := groupsMap[commandBufferKey]; ok {
+		return group
+	} else {
+		submissionKey := api.CmdSubmissionKey{subOrder, 0, 0, 0}
+		var submissionGroup *service.ProfilingData_GpuSlices_Group
+		if g, ok := groupsMap[submissionKey]; ok {
+			submissionGroup = g
+		} else {
+			submissionGroup = &service.ProfilingData_GpuSlices_Group{
+				Id:     int32(len(groupsMap)),
+				Name:   fmt.Sprintf("Submission: %v", subOrder),
+				Parent: nil,
+				Link:   &path.Command{Capture: capture, Indices: links[submissionKey][0]},
+			}
+			groupsMap[submissionKey] = submissionGroup
+		}
+
+		commandBufferGroup := &service.ProfilingData_GpuSlices_Group{
+			Id:     int32(len(groupsMap)),
+			Name:   fmt.Sprintf("Command Buffer: %v", cb),
+			Parent: submissionGroup,
+			Link:   &path.Command{Capture: capture, Indices: links[commandBufferKey][0]},
+		}
+		groupsMap[commandBufferKey] = commandBufferGroup
+		return commandBufferGroup
+	}
+}


### PR DESCRIPTION
 - A step to decouple the performance tree from the command tree, and to
 help make full use of the spaces inside the perftab by reducing blank area.
 - Implementation changes:
   1. Complete the GPU slices grouping logic at the server side,
   create the tree structure between the groups.
   2. When creating the performance tree at the client side, stop
   reusing the command tree's class, instead use a new tree that
   implements only the needed functions.
   3. Make sure the linking behavior between Profile, Command, and
   Performance tab doesn't regress.
 - Bug: b/169169693.