### PR TITLE
Faster Resource Handle to ID Map Creation

### DIFF
--- a/gapis/api/resource.go
+++ b/gapis/api/resource.go
@@ -58,12 +58,6 @@ type Resource interface {
 		r *path.ResolveConfig) error
 }
 
-// ResourceMeta represents resource with a state information obtained during building.
-type ResourceMeta struct {
-	Resources []Resource  // Resolved resource.
-	IDMap     ResourceMap // Map for resolved resources to ids.
-}
-
 // ReplaceCallback is called from SetResourceData to propagate changes to current command stream.
 type ReplaceCallback func(where uint64, with interface{})
 

--- a/gapis/api/vulkan/resources.go
+++ b/gapis/api/vulkan/resources.go
@@ -1035,8 +1035,10 @@ func (p GraphicsPipelineObjectʳ) ResourceData(ctx context.Context, s *api.Globa
 		}
 	}
 
-	resourceMeta, _ := resolve.ResourceMeta(ctx, nil, cmd, r)
-	resources := resourceMeta.IDMap
+	resources, err := resolve.ResourceIDMap(ctx, cmd, r)
+	if err != nil {
+		return nil, err
+	}
 
 	stages := []*api.Stage{
 		p.inputAssembly(cmd, drawCallInfo),
@@ -2037,11 +2039,14 @@ func (p ComputePipelineObjectʳ) ResourceData(ctx context.Context, s *api.Global
 		}
 	}
 
-	resourceMeta, _ := resolve.ResourceMeta(ctx, nil, cmd, r)
+	resources, err := resolve.ResourceIDMap(ctx, cmd, r)
+	if err != nil {
+		return nil, err
+	}
 
 	framebuffer.SetNil()
 
-	dataGroups := commonShaderDataGroups(ctx, s, cmd, resourceMeta.IDMap, boundDsets, dynamicOffsets, framebuffer,
+	dataGroups := commonShaderDataGroups(ctx, s, cmd, resources, boundDsets, dynamicOffsets, framebuffer,
 		p.UsedDescriptors().All(), VkShaderStageFlagBits_VK_SHADER_STAGE_COMPUTE_BIT,
 		map[uint32]StageData{0: p.Stage()})
 

--- a/gapis/resolve/requests_test.go
+++ b/gapis/resolve/requests_test.go
@@ -28,7 +28,6 @@ var _ = []database.Resolvable{
 	(*IndexLimitsResolvable)(nil),
 	(*ReportResolvable)(nil),
 	(*ResourceDataResolvable)(nil),
-	(*ResourceMetaResolvable)(nil),
 	(*ResourcesResolvable)(nil),
 	(*SetResolvable)(nil),
 	(*StateResolvable)(nil),

--- a/gapis/resolve/resolvables.proto
+++ b/gapis/resolve/resolvables.proto
@@ -105,12 +105,6 @@ message AllResourceDataResolvable {
   api.ResourceType type = 3;
 }
 
-message ResourceMetaResolvable {
-  repeated path.ID IDs = 1;
-  path.Command after = 2;
-  path.ResolveConfig config = 3;
-}
-
 message GlobalStateResolvable {
   path.GlobalState path = 1;
   path.ResolveConfig config = 2;

--- a/gapis/resolve/resource_meta.go
+++ b/gapis/resolve/resource_meta.go
@@ -24,12 +24,12 @@ import (
 )
 
 // ResourceMeta returns the metadata for the specified resource.
-func ResourceMeta(ctx context.Context, ids []*path.ID, after *path.Command, r *path.ResolveConfig) (*api.ResourceMeta, error) {
+func ResourceMeta(ctx context.Context, ids []*path.ID, after *path.Command, r *path.ResolveConfig) ([]api.Resource, error) {
 	obj, err := database.Build(ctx, &ResourceMetaResolvable{IDs: ids, After: after, Config: r})
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.ResourceMeta), nil
+	return obj.([]api.Resource), nil
 }
 
 // Resolve implements the database.Resolver interface.
@@ -51,11 +51,7 @@ func (r *ResourceMetaResolvable) Resolve(ctx context.Context) (interface{}, erro
 		}
 		values[i] = val
 	}
-	result := &api.ResourceMeta{
-		IDMap:     res.resourceMap,
-		Resources: values,
-	}
-	return result, nil
+	return values, nil
 }
 
 // ResourceIDMap returns the ResourceMap at the given command.

--- a/gapis/resolve/resource_meta.go
+++ b/gapis/resolve/resource_meta.go
@@ -25,24 +25,14 @@ import (
 
 // ResourceMeta returns the metadata for the specified resource.
 func ResourceMeta(ctx context.Context, ids []*path.ID, after *path.Command, r *path.ResolveConfig) ([]api.Resource, error) {
-	obj, err := database.Build(ctx, &ResourceMetaResolvable{IDs: ids, After: after, Config: r})
-	if err != nil {
-		return nil, err
-	}
-	return obj.([]api.Resource), nil
-}
-
-// Resolve implements the database.Resolver interface.
-func (r *ResourceMetaResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	resources, err := database.Build(ctx, &AllResourceDataResolvable{After: r.After, Config: r.Config})
+	resources, err := database.Build(ctx, &AllResourceDataResolvable{After: after, Config: r})
 	if err != nil {
 		return nil, err
 	}
 	res, ok := resources.(*ResolvedResources)
 	if !ok {
-		return nil, fmt.Errorf("Cannot resolve resources at command: %v", r.After)
+		return nil, fmt.Errorf("Cannot resolve resources at command: %v", after)
 	}
-	ids := r.IDs
 	values := make([]api.Resource, len(ids))
 	for i, id := range ids {
 		val, ok := res.resources[id.ID()]

--- a/gapis/resolve/set.go
+++ b/gapis/resolve/set.go
@@ -286,12 +286,14 @@ func change(ctx context.Context, p path.Node, val interface{}, r *path.ResolveCo
 }
 
 func changeResources(ctx context.Context, after *path.Command, ids []*path.ID, data []*api.ResourceData, r *path.ResolveConfig) (*path.Capture, error) {
-	meta, err := ResourceMeta(ctx, ids, after, r)
+	resources, err := ResourceMeta(ctx, ids, after, r)
 	if err != nil {
 		return nil, err
 	}
-	if len(meta.Resources) != len(ids) {
-		return nil, fmt.Errorf("Expected %d resource(s), got %d", len(ids), len(meta.Resources))
+
+	idMap, err := ResourceIDMap(ctx, after, r)
+	if err != nil {
+		return nil, err
 	}
 
 	cmdIdx := after.Indices[0]
@@ -324,12 +326,12 @@ func changeResources(ctx context.Context, after *path.Command, ids []*path.ID, d
 		return initialState.APIs[API]
 	}
 
-	for i, resource := range meta.Resources {
+	for i, resource := range resources {
 		if err := resource.SetResourceData(
 			ctx,
 			after,
 			data[i],
-			meta.IDMap,
+			idMap,
 			replaceCommands,
 			mutateInitialState,
 			r); err != nil {


### PR DESCRIPTION
To get this map, we do not need to resolve the resource data at the given command, but can use the global resource information and a little bit of logic to cover the handle re-use case to generate the mapping, when needed.

This gets rid of an extra mutate loop, when fetching the pipelines at a given command, i.e. speeds up command selection.