### PR TITLE
Add more logs when aborting AGI.

### DIFF
--- a/gapidapk/deviceinfo.go
+++ b/gapidapk/deviceinfo.go
@@ -124,6 +124,7 @@ func fetchDeviceInfo(ctx context.Context, d adb.Device) error {
 		cleanup = cleanup.Then(nextCleanup)
 		defer cleanup.Invoke(ctx)
 		if err != nil {
+			log.E(ctx, "Failed when settings up layers: %v", err)
 			return err
 		}
 

--- a/gapii/client/adb.go
+++ b/gapii/client/adb.go
@@ -145,7 +145,7 @@ func Start(ctx context.Context, p *android.InstalledPackage, a *android.Activity
 	log.I(ctx, "Setting up Layer")
 	cu, err := android.SetupLayers(ctx, d, p.Name, []string{gapidapk.PackageName(abi)}, []string{gapidapk.LayerName(true)})
 	if err != nil {
-		return nil, cleanup.Invoke(ctx), log.Err(ctx, err, "Setting up the layer")
+		return nil, cleanup.Invoke(ctx), log.Err(ctx, err, "Failed when setting up layers")
 	}
 	cleanup = cleanup.Then(cu)
 

--- a/gapis/perfetto/android/trace.go
+++ b/gapis/perfetto/android/trace.go
@@ -85,7 +85,7 @@ func SetupProfileLayersSource(ctx context.Context, d adb.Device, apk *android.In
 	nextCleanup, err := android.SetupLayers(ctx, d, apk.Name, packages, []string{})
 	cleanup = cleanup.Then(nextCleanup)
 	if err != nil {
-		return cleanup.Invoke(ctx), log.Err(ctx, err, "Failed to setup gpu.renderstages layer packages.")
+		return cleanup.Invoke(ctx), log.Err(ctx, err, "Failed to setup GPU activity producer environment.")
 	}
 	return cleanup, nil
 }


### PR DESCRIPTION
Layer setup is essentially setting up the settings global variables provided by
the settings provider. However, different OEMs may enforce extra permissions on
that due to security concerns, etc. Hence we must log the errors before AGI
aborts.

Bug: b/175579064