### PR TITLE
Remove the libc++ Android toolchain alias.

### DIFF
--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -334,12 +334,6 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
             locals = locals,
         )
 
-        # Use the LLVM libc++ Android toolchain.
-        native.bind(
-            name = "android/crosstool",
-            actual = "@androidndk//:toolchain-libcpp",
-        )
-
     if mingw:
         cc_configure()
 


### PR DESCRIPTION
The libc++ toolchain is now the default and only toolchain in the NDK.