### PR TITLE
Fix pinned status for shader tab

### DIFF
--- a/gapic/src/main/com/google/gapid/views/ShaderView.java
+++ b/gapic/src/main/com/google/gapid/views/ShaderView.java
@@ -177,7 +177,7 @@ public class ShaderView extends Composite
 
   @Override
   public boolean isPinnable() {
-    return shaderResource != null;
+    return !pinned && shaderResource != null;
   }
 
   @Override


### PR DESCRIPTION
Fixes the pinned icon for shader tab, which was visible when the tab was already pinned.