### PR TITLE
Prevent name clashes in Swarming tests

### DIFF
--- a/kokoro/linux/build-nightly.sh
+++ b/kokoro/linux/build-nightly.sh
@@ -18,6 +18,10 @@
 
 export SWARMING_TIMESTAMP=`date '+%Y%m%d-%H%M%S'`
 export SWARMING_TASK_PREFIX="Nightly_${SWARMING_TIMESTAMP}"
+# SWARMING_TEST_DIR must exists on x20 under agi/kokoro/swarming_nightly
+# (loaded by nightly.cfg) and must not be called "tests", to avoid clashing with
+# default tests loaded by common.cfg
+export SWARMING_TEST_DIR=${KOKORO_GFILE_DIR}/tests_nightly
 
 # We obtain the cumulated results from previous nightly runs through our x20
 # input, and we want to make sure to propagate those results event if the

--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -133,12 +133,17 @@ if [ -z "${SWARMING_TASK_PREFIX}" ] ; then
   export SWARMING_TASK_PREFIX="Kokoro_PR${KOKORO_GITHUB_PULL_REQUEST_NUMBER}"
 fi
 
+if [ -z "${SWARMING_TEST_DIR}" ] ; then
+  # By default, use the "tests" directory which is loaded by common.cfg
+  export SWARMING_TEST_DIR=${KOKORO_GFILE_DIR}/tests
+fi
+
 export SWARMING_AUTH_FLAG="--service-account-json=${KOKORO_KEYSTORE_DIR}/74894_kokoro_swarming_access_key"
 
 # Prepare Swarming files
 SWARMING_DIR=${SRC}/test/swarming
 cp -r bazel-bin/pkg ${SWARMING_DIR}/agi
-cp -r ${KOKORO_GFILE_DIR}/tests ${SWARMING_DIR}/tests
+cp -r ${SWARMING_TEST_DIR} ${SWARMING_DIR}/tests
 
 # Swarming environment
 


### PR DESCRIPTION
There was a risk of name clashes in Swarming tests.

Swarming tests are retrieved from x20 via Kokoro "gfile_resources"
entries, which all end up under ${KOKORO_GFILE_DIR} on the CI VM. In
kokoro/linux/common.cfg, the gfile_resource entry loads the default
tests, in kokoro/linux/nightly.cfg it loads the nightly ones. By
convention, we used to use the same "tests" subdirectory name on x20,
such that the code in build.sh could always rely on tests being
present in ${KOKORO_GFILE_DIR}/tests. However, this can lead to issues
when there are name clashes between test directories.

For instance, consider these tests on x20:

.../swarming/tests/foobar         # default tests contain a foobar test
.../swarming_nightly/tests/foobar # nightly tests also contain a foobar test

For a nightly build, Kokoro starts by processing common.cfg and copies
swarming/tests/foobar into ${KOKORO_GFILE_DIR}/tests/foobar, then it
moves on to nightly.cfg but this time it cannot copy
swarming_nightly/tests/foobar since there is already a "tests/foobar"
directory exisiting in ${KOKORO_GFILE_DIR}.

To prevent this, we make sure to use distinct test directory names for
default tests ("tests") and nightly tests ("test_nightly").

Bug: b/176805511