### PR TITLE
Fix possible segfault in mali.processGpuSlices (wrong map access)

### DIFF
--- a/gapis/trace/android/mali/profiling_data.go
+++ b/gapis/trace/android/mali/profiling_data.go
@@ -168,8 +168,8 @@ func processGpuSlices(ctx context.Context, processor *perfetto.Processor, captur
 						Link:   &path.Command{Capture: capture, Indices: indices[0]},
 					}
 					groupsMap[key] = group
+					names[i] = fmt.Sprintf("%v %v", groupsMap[key].Link.Indices, names[i])
 				}
-				names[i] = fmt.Sprintf("%v %v", groupsMap[key].Link.Indices, names[i])
 			}
 		} else {
 			log.W(ctx, "Encountered submission ID mismatch %v", v)


### PR DESCRIPTION
This code was recently refactored with commit
de97b2dfe310422e1667e93b2e34c7e607d77c56, where a bug sneaked in:
`key` may not be present in groupsMap here, posing a risk of segfault
when groupsMap[key].Link.Indices is accessed. In fact, this name[i]
assignment is meant to be included in the above block, where
groupsMap[key] is being defined.

Bug: b/176958438

Test: manual, 'gapit profile' on a trace that always triggered this
segfault. This is caught by the per-PR swarming tests, that were
unfortunately disabled (because a swarming bot was down) when the
offending commit was merged.