### PR TITLE
Simplify the apic_template rules to only generate code.

### DIFF
--- a/gapis/api/templates/BUILD.bazel
+++ b/gapis/api/templates/BUILD.bazel
@@ -68,22 +68,6 @@ api_template(
         "api_state.go",
     ],
     template = "api.go.tmpl",
-    deps = [
-        "//core/data:go_default_library",
-        "//core/data/binary:go_default_library",
-        "//core/data/dictionary:go_default_library",
-        "//core/data/id:go_default_library",
-        "//core/math/u64:go_default_library",
-        "//core/os/device:go_default_library",
-        "//gapis/api:go_default_library",
-        "//gapis/capture:go_default_library",
-        "//gapis/memory:go_default_library",
-        "//gapis/replay:go_default_library",
-        "//gapis/replay/builder:go_default_library",
-        "//gapis/replay/protocol:go_default_library",
-        "//gapis/replay/value:go_default_library",
-        "//gapis/service/path:go_default_library",
-    ],
 )
 
 api_template(

--- a/gapis/api/test/BUILD.bazel
+++ b/gapis/api/test/BUILD.bazel
@@ -33,7 +33,6 @@ apic_template(
         "//gapis/api/templates:mutate",
         "//gapis/api/templates:constant_sets",
         "//gapis/api/templates:convert",
-        "//gapis/api/templates:proto",
     ],
     visibility = ["//visibility:public"],
 )
@@ -44,24 +43,31 @@ go_library(
         "doc.go",
         "helpers.go",
         "test.go",
-    ],
-    embed = [
         ":generated",  # keep
     ],
     importpath = "github.com/google/gapid/gapis/api/test",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/data:go_default_library",  # keep
+        "//core/data/binary:go_default_library",  # keep
         "//core/data/compare:go_default_library",
+        "//core/data/id:go_default_library",  # keep
         "//core/data/protoconv:go_default_library",  # keep
         "//core/event/task:go_default_library",  # keep
         "//core/log:go_default_library",  # keep
         "//core/math/interval:go_default_library",
+        "//core/math/u64:go_default_library",  # keep
+        "//core/os/device:go_default_library",  # keep
         "//gapil/constset:go_default_library",  # keep
         "//gapis/api:go_default_library",
         "//gapis/api/test/test_pb:go_default_library",  # keep
         "//gapis/memory:go_default_library",
         "//gapis/memory/memory_pb:go_default_library",  # keep
         "//gapis/messages:go_default_library",  # keep
+        "//gapis/replay:go_default_library",  # keep
+        "//gapis/replay/builder:go_default_library",  # keep
+        "//gapis/replay/protocol:go_default_library",  # keep
+        "//gapis/replay/value:go_default_library",  # keep
         "//gapis/service/path:go_default_library",
         "//gapis/service/types:go_default_library",  # keep
         "//gapis/stringtable:go_default_library",  # keep

--- a/gapis/api/vulkan/BUILD.bazel
+++ b/gapis/api/vulkan/BUILD.bazel
@@ -50,7 +50,6 @@ apic_template(
         "//gapis/api/templates:mutate",
         "//gapis/api/templates:constant_sets",
         "//gapis/api/templates:convert",
-        "//gapis/api/templates:proto",
         "//gapis/api/templates:state_serialize",
     ],
     visibility = ["//visibility:public"],
@@ -109,15 +108,16 @@ go_library(
         "transform_wait_for_perfetto.go",
         "transform_wireframe.go",
         "vulkan.go",
+        ":generated",  # keep
     ],
     embed = [
-        ":generated",  # keep
         ":vulkan_go_proto",
     ],
     importpath = "github.com/google/gapid/gapis/api/vulkan",
     visibility = ["//visibility:public"],
     deps = [
         "//core/app/status:go_default_library",
+        "//core/data:go_default_library",  # keep
         "//core/data/binary:go_default_library",
         "//core/data/dictionary:go_default_library",
         "//core/data/endian:go_default_library",
@@ -129,6 +129,7 @@ go_library(
         "//core/image/astc:go_default_library",
         "//core/log:go_default_library",
         "//core/math/interval:go_default_library",
+        "//core/math/u64:go_default_library",  # keep
         "//core/os/device:go_default_library",
         "//core/stream:go_default_library",
         "//core/stream/fmts:go_default_library",

--- a/tools/build/rules/gapil.bzl
+++ b/tools/build/rules/gapil.bzl
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go:def.bzl",
-    "go_context",
-    "GoLibrary",
-)
-
 ApicTemplate = provider()
 
 def _api_library_impl(ctx):
@@ -50,11 +45,7 @@ api_library = rule(
 )
 
 def _api_template_impl(ctx):
-    go = go_context(ctx)
-    library = go.new_library(go)
     return [
-        library,
-        go.library_to_source(go, ctx.attr, library, False),
         ApicTemplate(
             main = ctx.file.template,
             uses = depset([ctx.file.template] + ctx.files.includes),
@@ -71,8 +62,5 @@ api_template = rule(
         ),
         "includes": attr.label_list(allow_files = True),
         "outputs": attr.string_list(),
-        "deps": attr.label_list(providers = [GoLibrary]),
-        "_go_context_data": attr.label(default=Label("@io_bazel_rules_go//:go_context_data")),
     },
-    toolchains = ["@io_bazel_rules_go//go:toolchain"],
 )


### PR DESCRIPTION
Instead of also trying to compile go code if any is generated. This removes all the go toolchain deps when generating non-go code.

Also removed the deps attribute from the templates as it's no longer used and dependencies need to be added to the rule that compiles the generated code.