### PR TITLE
Implement GPU counter data's detail visualization in perftab.

### DIFF
--- a/gapic/src/main/com/google/gapid/models/Profile.java
+++ b/gapic/src/main/com/google/gapid/models/Profile.java
@@ -225,14 +225,14 @@ public class Profile
       }
       // Link the nodes.
       for (PerfNode node : nodes.values()) {
-        if (node.group.hasParent()) {
-          nodes.get(node.group.getParent().getId()).children.add(node);
+        if (node.getGroup().hasParent()) {
+          nodes.get(node.getGroup().getParent().getId()).children.add(node);
         }
       }
       // Return the root nodes.
       List<PerfNode> rootNodes = Lists.newArrayList();
       for (PerfNode node : nodes.values()) {
-        if (!node.group.hasParent()) {
+        if (!node.getGroup().hasParent()) {
           rootNodes.add(node);
         }
       }
@@ -350,22 +350,24 @@ public class Profile
   }
 
   public static class PerfNode {
-    private final Service.ProfilingData.GpuSlices.Group group;
-    private final Map<Integer, Service.ProfilingData.GpuCounters.Perf> perfs;
+    private final Service.ProfilingData.GpuCounters.Entry entry;
     private final List<PerfNode> children;
 
     public PerfNode(Service.ProfilingData.GpuCounters.Entry entry) {
-      this.group = entry.getGroup();
-      this.perfs = entry.getMetricToValueMap();
+      this.entry = entry;
       this.children = Lists.newArrayList();
     }
 
+    public Service.ProfilingData.GpuCounters.Entry getEntry() {
+      return entry;
+    }
+
     public Service.ProfilingData.GpuSlices.Group getGroup() {
-      return group;
+      return entry.getGroup();
     }
 
     public Map<Integer, Service.ProfilingData.GpuCounters.Perf> getPerfs() {
-      return perfs;
+      return entry.getMetricToValueMap();
     }
 
     public boolean hasChildren() {

--- a/gapic/src/main/com/google/gapid/perfetto/canvas/RenderContext.java
+++ b/gapic/src/main/com/google/gapid/perfetto/canvas/RenderContext.java
@@ -323,6 +323,12 @@ public class RenderContext implements Fonts.TextMeasurer, AutoCloseable {
     }
   }
 
+  // draws the text on the left of x, and beneath the bottom of y.
+  public void drawTextRightJustified(Fonts.Style style, String text, double x, double y) {
+    Size size = fontContext.measure(style, text);
+    drawText(style, text, x - size.w, y);
+  }
+
   // draws the text centered vertically and on the left of x.
   public void drawTextRightJustified(Fonts.Style style, String text, double x, double y, double h) {
     Size size = fontContext.measure(style, text);

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -1116,11 +1116,12 @@ message ProfilingData {
         TimeWeightedAvg = 1;
       }
       int32 id = 1;
-      string name = 2;
-      string unit = 3;
-      AggregationOperator op = 4;
-      string description = 5;
-      bool select_by_default = 6;
+      uint32 counter_id = 2;  // -> Counter.id. Valid for GPU counter metrics.
+      string name = 3;
+      string unit = 4;
+      AggregationOperator op = 5;
+      string description = 6;
+      bool select_by_default = 7;
     }
 
     // Perf includes a best-guessing performance value and a confidence range.
@@ -1128,6 +1129,9 @@ message ProfilingData {
       double estimate = 1;
       double min = 2;
       double max = 3;
+      map<int32, double> estimateSamples = 4;  // {index} -> {sample weight}
+      map<int32, double> minSamples = 5;       // {index} -> {sample weight}
+      map<int32, double> maxSamples = 6;       // {index} -> {sample weight}
     }
 
     // Entry contains performance data for a specific command.


### PR DESCRIPTION
Add a canvas in the perftab to draw GPU counter detail curve. The curve
correspond to the selected cell in the performance table.
This detail counter curve surves mainly for 2 purposes:
1. Help improve those non-time based rate counter's aggregation.
With the detailed graph, users could notice a counter's spike inside a
long renderpass, otherwise the spike may gets flattened and loses attention
with merely the performance number.
2. Help AGI developers or early perftab users notice whether there's
calculation bugs on the performance number.

Bug: b/158057709.
Test: Manual test by openning the Performance(Experimental) tab.