### PR TITLE
Disable the UI error pop-up window for a known SWT issue.

### DIFF
--- a/gapic/src/main/com/google/gapid/Main.java
+++ b/gapic/src/main/com/google/gapid/Main.java
@@ -125,7 +125,9 @@ public class Main {
 
         LOG.log(Level.WARNING, "Unhandled exception in the UI thread.", thrown);
         handler.reportException(thrown);
-        showErrorDialog(null, getAnalytics(), "Unhandled exception in the UI thread.", thrown);
+        if (shouldShowUIErrorDialog(thrown)) {
+          showErrorDialog(null, getAnalytics(), "Unhandled exception in the UI thread.", thrown);
+        }
       });
     }
 
@@ -214,6 +216,16 @@ public class Main {
 
     private Analytics getAnalytics() {
       return (models == null) ? null : models.analytics;
+    }
+
+    private boolean shouldShowUIErrorDialog(Throwable throwable) {
+      // TODO b/178397207: Disable error dialog for a known UI issue, while waiting solution from the SWT side.
+      if (OS.isMac && throwable != null && throwable.getStackTrace().length > 0
+          && "org.eclipse.swt.widgets.Widget".equals(throwable.getStackTrace()[0].getClassName())
+          && "drawRect".equals(throwable.getStackTrace()[0].getMethodName())) {
+        return false;
+      }
+      return true;
     }
 
     private static interface ShellRunnable {


### PR DESCRIPTION
There's a known SWT's compatibility issue with macOS Big Sur, a more
detailed context could be found in the bug ticket. Based on testing,
this NPE UI error triggered by GlCanvas object is not that harmful: it
will not break gapis and hang the AGI session, nor will the rendering
get affected. But the error dialog which keeps popping up is a bit annoying.
This commit will suppress the dialog popping for this bug, while the error
stack trace will still get printed into terminal and log file silently.

Bug: b/178397207.