### PR TITLE
Use default trace name when no app is selected

### DIFF
--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -524,6 +524,12 @@ public class TracerDialog {
 
         traceTarget.addBoxListener(SWT.Modify, e -> {
           userHasChangedTarget = true;
+          if (traceTarget.getText().isEmpty() && !userHasChangedOutputFile) {
+            // The user may clear the target name do a system profiling with no app in particular,
+            // in this case avoid to keep an old app-based output file name.
+            file.setText(formatTraceName(DEFAULT_TRACE_FILE));
+            userHasChangedOutputFile = false; // cancel the modify event from set call.
+          }
         });
         file.addListener(SWT.Modify, e -> {
           userHasChangedOutputFile = true;


### PR DESCRIPTION
When the user clears the Application field, but has not edited the
output file name, make sure to update the output file name to a
default. This avoids keeping an old app-based output file name.

Bug: b/155356969
Test: manual