### PR TITLE
Add early minimal version of frame boundary extension

### DIFF
--- a/gapii/cc/call_observer.cpp
+++ b/gapii/cc/call_observer.cpp
@@ -50,7 +50,8 @@ CallObserver::CallObserver(SpyBase* spy, CallObserver* parent, uint8_t api)
       mObserveApplicationPool(spy->shouldObserveApplicationPool()),
       mApi(api),
       mShouldTrace(false),
-      mCurrentThread(core::Thread::current().id()) {
+      mCurrentThread(core::Thread::current().id()),
+      mEndOfFrame(false) {
   // context_t initialization.
   this->context_t::id = 0;
   this->context_t::next_pool_id = &spy->next_pool_id();

--- a/gapii/cc/call_observer.h
+++ b/gapii/cc/call_observer.h
@@ -183,10 +183,10 @@ class CallObserver : public context_t {
   void observeTimestamp();
 
   // setEndOfFrame marks this call as being an end of frame.
-  void setEndOfFrame() { mEndOfFrame = true; };
+  void setEndOfFrame() { mEndOfFrame = true; }
 
   // getEndOfFrame returns true if this call is marked as an end of frame.
-  bool getEndOfFrame() { return mEndOfFrame; };
+  bool getEndOfFrame() { return mEndOfFrame; }
 
  private:
   // shouldObserve returns true if the given slice is located in application

--- a/gapii/cc/call_observer.h
+++ b/gapii/cc/call_observer.h
@@ -182,6 +182,12 @@ class CallObserver : public context_t {
   // observeTimestamp encodes a timestamp extra in the trace
   void observeTimestamp();
 
+  // setEndOfFrame marks this call as being an end of frame.
+  void setEndOfFrame() { mEndOfFrame = true; };
+
+  // getEndOfFrame returns true if this call is marked as an end of frame.
+  bool getEndOfFrame() { return mEndOfFrame; };
+
  private:
   // shouldObserve returns true if the given slice is located in application
   // pool and we are supposed to observe application pool.
@@ -229,6 +235,9 @@ class CallObserver : public context_t {
 
   // Callback invoked whenever slice_encoded() is called.
   OnSliceEncodedCallback mOnSliceEncoded;
+
+  // True if this call marks the end of a frame
+  bool mEndOfFrame;
 };
 
 template <typename T>

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -328,7 +328,12 @@ void Spy::onPreEndOfFrame(CallObserver* observer, uint8_t api) {
   mNumDrawsPerFrame = 0;
 }
 
-void Spy::onPostEndOfFrame() {
+void Spy::onPostEndOfFrame(CallObserver* observer) {
+  if (!observer->getEndOfFrame()) {
+    // Just a queue submission that does not mark the end of frame
+    return;
+  }
+
   mFrameNumber++;
   if (should_record_timestamps()) {
     std::stringstream fn;

--- a/gapii/cc/spy.h
+++ b/gapii/cc/spy.h
@@ -40,7 +40,7 @@ class Spy : public VulkanSpy {
 
   void onPostDrawCall(CallObserver* observer, uint8_t api) override;
   void onPreEndOfFrame(CallObserver* observer, uint8_t api) override;
-  void onPostEndOfFrame() override;
+  void onPostEndOfFrame(CallObserver* observer) override;
   void onPostFence(CallObserver* observer) override;
 
   inline void RegisterSymbol(const std::string& name, void* symbol) {

--- a/gapii/cc/spy_base.h
+++ b/gapii/cc/spy_base.h
@@ -161,7 +161,7 @@ class SpyBase {
   inline virtual void onPreEndOfFrame(CallObserver*, uint8_t) {}
 
   // onPostEndOfFrame is after any command annotated with @frame_end
-  inline virtual void onPostEndOfFrame() {}
+  inline virtual void onPostEndOfFrame(CallObserver* observer) {}
 
   // onPostFence is called immediately after the driver call.
   inline virtual void onPostFence(CallObserver* observer) {}

--- a/gapii/cc/vulkan_extras.cpp
+++ b/gapii/cc/vulkan_extras.cpp
@@ -472,6 +472,7 @@ void VulkanSpy::recordFenceReset(CallObserver*, uint64_t) {}
 void VulkanSpy::recordAcquireNextImage(CallObserver*, uint64_t, uint32_t) {}
 void VulkanSpy::recordPresentSwapchainImage(CallObserver*, uint64_t, uint32_t) {
 }
+
 void VulkanSpy::recordBeginCommandBuffer(CallObserver*, VkCommandBuffer) {}
 void VulkanSpy::recordEndCommandBuffer(CallObserver*, VkCommandBuffer) {}
 
@@ -842,6 +843,12 @@ uint32_t VulkanSpy::SpyOverride_vkEnumerateDeviceExtensionProperties(
     }
   }
 
+  // AGI implements VK_EXT_frame_boundary itself
+  char frame_boundary_extension_name[] = "VK_EXT_frame_boundary";
+  uint32_t frame_boundary_spec_version = 1;
+  all_properties.push_back(VkExtensionProperties{frame_boundary_extension_name,
+                                                 frame_boundary_spec_version});
+
   if (pProperties == NULL) {
     *pCount = all_properties.size();
     return VkResult::VK_SUCCESS;
@@ -1015,6 +1022,10 @@ void VulkanSpy::recordWaitedFences(CallObserver* observer, VkDevice device,
   }
 
   observer->encode_message(&state);
+}
+
+void VulkanSpy::frameBoundary(CallObserver* observer) {
+  observer->setEndOfFrame();
 }
 
 }  // namespace gapii

--- a/gapir/cc/context.cpp
+++ b/gapir/cc/context.cpp
@@ -295,7 +295,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
           auto pCreateInfo = stack->pop<Vulkan::VkDeviceCreateInfo*>();
           auto physicalDevice = static_cast<size_val>(stack->pop<size_val>());
           if (!stack->isValid()) {
-            GAPID_ERROR("Error during calling funtion ReplayCreateVkDevice");
+            GAPID_ERROR("Error during calling function ReplayCreateVkDevice");
             return false;
           }
           uint32_t result = Vulkan::VkResult::VK_SUCCESS;

--- a/gapis/api/templates/api_spy.cpp.tmpl
+++ b/gapis/api/templates/api_spy.cpp.tmpl
@@ -274,7 +274,7 @@
       observer->observePending();
       observer->exit();
 
-      {{if GetAnnotation $ "frame_end"}}onPostEndOfFrame();{{end}}
+      {{if GetAnnotation $ "frame_end"}}onPostEndOfFrame(observer);{{end}}
       {{if not (IsVoid $.Return.Type)}}¶
         return result;
       {{end}}

--- a/gapis/api/templates/vulkan_gfx_api_extras.tmpl
+++ b/gapis/api/templates/vulkan_gfx_api_extras.tmpl
@@ -198,10 +198,23 @@ bool Vulkan::replayCreateVkDeviceImpl(Stack* stack, size_val physicalDevice,
                        return false;
                      }),
       layers.end());
+  // Drop frame boundary extension
+   std::vector<const char*> extensions(
+      pCreateInfo->ppEnabledExtensionNames,
+      pCreateInfo->ppEnabledExtensionNames + pCreateInfo->enabledExtensionCount);
+  extensions.erase(
+      std::remove_if(extensions.begin(), extensions.end(),
+                     [](const char* extension) -> bool {
+                       return std::strcmp(extension, "VK_EXT_frame_boundary") == 0;
+                     }),
+      extensions.end());
+
   VkDeviceCreateInfo new_info = *pCreateInfo;
   new_info.pNext = nullptr;
   new_info.ppEnabledLayerNames = layers.data();
   new_info.enabledLayerCount = layers.size();
+  new_info.ppEnabledExtensionNames = extensions.data();
+  new_info.enabledExtensionCount = extensions.size();
   stack->push(physicalDevice);
   stack->push(&new_info);
   stack->push(pAllocator);

--- a/gapis/api/vulkan/api/device.api
+++ b/gapis/api/vulkan/api/device.api
@@ -52,6 +52,7 @@
   @unused VkDevice                   VulkanHandle
   @unused ref!VulkanDebugMarkerInfo  DebugInfo
   @unused bool                       CreatedWithDeviceGroup
+  @unused bool                       UseFrameBoundaryExt
   @unused VkBool32                   HostQueryReset
 
   // Vulkan 1.1
@@ -278,6 +279,9 @@ sub ref!DeviceObject createDeviceObject(const VkDeviceCreateInfo* data) {
     ext := as!string(extensionNames[i])
     if !(ext in supported.ExtensionNames) { vkErrorUnrecognizedExtension(extensionNames[i]) }
     object.EnabledExtensions[i] = ext
+    if ext == "VK_EXT_frame_boundary" {
+      object.UseFrameBoundaryExt = true
+    }
   }
 
   if info.pEnabledFeatures != null {

--- a/gapis/api/vulkan/api/enums.api
+++ b/gapis/api/vulkan/api/enums.api
@@ -394,6 +394,11 @@ enum VkStructureType: u32 {
 
   // @extension("VK_KHR_driver_properties")
   VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR = 1000196000,
+
+  // @extension("VK_EXT_frame_boundary")
+  // TODO(b/156105650): This is a temporary value for the early implementation
+  // of this extension that is still being discussed in Khronos.
+  VK_STRUCTURE_TYPE_FRAME_BOUNDARY_EXT = 1000123456,
 }
 
 enum VkObjectType: u32 {

--- a/gapis/api/vulkan/api/queue.api
+++ b/gapis/api/vulkan/api/queue.api
@@ -85,6 +85,7 @@ cmd void vkGetDeviceQueue(
 @threadSafety("app")
 @indirect("VkQueue", "VkDevice")
 @submission
+@frame_end
 cmd VkResult vkQueueSubmit(
     VkQueue             queue,
     u32                 submitCount,
@@ -96,6 +97,7 @@ cmd VkResult vkQueueSubmit(
   LastBoundQueue = Queues[queue]
   clear(LastBoundQueue.ReadCoherentBuffers)
   enterSubcontext()
+
   for i in (0 .. submitCount) {
     info := submitInfo[i]
 
@@ -127,6 +129,9 @@ cmd VkResult vkQueueSubmit(
                 vkErrUnsupported("Multiple devices in a group not supported yet")
               }
             }
+          }
+          case VK_STRUCTURE_TYPE_FRAME_BOUNDARY_EXT: {
+            frameBoundary()
           }
           default: {}
         }
@@ -190,9 +195,9 @@ cmd VkResult vkQueueSubmit(
     fenceObj.Signaled = true
     recordFenceSignal(fence)
   }
+
   return ?
 }
-
 
 @threadSafety("system")
 @indirect("VkQueue", "VkDevice")

--- a/gapis/api/vulkan/extensions/ext_frame_boundary.api
+++ b/gapis/api/vulkan/extensions/ext_frame_boundary.api
@@ -1,0 +1,78 @@
+// Copyright (C) 2021 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Based off of the original vulkan.h header file which has the following
+// license.
+
+// Copyright (c) 2021 The Khronos Group Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and/or associated documentation files (the
+// "Materials"), to deal in the Materials without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Materials, and to
+// permit persons to whom the Materials are furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Materials.
+//
+// THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+
+// ==== THIS IS AN EARLY, TEMPORARY VERSION OF THIS EXTENSION ====
+//
+// This is an early implementation of the VK_EXT_frame_boundary extension which
+// is still being discussed with Khronos. The goal for this early version is to
+// support workloads that do not use vkQueuePresentKHR() to interact with the
+// presentation engine, but are still preparing only one frame at a time. Hence
+// we only need to flag some queue submissions as being an end of frame.
+//
+// The C header of this early version is:
+//
+// // This will eventually be in the VkStructureType enum, with another value.
+// #define VK_STRUCTURE_TYPE_FRAME_BOUNDARY_EXT 1000123456
+//
+// typedef struct VkFrameBoundaryEXT {
+//     VkStructureType              sType;
+//     const void*                  pNext;
+// } VkFrameBoundaryEXT;
+//
+// You can mark a vkQueueSubmit as the "end of frame" call by adding this struct
+// to its VkSubmitInfo's pNext chain.
+
+///////////////
+// Constants //
+///////////////
+
+@extension("VK_EXT_frame_boundary") define VK_EXT_FRAME_BOUNDARY_SPEC_VERSION   1
+@extension("VK_EXT_frame_boundary") define VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME "VK_EXT_frame_boundary"
+
+/////////////
+// Structs //
+/////////////
+
+@extension("VK_EXT_frame_boundary")
+class VkFrameBoundaryEXT {
+  VkStructureType            sType
+  const void*                pNext
+}
+
+extern void frameBoundary()

--- a/gapis/api/vulkan/extensions/khr_swapchain.api
+++ b/gapis/api/vulkan/extensions/khr_swapchain.api
@@ -326,6 +326,13 @@ cmd VkResult vkQueuePresentKHR(
   LastPresentInfo.PresentImageCount = 0
   LastPresentInfo.Queue = queue
 
+  // If the device does not use VK_EXT_frame_boundary, then vkQueuePresentKHR
+  // is the default frame boundary.
+  device := LastBoundQueue.Device
+  if !(device in Devices) { vkErrorInvalidDevice(device) }
+  if !(Devices[device].UseFrameBoundaryExt) {
+    frameBoundary()
+  }
 
   info := pPresentInfo[0]
 
@@ -335,7 +342,6 @@ cmd VkResult vkQueuePresentKHR(
     next := MutableVoidPtr(as!void*(info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
       // TODO: handle extensions for queue present
       // Example: Device Gropu Extension
       // switch sType {
@@ -343,6 +349,12 @@ cmd VkResult vkQueuePresentKHR(
       //   ext := as!VkDeviceGroupPresentInfoKHR*(next.Ptr)[0]
       //  }
       // }
+      switch sType {
+        case VK_STRUCTURE_TYPE_FRAME_BOUNDARY_EXT: {
+          frameBoundary()
+        }
+        default: {}
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
@@ -407,6 +419,7 @@ cmd VkResult vkQueuePresentKHR(
             results[i] = result
         }*/
   }
+
   return ?
 }
 

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -504,3 +504,5 @@ func (e externs) recordEndCommandBuffer(commandBuffer VkCommandBuffer) {
 func (e externs) onesCount(a uint32) uint32 {
 	return (uint32)(bits.OnesCount32(a))
 }
+
+func (e externs) frameBoundary() {}

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -113,6 +113,7 @@ import "extensions/khr_shader_float16_int8.api"
 import "extensions/khr_shader_atomic_int64.api"
 import "extensions/khr_driver_properties.api"
 import "extensions/khr_timeline_semaphore.api"
+import "extensions/ext_frame_boundary.api"
 
 import "android/vulkan_android.api"
 import "linux/vulkan_linux.api"
@@ -281,6 +282,7 @@ sub ref!ExtensionSet supportedDeviceExtensions() {
   supported.ExtensionNames["VK_KHR_shader_float16_int8"] = true
   supported.ExtensionNames["VK_KHR_shader_atomic_int64"] = true
   supported.ExtensionNames["VK_KHR_driver_properties"] = true
+  supported.ExtensionNames["VK_EXT_frame_boundary"] = true
   return supported
 }
 


### PR DESCRIPTION
The VK_EXT_frame_extension is still being discussed in Khronos, this
is an early minimal version that should be enough to capture Vulkan
workloads that do not use vkQueuePresentKHR (but that are still
preparing one frame at a time).

See the description in
gapis/api/vulkan/extensions/ext_frame_boundary.api

Bug: b/156105650