### PR TITLE
Make the linking between Profile, Performance, Command tabs more consistent.

### DIFF
--- a/gapic/src/main/com/google/gapid/models/Profile.java
+++ b/gapic/src/main/com/google/gapid/models/Profile.java
@@ -60,12 +60,14 @@ public class Profile
 
   private final Capture capture;
   private final CommandStream commands;
+  private int selectedGroupId;
 
   public Profile(
       Shell shell, Analytics analytics, Client client, Capture capture, Devices devices, CommandStream commands) {
     super(LOG, shell, analytics, client, Listener.class, capture, devices);
     this.capture = capture;
     this.commands = commands;
+    this.selectedGroupId = -1;
   }
 
   @Override
@@ -114,7 +116,10 @@ public class Profile
   }
 
   public void selectGroup(Service.ProfilingData.GpuSlices.Group group) {
-    listeners.fire().onGroupSelected(group);
+    if (group.getId() != selectedGroupId) {
+      selectedGroupId = group.getId();
+      listeners.fire().onGroupSelected(group);
+    }
   }
 
   public void linkCommandToGpuGroup(List<Long> commandIndex) {

--- a/gapic/src/main/com/google/gapid/perfetto/models/SliceTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/SliceTrack.java
@@ -245,6 +245,10 @@ public abstract class SliceTrack extends Track<SliceTrack.Data> {/*extends Track
     public final Set<Long> sliceKeys = Sets.newHashSet();
     private final String title;
 
+    public Slices(String title) {
+      this.title = title;
+    }
+
     public Slices(QueryEngine.Row row, ArgSet argset, String title) {
       this.title = title;
       this.add(row, argset);

--- a/gapic/src/main/com/google/gapid/views/PerformanceView.java
+++ b/gapic/src/main/com/google/gapid/views/PerformanceView.java
@@ -109,6 +109,7 @@ public class PerformanceView extends Composite
       if (items.length > 0) {
         PerfNode selection = (PerfNode)items[0].getData();
         models.profile.linkGpuGroupToCommand(selection.getGroup());
+        models.profile.selectGroup(selection.getGroup());
       }
     });
 

--- a/gapis/trace/android/adreno/profiling_data.go
+++ b/gapis/trace/android/adreno/profiling_data.go
@@ -165,7 +165,7 @@ func processGpuSlices(ctx context.Context, processor *perfetto.Processor, captur
 					groupId = int32(len(groupsMap))
 					group := &service.ProfilingData_GpuSlices_Group{
 						Id:     groupId,
-						Name:   fmt.Sprintf("RenderPass %v", uint64(renderPasses[i])),
+						Name:   fmt.Sprintf("RenderPass %v, RenderTarget %v", uint64(renderPasses[i]), uint64(renderTargets[i])),
 						Parent: parent,
 						Link:   &path.Command{Capture: capture, Indices: idx},
 					}

--- a/gapis/trace/android/mali/profiling_data.go
+++ b/gapis/trace/android/mali/profiling_data.go
@@ -155,21 +155,21 @@ func processGpuSlices(ctx context.Context, processor *perfetto.Processor, captur
 		if ok {
 			cb := uint64(commandBuffers[i])
 			key := api.CmdSubmissionKey{subOrder, cb, uint64(renderPasses[i]), uint64(renderTargets[i])}
-			if group, ok := groupsMap[key]; ok {
-				groupId = group.Id
-			} else if indices, ok := syncData.SubmissionIndices[key]; ok {
-				if names[i] == "vertex" || names[i] == "fragment" {
+			if names[i] == "vertex" || names[i] == "fragment" {
+				if group, ok := groupsMap[key]; ok {
+					groupId = group.Id
+				} else if indices, ok := syncData.SubmissionIndices[key]; ok {
 					parent := utils.FindParentGroup(ctx, subOrder, cb, groupsMap, syncData.SubmissionIndices, capture)
 					groupId = int32(len(groupsMap))
 					group := &service.ProfilingData_GpuSlices_Group{
 						Id:     groupId,
-						Name:   fmt.Sprintf("RenderPass %v", uint64(renderPasses[i])),
+						Name:   fmt.Sprintf("RenderPass %v, RenderTarget %v", uint64(renderPasses[i]), uint64(renderTargets[i])),
 						Parent: parent,
 						Link:   &path.Command{Capture: capture, Indices: indices[0]},
 					}
 					groupsMap[key] = group
-					names[i] = fmt.Sprintf("%v %v", group.Link.Indices, names[i])
 				}
+				names[i] = fmt.Sprintf("%v %v", groupsMap[key].Link.Indices, names[i])
 			}
 		} else {
 			log.W(ctx, "Encountered submission ID mismatch %v", v)


### PR DESCRIPTION
 - The linking relationship between them should be: A GPU group <-> a command in
 Command tab <-> a renderPass-renderTarget entry in Performance tab <-> one or several
 GPU slices in Profile tab.
 - This PR adds in the linking from Command & Performance tabs towards Profile tab, to make
 the above logic complete.
 - Fixes two label formatting issues.
 - Bug: b/174805176.