### PR TITLE
Install apk as queryable.

### DIFF
--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -125,6 +125,12 @@ func (b *binding) InstallAPK(ctx context.Context, path string, reinstall bool, g
 		// during installation. Before API 23, the flag did not exist.
 		args = append(args, "-g")
 	}
+	if b.Instance().GetConfiguration().GetOS().GetAPIVersion() >= 30 {
+		// Starting with API 30, non-system applications can not be queried by
+		// application targeting api level 30 by default. This flag allows the
+		// installed apk to be queryable.
+		args = append(args, "--force-queryable")
+	}
 	args = append(args, path)
 	return b.Command("install", args...).Run(ctx)
 }


### PR DESCRIPTION
Starting in Android 11 the package visibility is changed per
https://developer.android.com/training/basics/intents/package-visibility, for
applications that target Android 11 or beyond will no longer be able to query
all packages by default. This prevents our apk from being discovered in the
application process and hence the graphics environment is not properly set up
and the application process can not load any Vulkan layer or UGD inside the
apk. This patch adds --force-queryable as one of the args when apk is installed
to allow the apk to be queryable by other applications.

Bug: b/175513065, b/176101695
Test: Run with an application targets api 30, no AppFilters error