### PR TITLE
Avoid GAPIS panics when mutate context is cancelled

### DIFF
--- a/core/event/task/doc.go
+++ b/core/event/task/doc.go
@@ -13,9 +13,4 @@
 // limitations under the License.
 
 // Package task contains types that can be used to create cancelable tasks.
-//
-// This package builds on top of Go's standard "context" package. Before
-// touching this package internals, make sure to understand the standard Go
-// context. This article gives a good introduction:
-// https://blog.golang.org/context
 package task

--- a/core/event/task/doc.go
+++ b/core/event/task/doc.go
@@ -13,4 +13,9 @@
 // limitations under the License.
 
 // Package task contains types that can be used to create cancelable tasks.
+//
+// This package builds on top of Go's standard "context" package. Before
+// touching this package internals, make sure to understand the standard Go
+// context. This article gives a good introduction:
+// https://blog.golang.org/context
 package task

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -219,6 +219,8 @@ var ( // Don't error if these packages aren't used.
   {{template "Go.GeneratedHeader" (Global "OutputDir")}}
 
 import (
+    "context"
+    "errors"
     "github.com/google/gapid/core/data/id"
     ϟapi "github.com/google/gapid/gapis/api"
 )
@@ -234,13 +236,23 @@ import (
     ϟapi.Register(API{})
   }
 ¶
-  func panicOnError(err error) {
+  // panicOnFatalError panics on errors that are not task cancellation errors.
+  // This function is used to avoid reporting errors and doing error checking
+  // across all generated code. However, we do not want to panic upon a task
+  // cancellation. This may happen if we have a task being cancelled while
+  // doing command mutations: in generated code, calls to e.g. MustRead or
+  // MustWrite trigger database accesses that then result in a task cancellation
+  // error. Hence, we filter out these errors here. Note that each Mutate
+  // function still catches task cancellation by returning task.StopReason().
+  func panicOnFatalError(err error) {
     if err != nil {
+      if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+        return
+      }
       panic(err)
     }
   }
 {{end}}
-
 
 {{/*
 -------------------------------------------------------------------------------
@@ -1055,7 +1067,7 @@ import (
     // MustRead calls and returns Read, panicing if there was an error.
     func (s {{$slice_ty}}) MustReadʷ(ϟctx context.Context, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) []{{$el_ty}} {
       vals, err := s.Readʷ(ϟctx, ϟc, ϟg, ϟb, ϟw)
-      panicOnError(err)
+      panicOnFatalError(err)
       return vals
     }
 
@@ -1086,7 +1098,7 @@ import (
     // MustWrite calls and returns Write, panicing if there was an error.
     func (s {{$slice_ty}}) MustWriteʷ(ϟctx context.Context, src []{{$el_ty}}, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) uint64 {
       count, err := s.Writeʷ(ϟctx, src, ϟc, ϟg, ϟb, ϟw)
-      panicOnError(err)
+      panicOnFatalError(err)
       return count
     }
 
@@ -1162,7 +1174,7 @@ import (
           ϟb.StorePointer(dst, ptr)
           dst++
         }
-        panicOnError(ϟd.Error())
+        panicOnFatalError(ϟd.Error())
       {{else if IsClass ($s.To | Underlying)}}
         {{Template "ReadStructWithRemapping" $s.To}}
       {{else}}
@@ -1180,7 +1192,7 @@ import (
             ϟb.Store(ptr)
             ptr += step
           }
-          panicOnError(ϟd.Error())
+          panicOnFatalError(ϟd.Error())
         {{else}}
           ϟb.Write(s.Range(), s.ResourceID(ϟctx, ϟg))
         {{end}}
@@ -1224,7 +1236,7 @@ import (
           }
           ptr += step
         }
-        panicOnError(ϟd.Error())
+        panicOnFatalError(ϟd.Error())
       {{end}}
     }
     return s
@@ -1379,7 +1391,7 @@ import (
     // MustRead calls and returns Read, panicing if there was an error.
     func (p {{$ptr_ty}}) MustReadʷ(ϟctx context.Context, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) {{$el_ty}} {
       val, err := p.Readʷ(ϟctx, ϟc, ϟg, ϟb, ϟw)
-      panicOnError(err)
+      panicOnFatalError(err)
       return val
     }
 
@@ -1401,7 +1413,7 @@ import (
 
     // MustWrite calls Write, panicing if there was an error.
     func (p {{$ptr_ty}}) MustWriteʷ(ϟctx context.Context, value {{$el_ty}}, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) {
-      panicOnError(p.Writeʷ(ϟctx, value, ϟc, ϟg, ϟb, ϟw))
+      panicOnFatalError(p.Writeʷ(ϟctx, value, ϟc, ϟg, ϟb, ϟw))
     }
   {{end}}
 
@@ -2022,7 +2034,7 @@ import (
     for i, c := uint64(0), s.Count(); i < c; i++ {
       {{Template "ReadStructFieldsWithRemapping" $}}
     }
-    panicOnError(ϟd.Error())
+    panicOnFatalError(ϟd.Error())
   {{end}}
 {{end}}
 

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -219,8 +219,6 @@ var ( // Don't error if these packages aren't used.
   {{template "Go.GeneratedHeader" (Global "OutputDir")}}
 
 import (
-    "context"
-    "errors"
     "github.com/google/gapid/core/data/id"
     ϟapi "github.com/google/gapid/gapis/api"
 )
@@ -236,23 +234,13 @@ import (
     ϟapi.Register(API{})
   }
 ¶
-  // panicOnFatalError panics on errors that are not task cancellation errors.
-  // This function is used to avoid reporting errors and doing error checking
-  // across all generated code. However, we do not want to panic upon a task
-  // cancellation. This may happen if we have a task being cancelled while
-  // doing command mutations: in generated code, calls to e.g. MustRead or
-  // MustWrite trigger database accesses that then result in a task cancellation
-  // error. Hence, we filter out these errors here. Note that each Mutate
-  // function still catches task cancellation by returning task.StopReason().
-  func panicOnFatalError(err error) {
+  func panicOnError(err error) {
     if err != nil {
-      if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-        return
-      }
       panic(err)
     }
   }
 {{end}}
+
 
 {{/*
 -------------------------------------------------------------------------------
@@ -1067,7 +1055,7 @@ import (
     // MustRead calls and returns Read, panicing if there was an error.
     func (s {{$slice_ty}}) MustReadʷ(ϟctx context.Context, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) []{{$el_ty}} {
       vals, err := s.Readʷ(ϟctx, ϟc, ϟg, ϟb, ϟw)
-      panicOnFatalError(err)
+      panicOnError(err)
       return vals
     }
 
@@ -1098,7 +1086,7 @@ import (
     // MustWrite calls and returns Write, panicing if there was an error.
     func (s {{$slice_ty}}) MustWriteʷ(ϟctx context.Context, src []{{$el_ty}}, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) uint64 {
       count, err := s.Writeʷ(ϟctx, src, ϟc, ϟg, ϟb, ϟw)
-      panicOnFatalError(err)
+      panicOnError(err)
       return count
     }
 
@@ -1174,7 +1162,7 @@ import (
           ϟb.StorePointer(dst, ptr)
           dst++
         }
-        panicOnFatalError(ϟd.Error())
+        panicOnError(ϟd.Error())
       {{else if IsClass ($s.To | Underlying)}}
         {{Template "ReadStructWithRemapping" $s.To}}
       {{else}}
@@ -1192,7 +1180,7 @@ import (
             ϟb.Store(ptr)
             ptr += step
           }
-          panicOnFatalError(ϟd.Error())
+          panicOnError(ϟd.Error())
         {{else}}
           ϟb.Write(s.Range(), s.ResourceID(ϟctx, ϟg))
         {{end}}
@@ -1236,7 +1224,7 @@ import (
           }
           ptr += step
         }
-        panicOnFatalError(ϟd.Error())
+        panicOnError(ϟd.Error())
       {{end}}
     }
     return s
@@ -1391,7 +1379,7 @@ import (
     // MustRead calls and returns Read, panicing if there was an error.
     func (p {{$ptr_ty}}) MustReadʷ(ϟctx context.Context, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) {{$el_ty}} {
       val, err := p.Readʷ(ϟctx, ϟc, ϟg, ϟb, ϟw)
-      panicOnFatalError(err)
+      panicOnError(err)
       return val
     }
 
@@ -1413,7 +1401,7 @@ import (
 
     // MustWrite calls Write, panicing if there was an error.
     func (p {{$ptr_ty}}) MustWriteʷ(ϟctx context.Context, value {{$el_ty}}, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) {
-      panicOnFatalError(p.Writeʷ(ϟctx, value, ϟc, ϟg, ϟb, ϟw))
+      panicOnError(p.Writeʷ(ϟctx, value, ϟc, ϟg, ϟb, ϟw))
     }
   {{end}}
 
@@ -2034,7 +2022,7 @@ import (
     for i, c := uint64(0), s.Count(); i < c; i++ {
       {{Template "ReadStructFieldsWithRemapping" $}}
     }
-    panicOnFatalError(ϟd.Error())
+    panicOnError(ϟd.Error())
   {{end}}
 {{end}}
 

--- a/gapis/api/templates/mutate.go.tmpl
+++ b/gapis/api/templates/mutate.go.tmpl
@@ -23,6 +23,7 @@
 
   import (
     "context"
+    "errors"
     "fmt"
     "strings"
 
@@ -157,7 +158,29 @@
       {{end}}
       func (ϟc *{{$name}}) Mutate(§
     {{end}}
-        ϟctx context.Context, ϟi api.CmdID, ϟg *api.GlobalState, ϟb *builder.Builder, ϟw api.StateWatcher) error {
+        ϟctx context.Context, ϟi api.CmdID, ϟg *api.GlobalState, ϟb *builder.Builder, ϟw api.StateWatcher) (err error) {
+
+      {{/*
+        Catch context cancellations that lead to a panic.
+        During mutation, some primitives (e.g. MustRead, MustWrite) do database
+        accesses that can return an error when the context is cancelled: this
+        triggers panicOnError, yet GAPIS should not panic upon a context
+        cancellation. Propagating such errors across all generated code is quite
+        cumbersome, so instead we recover from cancellation errors here.
+      */}}
+      defer func () {
+        r := recover()
+        if r != nil {
+          if e, ok := r.(error); ok {
+            if errors.Is(e, context.Canceled) || errors.Is(e, context.DeadlineExceeded) {
+              {{/* NB: here "err" is the return varialbe of Mutate() */}}
+              err = e
+              return
+            }
+          }
+          panic(r)
+        }
+      }()
 
       {{if not $r}}ϟb = nil // @no_replay{{end}}
 

--- a/gapis/api/templates/mutate.go.tmpl
+++ b/gapis/api/templates/mutate.go.tmpl
@@ -23,6 +23,7 @@
 
   import (
     "context"
+    "errors"
     "fmt"
     "strings"
 
@@ -157,7 +158,29 @@
       {{end}}
       func (ϟc *{{$name}}) Mutate(§
     {{end}}
-        ϟctx context.Context, ϟi api.CmdID, ϟg *api.GlobalState, ϟb *builder.Builder, ϟw api.StateWatcher) error {
+        ϟctx context.Context, ϟi api.CmdID, ϟg *api.GlobalState, ϟb *builder.Builder, ϟw api.StateWatcher) (err error) {
+
+      {{/*
+        Catch context cancellations that lead to a panic.
+        During mutation, some primitives (e.g. MustRead, MustWrite) do database
+        accesses that can return an error when the context is cancelled: this
+        triggers panicOnError, yet GAPIS should not panic upon a context
+        cancellation. Propagating such errors across all generated code is quite
+        cumbersome, so instead we recover from cancellation errors here.
+      */}}
+      defer func () {
+        r := recover()
+        if r != nil {
+          if e, ok := r.(error); ok {
+            if errors.Is(e, context.Canceled) || errors.Is(e, context.DeadlineExceeded) {
+              {{/* NB: here "err" is the return varialbe of Mutate() */}}
+              err = e
+              return
+            }
+          }
+          panic(r)
+        }
+      }()
 
       {{if not $r}}ϟb = nil // @no_replay{{end}}
 
@@ -180,7 +203,6 @@
       }
       {{Template "Block" $.Block}}
 
-      {{/* This makes sure mutate detects task cancellation. */}}
       return task.StopReason(ϟctx)
     }
 

--- a/gapis/api/templates/mutate.go.tmpl
+++ b/gapis/api/templates/mutate.go.tmpl
@@ -23,7 +23,6 @@
 
   import (
     "context"
-    "errors"
     "fmt"
     "strings"
 
@@ -158,29 +157,7 @@
       {{end}}
       func (ϟc *{{$name}}) Mutate(§
     {{end}}
-        ϟctx context.Context, ϟi api.CmdID, ϟg *api.GlobalState, ϟb *builder.Builder, ϟw api.StateWatcher) (err error) {
-
-      {{/*
-        Catch context cancellations that lead to a panic.
-        During mutation, some primitives (e.g. MustRead, MustWrite) do database
-        accesses that can return an error when the context is cancelled: this
-        triggers panicOnError, yet GAPIS should not panic upon a context
-        cancellation. Propagating such errors across all generated code is quite
-        cumbersome, so instead we recover from cancellation errors here.
-      */}}
-      defer func () {
-        r := recover()
-        if r != nil {
-          if e, ok := r.(error); ok {
-            if errors.Is(e, context.Canceled) || errors.Is(e, context.DeadlineExceeded) {
-              {{/* NB: here "err" is the return varialbe of Mutate() */}}
-              err = e
-              return
-            }
-          }
-          panic(r)
-        }
-      }()
+        ϟctx context.Context, ϟi api.CmdID, ϟg *api.GlobalState, ϟb *builder.Builder, ϟw api.StateWatcher) error {
 
       {{if not $r}}ϟb = nil // @no_replay{{end}}
 
@@ -203,6 +180,7 @@
       }
       {{Template "Block" $.Block}}
 
+      {{/* This makes sure mutate detects task cancellation. */}}
       return task.StopReason(ϟctx)
     }
 


### PR DESCRIPTION
If the context gets cancelled during capture command mutation,
panicOnError() may be triggered and leads to a GAPIS panic. This
change catches such panics and transform them to regular errors.

Another option would have been to get rid of panicOnError and
propagate the errors across all generated code inside Mutate
functions: I had a quick try at this, and it gets quite
cumbersome, especially things like:

```
foo := bar(..., MustRead(...), ...)
```

must be turned into:

```
tmp, err := MustRead(...)
if err != nil {
  return nil, err
}
foo := bar(..., tmp, ...)
```

Using panic for control flow is not awesome, but it is very convenient
here to jump from possibly deep-nested calls in generated code up to
the top-level of Mutate.

Fix #59
Bug: b/149701723
Test: manual, by hard-coding panics and errors