### PR TITLE
Faster Pipeline Resolve

### DIFF
--- a/gapic/src/main/com/google/gapid/util/Paths.java
+++ b/gapic/src/main/com/google/gapid/util/Paths.java
@@ -251,7 +251,7 @@ public class Paths {
     }
     return Path.Any.newBuilder()
         .setPipelines(Path.Pipelines.newBuilder()
-            .setAfter(command.getNode()))
+            .setCommandTreeNode(command.getNode()))
         .build();
   }
 

--- a/gapis/api/BUILD.bazel
+++ b/gapis/api/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "labeled.go",
         "memory_breakdown.go",
         "mesh.go",
+        "pipeline.go",
         "property.go",
         "reference.go",
         "resource.go",

--- a/gapis/api/pipeline.go
+++ b/gapis/api/pipeline.go
@@ -1,0 +1,40 @@
+// Copyright (C) 2021 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/gapid/gapis/service/path"
+)
+
+var (
+	// ErrPipelineNotAvailable is an error returned by PipelineProvider if the
+	// pipelines are requested on an object that does not have pipelines.
+	ErrPipelineNotAvailable = errors.New("Pipelines not available at this command")
+)
+
+// BoundPipeline represents a pipeline resource and its data currently bound.
+type BoundPipeline struct {
+	Pipeline Resource
+	Data     *ResourceData
+}
+
+// PipelineProvider is the interface implemented by types that provide pipelines.
+type PipelineProvider interface {
+	// BoundPipeline returns the pipeline bound at object o.
+	BoundPipeline(ctx context.Context, o interface{}, p *path.Pipelines, r *path.ResolveConfig) (BoundPipeline, error)
+}

--- a/gapis/api/vulkan/BUILD.bazel
+++ b/gapis/api/vulkan/BUILD.bazel
@@ -64,6 +64,7 @@ go_library(
         "custom_replay.go",
         "doc.go",
         "draw_call_mesh.go",
+        "draw_call_pipeline.go",
         "externs.go",
         "extras.go",
         "frame_loop.go",

--- a/gapis/api/vulkan/draw_call_pipeline.go
+++ b/gapis/api/vulkan/draw_call_pipeline.go
@@ -1,0 +1,77 @@
+// Copyright (C) 2021 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vulkan
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/api"
+	"github.com/google/gapid/gapis/resolve"
+	"github.com/google/gapid/gapis/service/path"
+)
+
+// drawCallPipeline returns the bound pipeline for dc at p.
+func drawCallPipeline(ctx context.Context, dc *VkQueueSubmit, p *path.Pipelines, r *path.ResolveConfig) (api.BoundPipeline, error) {
+	bound := api.BoundPipeline{}
+	cmdPath := path.FindCommand(p)
+	if cmdPath == nil {
+		log.W(ctx, "Couldn't find command at path '%v'", p)
+		return bound, api.ErrPipelineNotAvailable
+	}
+
+	cmd, err := resolve.Cmd(ctx, cmdPath, r)
+	if err != nil {
+		return bound, err
+	}
+
+	if !cmd.CmdFlags().IsExecutedDraw() && !cmd.CmdFlags().IsExecutedDispatch() {
+		return bound, api.ErrPipelineNotAvailable
+	}
+
+	s, err := resolve.GlobalState(ctx, cmdPath.GlobalStateAfter(), r)
+	if err != nil {
+		return bound, err
+	}
+
+	c := getStateObject(s)
+
+	lastQueue := c.LastBoundQueue()
+	if lastQueue.IsNil() {
+		return bound, fmt.Errorf("No previous queue submission")
+	}
+
+	if cmd.CmdFlags().IsExecutedDraw() {
+		lastDrawInfo, ok := c.LastDrawInfos().Lookup(lastQueue.VulkanHandle())
+		if !ok {
+			return bound, fmt.Errorf("There have been no previous draws")
+		}
+		bound.Pipeline = lastDrawInfo.GraphicsPipeline()
+	} else {
+		lastComputeInfo, ok := c.LastComputeInfos().Lookup(lastQueue.VulkanHandle())
+		if !ok {
+			return bound, fmt.Errorf("There have been no previous dispatches")
+		}
+		bound.Pipeline = lastComputeInfo.ComputePipeline()
+	}
+
+	if bound.Pipeline == nil {
+		return bound, api.ErrPipelineNotAvailable
+	}
+
+	bound.Data, err = bound.Pipeline.ResourceData(ctx, s, cmdPath, r)
+	return bound, err
+}

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -144,6 +144,18 @@ func (API) Mesh(ctx context.Context, o interface{}, p *path.Mesh, r *path.Resolv
 	return nil, api.ErrMeshNotAvailable
 }
 
+// Interface check.
+var _ api.PipelineProvider = &API{}
+
+// BoundPipeline implements the api.PipelineProvider interface.
+func (API) BoundPipeline(ctx context.Context, o interface{}, p *path.Pipelines, r *path.ResolveConfig) (api.BoundPipeline, error) {
+	switch dc := o.(type) {
+	case *VkQueueSubmit:
+		return drawCallPipeline(ctx, dc, p, r)
+	}
+	return api.BoundPipeline{}, api.ErrPipelineNotAvailable
+}
+
 type MarkerType int
 
 const (

--- a/gapis/resolve/BUILD.bazel
+++ b/gapis/resolve/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "memory.go",
         "mesh.go",
         "metrics.go",
+        "pipeline.go",
         "report.go",
         "resolve.go",
         "resource_data.go",

--- a/gapis/resolve/pipeline.go
+++ b/gapis/resolve/pipeline.go
@@ -1,0 +1,91 @@
+// Copyright (C) 2021 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolve
+
+import (
+	"context"
+
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/api"
+	"github.com/google/gapid/gapis/messages"
+	"github.com/google/gapid/gapis/service"
+	"github.com/google/gapid/gapis/service/path"
+)
+
+// Pipelines resolves the data of the currently bound pipelines at the specified
+// point in the capture.
+func Pipelines(ctx context.Context, p *path.Pipelines, r *path.ResolveConfig) (interface{}, error) {
+	obj, err := ResolveInternal(ctx, p.Parent(), r)
+	if err != nil {
+		return nil, err
+	}
+
+	if pipelines, err := pipelinesFor(ctx, obj, p, r); err != api.ErrPipelineNotAvailable {
+		return pipelines, err
+	}
+	return nil, &service.ErrDataUnavailable{Reason: messages.ErrNotADrawCall()}
+}
+
+func pipelinesFor(ctx context.Context, o interface{}, p *path.Pipelines, r *path.ResolveConfig) (interface{}, error) {
+	switch o := o.(type) {
+	case api.APIObject:
+		if a := o.API(); a != nil {
+			if pp, ok := a.(api.PipelineProvider); ok {
+				bound, err := pp.BoundPipeline(ctx, o, p, r)
+				if err != nil {
+					return nil, err
+				}
+				return &service.MultiResourceData{
+					Resources: map[string]*service.MultiResourceData_ResourceOrError{
+						bound.Pipeline.ResourceHandle(): &service.MultiResourceData_ResourceOrError{
+							Val: &service.MultiResourceData_ResourceOrError_Resource{
+								Resource: bound.Data,
+							},
+						},
+					},
+				}, nil
+			}
+		}
+
+	case *service.CommandTreeNode:
+		cmds, err := Cmds(ctx, o.Commands.Capture)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(o.Commands.From) != len(o.Commands.To) {
+			return nil, log.Errf(ctx, nil, "Subcommand indices must be the same length")
+		}
+
+		lastSubcommand := len(o.Commands.From) - 1
+		for i := 0; i < lastSubcommand; i++ {
+			if o.Commands.From[i] != o.Commands.To[i] {
+				return nil, log.Errf(ctx, nil, "Subcommand ranges must be identical everywhere but the last element")
+			}
+		}
+
+		cmd := append([]uint64{}, o.Commands.From...) // make a copy of o.Commands.From
+		for i := o.Commands.To[lastSubcommand]; i >= o.Commands.From[lastSubcommand]; i-- {
+			cmd[lastSubcommand] = i
+			p := o.Commands.Capture.Command(cmd[0], cmd[1:]...).Pipelines()
+			if pl, err := pipelinesFor(ctx, cmds[o.Commands.From[0]], p, r); err != api.ErrPipelineNotAvailable {
+				return pl, err
+			}
+		}
+
+		return nil, &service.ErrDataUnavailable{Reason: messages.ErrNotADrawCall()}
+	}
+	return nil, nil
+}

--- a/gapis/resolve/resolvables.proto
+++ b/gapis/resolve/resolvables.proto
@@ -89,11 +89,6 @@ message ResourcesResolvable {
   path.ResolveConfig config = 2;
 }
 
-message PipelinesResolvable {
-  path.Command after = 1;
-  path.ResolveConfig config = 2;
-}
-
 message AllResourceDataResolvable {
   path.Command after = 1;
   path.ResolveConfig config = 2;

--- a/gapis/resolve/resource_data.go
+++ b/gapis/resolve/resource_data.go
@@ -25,7 +25,6 @@ import (
 	"github.com/google/gapid/gapis/api/sync"
 	"github.com/google/gapid/gapis/capture"
 	"github.com/google/gapid/gapis/database"
-	"github.com/google/gapid/gapis/messages"
 	"github.com/google/gapid/gapis/resolve/initialcmds"
 	"github.com/google/gapid/gapis/service"
 	"github.com/google/gapid/gapis/service/path"
@@ -203,83 +202,4 @@ func ResourceDatas(ctx context.Context, p *path.MultiResourceData, r *path.Resol
 		}
 	}
 	return &service.MultiResourceData{Resources: m}, nil
-}
-
-// Pipelines resolves the data of the currently bound pipelines at the specified
-// point in the capture.
-func Pipelines(ctx context.Context, p *path.Pipelines, r *path.ResolveConfig) (interface{}, error) {
-	ctn, err := CommandTreeNode(ctx, p.After, r)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(ctn.Commands.From) != len(ctn.Commands.To) {
-		return nil, log.Errf(ctx, nil, "Subcommand indices must be the same length")
-	}
-
-	lastSubcommand := len(ctn.Commands.From) - 1
-	for i := 0; i < lastSubcommand; i++ {
-		if ctn.Commands.From[i] != ctn.Commands.To[i] {
-			return nil, log.Errf(ctx, nil, "Subcommand ranges must be identical everywhere but the last element")
-		}
-	}
-
-	cmd := append([]uint64{}, ctn.Commands.From...) // make a copy of ctn.Commands.From
-	for i := ctn.Commands.To[lastSubcommand]; i >= ctn.Commands.From[lastSubcommand]; i-- {
-		cmd[lastSubcommand] = i
-		c := ctn.Commands.Capture.Command(cmd[0], cmd[1:]...)
-
-		currentCmd, err := Cmd(ctx, c, r)
-		if err != nil {
-			return nil, err
-		}
-
-		if currentCmd.CmdFlags().IsExecutedDraw() || currentCmd.CmdFlags().IsExecutedDispatch() {
-			obj, err := database.Build(ctx, &PipelinesResolvable{After: c, Config: r})
-			if err != nil {
-				return nil, err
-			}
-			return obj, nil
-		}
-	}
-
-	return nil, &service.ErrDataUnavailable{Reason: messages.ErrNotADrawCall()}
-}
-
-// Resolve implements the database.Resolver interface.
-func (r *PipelinesResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	resources, err := database.Build(ctx, &AllResourceDataResolvable{
-		After:  r.After,
-		Type:   path.ResourceType_Pipeline,
-		Config: r.Config,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	res, ok := resources.(*ResolvedResources)
-	if !ok {
-		return nil, fmt.Errorf("Cannot resolve resources at command: %v", r.After)
-	}
-
-	pipelines := map[string]*service.MultiResourceData_ResourceOrError{}
-	for id, val := range res.resourceData {
-		switch v := val.(type) {
-		case error:
-			pipelines[id.String()] = &service.MultiResourceData_ResourceOrError{
-				Val: &service.MultiResourceData_ResourceOrError_Error{
-					Error: service.NewError(v),
-				},
-			}
-		case *api.ResourceData:
-			if p := v.GetPipeline(); p.GetBound() {
-				pipelines[id.String()] = &service.MultiResourceData_ResourceOrError{
-					Val: &service.MultiResourceData_ResourceOrError_Resource{
-						Resource: v,
-					},
-				}
-			}
-		}
-	}
-	return &service.MultiResourceData{Resources: pipelines}, nil
 }

--- a/gapis/service/path/path.proto
+++ b/gapis/service/path/path.proto
@@ -456,10 +456,13 @@ message Metrics {
   bool memory_breakdown = 2;
 }
 
-// Pipelines requests the currently bound piplines for a given command.
+// Pipelines requests the currently bound pipelines for a given command.
 message Pipelines {
-  // The command after which to get the currently bound piplines.
-  CommandTreeNode after = 2;
+  // The object at which to get the pipelines.
+  oneof object {
+    Command command = 1;
+    CommandTreeNode command_tree_node = 2;
+  }
 }
 
 // Report is a path to a list of report items for a capture.

--- a/gapis/service/path/validate.go
+++ b/gapis/service/path/validate.go
@@ -255,7 +255,7 @@ func (n *Parameter) Validate() error {
 
 // Validate checks the path is valid.
 func (n *Pipelines) Validate() error {
-	return checkNotNilAndValidate(n, n.After, "after")
+	return checkNotNilAndValidate(n, protoutil.OneOf(n.Object), "object")
 }
 
 // Validate checks the path is valid.


### PR DESCRIPTION
Instead of resolving the bound pipelines by getting all Pipeline resource datas and then filtering to the bound ones, use the state to find the bound pipelines. This avoids having to do another mutate run to resolve all the pipeline resource datas, most of which are then summarily ignored.

For a resource heavy trace, this brings the time it takes to get the bound pipelines on command selection in the UI from ~5 seconds to well below one second.