### PR TITLE
Fixed tab menu item sync

### DIFF
--- a/gapic/src/main/com/google/gapid/GraphicsTraceView.java
+++ b/gapic/src/main/com/google/gapid/GraphicsTraceView.java
@@ -227,8 +227,10 @@ public class GraphicsTraceView extends Composite
 
   protected void syncTabMenuItem(MainTab.Type type, boolean shown) {
     Action action = typeActions.get(type);
-    if (action != null && action.isChecked() != shown) {
+    if (action != null) {
       action.setChecked(shown);
+    }
+    if (hiddenTabs.contains(type) == shown) {
       if (shown) {
         hiddenTabs.remove(type);
       } else {


### PR DESCRIPTION
When a tab was opened or closed from the menu, the menu item check is already in sync when the function syncTabMenuItem is called, so the hiddenTabs were not updated. To fix this, the menu item check and the hiddenTabs are now synced separately.

Fixes b/178501229