### PR TITLE
Don't ignore errors from running the smoketests.

### DIFF
--- a/cmd/smoketests/main.go
+++ b/cmd/smoketests/main.go
@@ -198,7 +198,10 @@ func gapit(ctx context.Context, nbErr *int, gapitPath string, args ...string) er
 		if _, ok := err.(*exec.ExitError); ok {
 			// Here the gapit command raised an error
 			fmt.Printf("FAIL %s\n", printCmd)
-			*nbErr += 1
+			fmt.Println("===============================================")
+			fmt.Println(output)
+			fmt.Println("===============================================")
+			*nbErr++
 		} else {
 			// Here the error comes from somewhere else
 			return err

--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -74,21 +74,12 @@ build //:pkg //:symbols
 build //cmd/vulkan_sample:vulkan_sample
 
 # Build and run the smoketests.
-set +e
 build //cmd/smoketests:smoketests
 echo $(date): Run smoketests...
 # Using "bazel run //cmd/smoketests seems to make 'bazel-bin/pkg/gapit'
 # disappear, hence we call the binary directly
 bazel-bin/cmd/smoketests/linux_amd64_stripped/smoketests -gapit bazel-bin/pkg/gapit -traces test/traces
-for i in smoketests.*/*/*.log
-do
-  echo "============================================================"
-  echo $i
-  cat $i
-done
 echo $(date): Smoketests completed.
-
-set -e
 
 # Build the release packages.
 mkdir $BUILD_ROOT/out


### PR DESCRIPTION
And have the smoketest binary emit the log of failed tests.