### PR TITLE
Check for ANGLE releases and prompt the user on new versions.

### DIFF
--- a/core/os/android/adb/device.go
+++ b/core/os/android/adb/device.go
@@ -237,8 +237,8 @@ func newDevice(ctx context.Context, serial string, status bind.Status) (*binding
 	}
 
 	// Query device ANGLE support
-	if anglePackage, err := d.QueryAnglePackageName(ctx); err == nil {
-		d.To.Configuration.AnglePackage = anglePackage
+	if angle, err := d.QueryAngle(ctx); err == nil {
+		d.To.Configuration.Angle = angle
 	}
 
 	// Query infos related to the Vulkan driver

--- a/core/os/device/device.proto
+++ b/core/os/device/device.proto
@@ -173,8 +173,8 @@ message Configuration {
   Drivers drivers = 4;
   // Perfetto capability.
   PerfettoCapability perfetto_capability = 5;
-  // Angle package name
-  string angle_package = 6;
+  // ANGLE info.
+  ANGLE angle = 6;
 }
 
 message VulkanProfilingLayers {
@@ -196,6 +196,11 @@ message GPUProfiling {
   reserved 3;
   bool has_render_stage_producer_layer = 4;
   bool has_gpu_mem_total = 5;
+}
+
+message ANGLE {
+  string package = 1;
+  int32 version = 2;
 }
 
 // Instance represents a physical device.

--- a/gapic/src/main/BUILD.bazel
+++ b/gapic/src/main/BUILD.bazel
@@ -80,6 +80,7 @@ proto_library(
     srcs = ["com/google/gapid/settings.proto"],
     deps = [
         "//core/os/device:device_proto",
+        "//gapis/service:service_proto",
         "@perfetto//:protos_perfetto_config_merged_config_protos",
     ],
 )

--- a/gapic/src/main/com/google/gapid/server/Client.java
+++ b/gapic/src/main/com/google/gapid/server/Client.java
@@ -38,7 +38,7 @@ import com.google.gapid.proto.service.Service.GetServerInfoRequest;
 import com.google.gapid.proto.service.Service.GetStringTableRequest;
 import com.google.gapid.proto.service.Service.ImportCaptureRequest;
 import com.google.gapid.proto.service.Service.LoadCaptureRequest;
-import com.google.gapid.proto.service.Service.Release;
+import com.google.gapid.proto.service.Service.Releases;
 import com.google.gapid.proto.service.Service.SaveCaptureRequest;
 import com.google.gapid.proto.service.Service.ServerInfo;
 import com.google.gapid.proto.service.Service.SetRequest;
@@ -82,13 +82,13 @@ public class Client {
             in -> immediateFuture(throwIfError(in.getInfo(), in.getError(), stack))));
   }
 
-  public ListenableFuture<Release> checkForUpdates(boolean includeDevReleases) {
+  public ListenableFuture<Releases> checkForUpdates(boolean includeDevReleases) {
     return call(() -> String.format("RPC->checkForUpdates(%b)", includeDevReleases),
         stack -> MoreFutures.transformAsync(
             client.checkForUpdates(CheckForUpdatesRequest.newBuilder()
                 .setIncludeDevReleases(includeDevReleases)
                 .build()),
-            in -> immediateFuture(throwIfError(in.getRelease(), in.getError(), stack))));
+            in -> immediateFuture(throwIfError(in.getReleases(), in.getError(), stack))));
   }
 
   public ListenableFuture<Value> get(Path.Any path, Path.Device device) {

--- a/gapic/src/main/com/google/gapid/settings.proto
+++ b/gapic/src/main/com/google/gapid/settings.proto
@@ -20,6 +20,7 @@ option java_package = "com.google.gapid.proto";
 option java_outer_classname = "SettingsProto";
 
 import "core/os/device/device.proto";
+import "gapis/service/service.proto";
 
 message Point {
   int32 x = 1;
@@ -51,6 +52,7 @@ message Preferences {
   bool update_available = 5;
   // milliseconds since midnight, January 1, 1970 UTC.
   int64 last_check_for_updates = 6;
+  service.Releases.ANGLERelease latest_angle_release = 11;
   string analytics_client_id = 7;  // Empty (default) means do not track.
   bool disable_replay_optimization = 8;
   bool report_crashes = 9;

--- a/gapic/src/main/com/google/gapid/util/URLs.java
+++ b/gapic/src/main/com/google/gapid/util/URLs.java
@@ -19,4 +19,5 @@ public interface URLs {
   public static final String FILE_BUG_URL =
       "https://github.com/google/agi/issues/new?template=standard-bug-report-for-gapid.md";
   public static final String DEVICE_COMPATIBILITY_URL = "https://gpuinspector.dev/validation";
+  public static final String ANGLE_DOWNLOAD = "https://agi-angle.storage.googleapis.com/index.html";
 }

--- a/gapic/src/main/com/google/gapid/util/UpdateWatcher.java
+++ b/gapic/src/main/com/google/gapid/util/UpdateWatcher.java
@@ -75,6 +75,7 @@ public class UpdateWatcher {
           prefs.setUpdateAvailable(true);
           listener.onNewReleaseAvailable(releases.getAGI());
         }
+        prefs.setLatestAngleRelease(releases.getANGLE());
       } catch (InterruptedException | ExecutionException e) {
         /* never mind */
       }

--- a/gapic/src/main/com/google/gapid/util/UpdateWatcher.java
+++ b/gapic/src/main/com/google/gapid/util/UpdateWatcher.java
@@ -70,7 +70,7 @@ public class UpdateWatcher {
       prefs.setUpdateAvailable(false);
       try {
         Release release = future.get();
-        if (release != null) {
+        if (GapidVersion.GAPID_VERSION.isOlderThan(release)) {
           prefs.setUpdateAvailable(true);
           listener.onNewReleaseAvailable(release);
         }

--- a/gapic/src/main/com/google/gapid/util/Version.java
+++ b/gapic/src/main/com/google/gapid/util/Version.java
@@ -36,8 +36,44 @@ public class Version {
     return new Version(info.getVersionMajor(), info.getVersionMinor(), info.getVersionPoint(), "");
   }
 
+  public int getDevVersion() {
+    // For the dev builds, the build has format dev-YYYYMMDD.
+    if (build.startsWith("dev-") && build.length() >= 12) {
+      try {
+        return Integer.parseInt(build.substring(4, 12));
+      } catch (NumberFormatException e) {
+        // Ignore.
+      }
+    }
+    return -1;
+  }
+
+  public boolean isDeveloper() {
+    return "developer".equals(build);
+  }
+
   public boolean isCompatible(Version version) {
     return major == version.major && minor == version.minor;
+  }
+
+  public boolean isOlderThan(Service.Release release) {
+    if (isDeveloper()) {
+      return false;
+    } else if (major < release.getVersionMajor()) {
+      return true;
+    } else if (major > release.getVersionMajor()) {
+      return false;
+    } else if (minor < release.getVersionMinor()) {
+      return true;
+    } else if (minor > release.getVersionMinor()) {
+      return false;
+    } else if (point < release.getVersionPoint()) {
+      return true;
+    } else if (point > release.getVersionPoint()) {
+      return false;
+    }
+    int devVersion = getDevVersion();
+    return devVersion >= 0 && devVersion < release.getVersionDev();
   }
 
   @Override

--- a/gapic/src/main/com/google/gapid/util/Version.java
+++ b/gapic/src/main/com/google/gapid/util/Version.java
@@ -56,7 +56,7 @@ public class Version {
     return major == version.major && minor == version.minor;
   }
 
-  public boolean isOlderThan(Service.Release release) {
+  public boolean isOlderThan(Service.Releases.AGIRelease release) {
     if (isDeveloper()) {
       return false;
     } else if (major < release.getVersionMajor()) {

--- a/gapii/client/adb.go
+++ b/gapii/client/adb.go
@@ -95,8 +95,8 @@ func Start(ctx context.Context, p *android.InstalledPackage, a *android.Activity
 			}
 		} else {
 			// We shouldn't be able to get here. EnableAngle flag should only be set
-			//  when there's an Angle package on the device to enable.
-			log.W(ctx, "ANGLE enabled but no package found")
+			// when there's an Angle package on the device to enable.
+			return nil, cleanup.Invoke(ctx), log.Err(ctx, nil, "ANGLE requested but no ANGLE package found")
 		}
 	}
 

--- a/gapii/client/adb.go
+++ b/gapii/client/adb.go
@@ -86,7 +86,7 @@ func Start(ctx context.Context, p *android.InstalledPackage, a *android.Activity
 	log.I(ctx, "Checking if ANGLE requested")
 	if o.EnableAngle {
 		log.I(ctx, "ANGLE is enabled")
-		if anglePackage := p.Device.Instance().GetConfiguration().AnglePackage; anglePackage != "" {
+		if anglePackage := p.Device.Instance().GetConfiguration().GetAngle().GetPackage(); anglePackage != "" {
 			log.I(ctx, "Found ANGLE package %s, enabling it for %s", anglePackage, p.Name)
 			nextCleanup, err := adb.SetupAngle(ctx, d, a.Package)
 			cleanup = cleanup.Then(nextCleanup)

--- a/gapis/client/client.go
+++ b/gapis/client/client.go
@@ -73,7 +73,7 @@ func (c *client) GetServerInfo(ctx context.Context) (*service.ServerInfo, error)
 	return res.GetInfo(), nil
 }
 
-func (c *client) CheckForUpdates(ctx context.Context, includeDevReleases bool) (*service.Release, error) {
+func (c *client) CheckForUpdates(ctx context.Context, includeDevReleases bool) (*service.Releases, error) {
 	res, err := c.client.CheckForUpdates(ctx, &service.CheckForUpdatesRequest{
 		IncludeDevReleases: includeDevReleases,
 	})
@@ -83,7 +83,7 @@ func (c *client) CheckForUpdates(ctx context.Context, includeDevReleases bool) (
 	if err := res.GetError(); err != nil {
 		return nil, err.Get()
 	}
-	return res.GetRelease(), nil
+	return res.GetReleases(), nil
 }
 
 func (c *client) Get(ctx context.Context, p *path.Any, r *path.ResolveConfig) (interface{}, error) {

--- a/gapis/server/BUILD.bazel
+++ b/gapis/server/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "export_replay.go",
         "grpc.go",
         "server.go",
+        "update.go",
     ],
     importpath = "github.com/google/gapid/gapis/server",
     visibility = ["//visibility:public"],

--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -214,11 +214,11 @@ func (s *grpcServer) GetServerInfo(ctx xctx.Context, req *service.GetServerInfoR
 
 func (s *grpcServer) CheckForUpdates(ctx xctx.Context, req *service.CheckForUpdatesRequest) (*service.CheckForUpdatesResponse, error) {
 	defer s.inRPC()()
-	release, err := s.handler.CheckForUpdates(s.bindCtx(ctx), req.IncludeDevReleases)
+	releases, err := s.handler.CheckForUpdates(s.bindCtx(ctx), req.IncludeDevReleases)
 	if err := service.NewError(err); err != nil {
 		return &service.CheckForUpdatesResponse{Res: &service.CheckForUpdatesResponse_Error{Error: err}}, nil
 	}
-	return &service.CheckForUpdatesResponse{Res: &service.CheckForUpdatesResponse_Release{Release: release}}, nil
+	return &service.CheckForUpdatesResponse{Res: &service.CheckForUpdatesResponse_Releases{Releases: releases}}, nil
 }
 
 func (s *grpcServer) Get(ctx xctx.Context, req *service.GetRequest) (*service.GetResponse, error) {

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -112,7 +112,7 @@ func (s *server) GetServerInfo(ctx context.Context) (*service.ServerInfo, error)
 	return s.info, nil
 }
 
-func (s *server) CheckForUpdates(ctx context.Context, includeDevReleases bool) (*service.Release, error) {
+func (s *server) CheckForUpdates(ctx context.Context, includeDevReleases bool) (*service.Releases, error) {
 	ctx = status.Start(ctx, "RPC CheckForUpdates")
 	defer status.Finish(ctx)
 	ctx = log.Enter(ctx, "CheckForUpdates")

--- a/gapis/server/update.go
+++ b/gapis/server/update.go
@@ -1,0 +1,96 @@
+// Copyright (C) 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/messages"
+	"github.com/google/gapid/gapis/service"
+
+	"github.com/google/go-github/github"
+)
+
+const (
+	githubOrg     = "google"
+	githubRepo    = "agi"
+	devGithubRepo = "agi-dev-releases"
+)
+
+func checkForUpdates(ctx context.Context, includeDevReleases bool) (*service.Release, error) {
+	client := github.NewClient(nil)
+	options := &github.ListOptions{}
+	releases, _, err := client.Repositories.ListReleases(ctx, githubOrg, githubRepo, options)
+	if err != nil {
+		return nil, log.Err(ctx, err, "Failed to list releases")
+	}
+
+	if includeDevReleases {
+		devReleases, _, err := client.Repositories.ListReleases(ctx, githubOrg, devGithubRepo, options)
+		if err != nil {
+			return nil, log.Err(ctx, err, "Failed to list dev-releases")
+		}
+		releases = append(releases, devReleases...)
+	}
+
+	var mostRecent *service.Release
+	mostRecentVersion := app.Version
+	mostRecentDevVersion := app.Version.GetDevVersion()
+
+	for _, release := range releases {
+		// Filter out pre-releases
+		if release.GetPrerelease() {
+			continue
+		}
+
+		// tagName is either:
+		// Regular release: v<major>.<minor>.<point>
+		// Dev pre-release: v<major>.<minor>.<point>-dev-<dev>
+		var version app.VersionSpec
+		tagName := release.GetTagName()
+		devVersion := -1
+		numFields, err := fmt.Sscanf(tagName, "v%d.%d.%d-dev-%d", &version.Major, &version.Minor, &version.Point, &devVersion)
+		if err != nil && numFields < 3 {
+			// some non-release tags have other format, e.g. libinterceptor-v1.0
+			log.I(ctx, "Ignoring tag %s", tagName)
+			continue
+		}
+
+		// dev-releases are previews of the next release, so e.g. 1.2.3 is more recent than 1.2.3-dev-456
+		if version.GreaterThan(mostRecentVersion) ||
+			(version.Equal(mostRecentVersion) && mostRecentDevVersion != -1 && mostRecentDevVersion < devVersion) {
+			mostRecent = &service.Release{
+				Name:         release.GetName(),
+				VersionMajor: uint32(version.Major),
+				VersionMinor: uint32(version.Minor),
+				VersionPoint: uint32(version.Point),
+				Prerelease:   release.GetPrerelease(),
+				BrowserUrl:   release.GetHTMLURL(),
+			}
+			mostRecentVersion = version
+			mostRecentDevVersion = devVersion
+		}
+	}
+	if mostRecent == nil {
+		return nil, &service.ErrDataUnavailable{
+			Reason:    messages.NoNewBuildsAvailable(),
+			Transient: true,
+		}
+	}
+	return mostRecent, nil
+}

--- a/gapis/server/update.go
+++ b/gapis/server/update.go
@@ -16,6 +16,10 @@ package server
 
 import (
 	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
 
 	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/log"
@@ -29,9 +33,28 @@ const (
 	githubOrg     = "google"
 	githubRepo    = "agi"
 	devGithubRepo = "agi-dev-releases"
+	angleURL      = "https://agi-angle.storage.googleapis.com/"
+	angleJSON     = "current.json"
 )
 
-func checkForUpdates(ctx context.Context, includeDevReleases bool) (*service.Release, error) {
+func checkForUpdates(ctx context.Context, includeDevReleases bool) (*service.Releases, error) {
+	agi, err := checkForAGIUpdates(ctx, includeDevReleases)
+	if err != nil {
+		return nil, err
+	}
+
+	angle, err := checkForANGLEUpdates(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &service.Releases{
+		AGI:   agi,
+		ANGLE: angle,
+	}, nil
+}
+
+func checkForAGIUpdates(ctx context.Context, includeDevReleases bool) (*service.Releases_AGIRelease, error) {
 	client := github.NewClient(nil)
 	options := &github.ListOptions{}
 	releases, _, err := client.Repositories.ListReleases(ctx, githubOrg, githubRepo, options)
@@ -49,7 +72,7 @@ func checkForUpdates(ctx context.Context, includeDevReleases bool) (*service.Rel
 
 	version, release := getLastestRelease(ctx, releases)
 	if release != nil {
-		return &service.Release{
+		return &service.Releases_AGIRelease{
 			Name:         release.GetName(),
 			VersionMajor: uint32(version.Major),
 			VersionMinor: uint32(version.Minor),
@@ -60,7 +83,7 @@ func checkForUpdates(ctx context.Context, includeDevReleases bool) (*service.Rel
 	}
 	return nil, &service.ErrDataUnavailable{
 		Reason:    messages.NoNewBuildsAvailable(),
-		Transient: true,
+		Transient: false,
 	}
 }
 
@@ -85,4 +108,58 @@ func getLastestRelease(ctx context.Context, releases []*github.RepositoryRelease
 		}
 	}
 	return maxVersion, maxRelease
+}
+
+// This struct is used to parse JSON, so fields need to be public.
+type angleVersion struct {
+	Version uint32
+	Arm32   string
+	Arm64   string
+	X86     string
+}
+
+func checkForANGLEUpdates(ctx context.Context) (*service.Releases_ANGLERelease, error) {
+	base, _ := url.Parse(angleURL)
+
+	jsonURL, _ := base.Parse(angleJSON)
+	res, err := http.Get(jsonURL.String())
+	if err != nil {
+		return nil, &service.ErrDataUnavailable{
+			Reason:    messages.ErrInternalError(err),
+			Transient: true,
+		}
+	}
+	data, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+	if err != nil {
+		return nil, &service.ErrDataUnavailable{
+			Reason:    messages.ErrInternalError(err),
+			Transient: true,
+		}
+	}
+
+	var version angleVersion
+	if err := json.Unmarshal(data, &version); err != nil {
+		return nil, &service.ErrDataUnavailable{
+			Reason:    messages.ErrInternalError(err),
+			Transient: false,
+		}
+	}
+
+	arm32, _ := base.Parse(version.Arm32)
+	arm64, _ := base.Parse(version.Arm64)
+	x86, _ := base.Parse(version.X86)
+	if arm32 == nil || arm64 == nil || x86 == nil {
+		return nil, &service.ErrDataUnavailable{
+			Reason:    messages.NoNewBuildsAvailable(),
+			Transient: false,
+		}
+	}
+
+	return &service.Releases_ANGLERelease{
+		Version: version.Version,
+		Arm_32:  arm32.String(),
+		Arm_64:  arm64.String(),
+		X86:     x86.String(),
+	}, nil
 }

--- a/gapis/server/update.go
+++ b/gapis/server/update.go
@@ -48,13 +48,13 @@ func checkForUpdates(ctx context.Context, includeDevReleases bool) (*service.Rel
 	}
 
 	version, release := getLastestRelease(ctx, releases)
-	if release != nil && version.GreaterThanDevVersion(app.Version) {
+	if release != nil {
 		return &service.Release{
 			Name:         release.GetName(),
 			VersionMajor: uint32(version.Major),
 			VersionMinor: uint32(version.Minor),
 			VersionPoint: uint32(version.Point),
-			Prerelease:   release.GetPrerelease(),
+			VersionDev:   uint32(version.GetDevVersion()),
 			BrowserUrl:   release.GetHTMLURL(),
 		}, nil
 	}

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -56,10 +56,10 @@ type Service interface {
 	// GetServerInfo returns information about the running server.
 	GetServerInfo(ctx context.Context) (*ServerInfo, error)
 
-	// CheckForUpdates checks for a new build of GAPID on the hosting server.
+	// CheckForUpdates checks for a new build of AGI and ANGLE on the hosting servers.
 	// Care should be taken to call this infrequently to avoid reaching the
 	// server's maximum unauthenticated request limits.
-	CheckForUpdates(ctx context.Context, includeDevReleases bool) (*Release, error)
+	CheckForUpdates(ctx context.Context, includeDevReleases bool) (*Releases, error)
 
 	// GetAvailableStringTables returns list of available string table descriptions.
 	GetAvailableStringTables(ctx context.Context) ([]*stringtable.Info, error)

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -125,18 +125,30 @@ message CheckForUpdatesRequest {
 }
 message CheckForUpdatesResponse {
   oneof res {
-    Release release = 1;
+    Releases releases = 1;
     Error error = 2;
   }
 }
 
-message Release {
-  string name = 1;
-  uint32 version_major = 2;
-  uint32 version_minor = 3;
-  uint32 version_point = 4;
-  uint32 version_dev = 5;
-  string browser_url = 6;
+message Releases {
+  message AGIRelease {
+    string name = 1;
+    uint32 version_major = 2;
+    uint32 version_minor = 3;
+    uint32 version_point = 4;
+    uint32 version_dev = 5;
+    string browser_url = 6;
+  }
+
+  message ANGLERelease {
+    uint32 version = 1;
+    string arm_32 = 2;
+    string arm_64 = 3;
+    string x86 = 4;
+  }
+
+  AGIRelease AGI = 1;
+  ANGLERelease ANGLE = 2;
 }
 
 message GetRequest {

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -135,7 +135,7 @@ message Release {
   uint32 version_major = 2;
   uint32 version_minor = 3;
   uint32 version_point = 4;
-  bool prerelease = 5;
+  uint32 version_dev = 5;
   string browser_url = 6;
 }
 


### PR DESCRIPTION
When checking for AGI updates, also check for new ANGLE versions. In the trace dialog, when selecting the ANGLE trace mode, if there is a new ANGLE version available, show a message to the user with a link to the APK download. Determines the link based off the device's ABI if possible, otherwise shows the ANGLE download landing page.

Bug: http://b/158696453