### PR TITLE
Add capture start time unit, remove MEC support flag

### DIFF
--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -280,8 +280,7 @@ public class TracerDialog {
       private static final int DURATION_PERFETTO_MAX = maxPerfetto.get();
       private static final String DURATION_FRAMES_UNIT = "Frames";
       private static final String DURATION_PERFETTO_UNIT = "Seconds";
-      private static final String MEC_LABEL_WARNING =
-          "NOTE: Mid-Execution capture for %s is experimental";
+      private static final String START_AT_TIME_UNIT = "Seconds";
       private static final String PERFETTO_LABEL = "Profile Config: ";
       // Quote 'GPU activity' in the warning message to match the config panel tickbox title.
       private static final String EMPTY_APP_WITH_RENDER_STAGE =
@@ -310,7 +309,7 @@ public class TracerDialog {
       private final Label durationLabel;
       private final Spinner duration;
       private final Label durationUnit;
-      private Label mecWarningLabel;
+      private final Label startUnit;
       private final Button withoutBuffering;
       private final Button hideUnknownExtensions;
       private final Button clearCache;
@@ -421,7 +420,8 @@ public class TracerDialog {
         startFrame = withLayoutData(createSpinner(durGroup, 100, 1, 999999),
             new GridData(SWT.FILL, SWT.TOP, false, false));
         startFrame.setVisible(false);
-        mecWarningLabel = createLabel(durGroup, "");
+        startUnit = createLabel(durGroup, START_AT_TIME_UNIT);
+        startUnit.setVisible(false);
 
         durationLabel = createLabel(durGroup, FRAMES_LABEL);
         durationLabel.setVisible(DURATION_FRAMES_MAX > 1);
@@ -506,18 +506,9 @@ public class TracerDialog {
         traceTarget.addBoxListener(SWT.Modify, e -> updateEmptyAppWithRenderStageWarning(models.settings));
 
         Listener mecListener = e -> {
-          TraceTypeCapabilities config = getSelectedApi();
-          boolean beginning = startType.getSelectionIndex() == StartType.Beginning.ordinal();
-          if (!beginning && config != null &&
-              config.getMidExecutionCaptureSupport() == Service.FeatureStatus.Experimental) {
-            mecWarningLabel.setText(String.format(MEC_LABEL_WARNING, config.getApi()));
-          } else {
-            mecWarningLabel.setText("");
-          }
-          mecWarningLabel.requestLayout();
-
           StartType start = StartType.values()[startType.getSelectionIndex()];
           startFrame.setVisible(start == StartType.Frame || start == StartType.Time);
+          startUnit.setVisible(start == StartType.Time);
         };
         api.getCombo().addListener(SWT.Selection, mecListener);
         startType.addListener(SWT.Selection, mecListener);
@@ -938,20 +929,18 @@ public class TracerDialog {
           options.addAllEnvironment(splitEnv(envVars.getText()));
         }
         int delay = 0;
-        if (config.getMidExecutionCaptureSupport() != Service.FeatureStatus.NotSupported) {
-          switch (start) {
-            case Time:
-              delay = startFrame.getSelection();
-              // $FALL-THROUGH$
-            case Manual:
-              options.setDeferStart(true);
-              break;
-            case Frame:
-              options.setStartFrame(startFrame.getSelection());
-              break;
-            default:
-              // Do nothing.
-          }
+        switch (start) {
+          case Time:
+            delay = startFrame.getSelection();
+            // $FALL-THROUGH$
+          case Manual:
+            options.setDeferStart(true);
+            break;
+          case Frame:
+            options.setStartFrame(startFrame.getSelection());
+            break;
+          default:
+            // Do nothing.
         }
         if (dev.config.getHasCache()) {
           trace.setClearCache(clearCache.getSelection());

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -1206,20 +1206,16 @@ message DeviceTraceConfiguration {
   bool has_cache = 7;
 }
 
-enum FeatureStatus {
-  NotSupported = 0;
-  Supported = 1;
-  Experimental = 2;
-}
-
 message TraceTypeCapabilities {
   // The type of trace this describes.
   TraceType type = 5;
   // What is the API this is for.
   string api = 1;
   reserved 2;
-  // Does this API support MEC.
-  FeatureStatus mid_execution_capture_support = 3;
+  // [deprecated] Does this API support MEC.
+  // This was used only for GLES.
+  // FeatureStatus mid_execution_capture_support = 3;
+  reserved 3;
   // Whether unsupported extensions can be enabled.
   bool can_enable_unsupported_extensions = 4;
   // Does this trace require starting an application.

--- a/gapis/trace/tracer/default_api_trace_options.go
+++ b/gapis/trace/tracer/default_api_trace_options.go
@@ -23,7 +23,6 @@ func VulkanTraceOptions() *service.TraceTypeCapabilities {
 	return &service.TraceTypeCapabilities{
 		Type:                           service.TraceType_Graphics,
 		Api:                            "Vulkan",
-		MidExecutionCaptureSupport:     service.FeatureStatus_Supported,
 		CanEnableUnsupportedExtensions: true,
 		RequiresApplication:            true,
 	}
@@ -34,7 +33,6 @@ func AngleTraceOptions() *service.TraceTypeCapabilities {
 	return &service.TraceTypeCapabilities{
 		Type:                           service.TraceType_Graphics,
 		Api:                            "OpenGL on ANGLE",
-		MidExecutionCaptureSupport:     service.FeatureStatus_Supported,
 		CanEnableUnsupportedExtensions: true,
 		RequiresApplication:            true,
 	}
@@ -44,7 +42,6 @@ func AngleTraceOptions() *service.TraceTypeCapabilities {
 func PerfettoTraceOptions() *service.TraceTypeCapabilities {
 	return &service.TraceTypeCapabilities{
 		Type:                           service.TraceType_Perfetto,
-		MidExecutionCaptureSupport:     service.FeatureStatus_Supported,
 		CanEnableUnsupportedExtensions: false,
 		RequiresApplication:            false,
 	}


### PR DESCRIPTION
Since AGI dropped GLES support, now all supported APIs support MEC, so
remove the mid_execution_capture_support flag which is now obsolete.

In the UI, this lets us refactor mecWarningLabel into a startUnit
label that is used to show the time unit (seconds) for "Time" capture
start type.

Bug: b/173098919
Test: manual