### PR TITLE
Add VK_ANDROID_frame_boundary for HWUI

### DIFF
--- a/gapii/cc/vulkan_extras.cpp
+++ b/gapii/cc/vulkan_extras.cpp
@@ -842,6 +842,12 @@ uint32_t VulkanSpy::SpyOverride_vkEnumerateDeviceExtensionProperties(
     }
   }
 
+  // AGI implements VK_ANDROID_frame_boundary itself
+  char frame_boundary_extension_name[] = "VK_ANDROID_frame_boundary";
+  uint32_t frame_boundary_spec_version = 1;
+  all_properties.push_back(VkExtensionProperties{frame_boundary_extension_name,
+                                                 frame_boundary_spec_version});
+
   if (pProperties == NULL) {
     *pCount = all_properties.size();
     return VkResult::VK_SUCCESS;

--- a/gapii/cc/vulkan_extras.inc
+++ b/gapii/cc/vulkan_extras.inc
@@ -156,3 +156,11 @@ void walkImageSubRng(
 void parseShaderModule(
     StageData* stage,
     gapil::Ref<DescriptorInfo>& descriptors);
+
+// AGI implements VK_ANDROID_frame_boundary itself, the underlying ICD
+// is not expected to provide it. Hence, override the spy to avoid calling into
+// the next layer/ICD implementation of that function.
+void SpyOverride_vkFrameBoundaryANDROID(VkDevice device,
+                                        VkSemaphore semaphore,
+                                        VkImage image,
+                                        AHardwareBuffer* buffer) {}

--- a/gapis/api/templates/vulkan_gfx_api_extras.tmpl
+++ b/gapis/api/templates/vulkan_gfx_api_extras.tmpl
@@ -198,10 +198,25 @@ bool Vulkan::replayCreateVkDeviceImpl(Stack* stack, size_val physicalDevice,
                        return false;
                      }),
       layers.end());
+  // VK_ANDROID_frame_boundary is implemented by AGI itself, the driver at
+  // replay time is not expected to support it, so drop this extension at replay
+  // time.
+   std::vector<const char*> extensions(
+      pCreateInfo->ppEnabledExtensionNames,
+      pCreateInfo->ppEnabledExtensionNames + pCreateInfo->enabledExtensionCount);
+  extensions.erase(
+      std::remove_if(extensions.begin(), extensions.end(),
+                     [](const char* extension) -> bool {
+                       return std::strcmp(extension, "VK_ANDROID_frame_boundary") == 0;
+                     }),
+      extensions.end());
+
   VkDeviceCreateInfo new_info = *pCreateInfo;
   new_info.pNext = nullptr;
   new_info.ppEnabledLayerNames = layers.data();
   new_info.enabledLayerCount = layers.size();
+  new_info.ppEnabledExtensionNames = extensions.data();
+  new_info.enabledExtensionCount = extensions.size();
   stack->push(physicalDevice);
   stack->push(&new_info);
   stack->push(pAllocator);

--- a/gapis/api/vulkan/extensions/android_frame_boundary.api
+++ b/gapis/api/vulkan/extensions/android_frame_boundary.api
@@ -1,0 +1,75 @@
+// Copyright (C) 2021 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// VK_ANDROID_frame_boundary is not defined by Khronos, it's a bespoke device
+// extension AGI implements in order to support HWUI use-case, which bypasses
+// the Khronos swapchain and thus never uses vkQueuePresentKHR. HWUI can use
+// vkFrameBoundaryANDROID in order to mark frame boundaries. This approach is
+// sufficient for HWUI, which renders frames in sequence, one at a time, but
+// cannot handle the general case of overlapping frames.
+//
+// As this extension won't be defined by Khronos vulkan headers, use this:
+//
+// typedef void (VKAPI_PTR *PFN_vkFrameBoundaryANDROID)(VkDevice device, VkSemaphore semaphore, VkImage image, AHardwareBuffer* buffer);
+//
+// Make sure to load this function only when the device supports
+// "VK_ANDROID_frame_boundary", this support will be present only when AGI's
+// spy vulkan layer is present (i.e., when AGI traces the app).
+
+/////////////
+// Structs //
+/////////////
+
+// In due time, this will be declared in the implementation of
+// VK_ANDROID_external_memory_android_hardware_buffer
+@platform("VK_USE_PLATFORM_ANDROID_KHR")
+@extension("VK_ANDROID_external_memory_android_hardware_buffer")
+@forwarddecl
+class AHardwareBuffer {}
+
+//////////////
+// Commands //
+//////////////
+
+@extension("VK_ANDROID_frame_boundary")
+@indirect("VkDevice")
+@override
+@frame_end
+cmd void vkFrameBoundaryANDROID(
+    VkDevice                device,
+    VkSemaphore             semaphore,
+    VkImage                 image,
+    AHardwareBuffer*        buffer) {
+
+  if !(device in Devices) { vkErrorInvalidDevice(device) }
+  if !(semaphore in Semaphores) { vkErrorInvalidSemaphore(semaphore) }
+  if !(image in Images) { vkErrorInvalidImage(image) }
+
+  sema := Semaphores[semaphore]
+  if sema.SubmitCount == 0 {
+    vkErrorSemaphoreNotSubmitted(semaphore)
+  } else {
+    // The semaphore signal and submit logic is copied from vkQueuePresentKHR
+    if (sema.Signaled) {
+      sema.Signaled = false
+      // TODO: This should be decreased not when it is processed but
+      // when it is submmitted for wait. Change the logic when we
+      // support handling unsignaled waits.
+      sema.SubmitCount = sema.SubmitCount - 1
+    } else {
+      // TODO: handle case when semaphore is not yet signaled
+      // see https://github.com/google/gapid/issues/1860
+    }
+  }
+}

--- a/gapis/api/vulkan/extensions/android_frame_boundary.api
+++ b/gapis/api/vulkan/extensions/android_frame_boundary.api
@@ -31,7 +31,7 @@
 // Structs //
 /////////////
 
-// In due time, this will be declared in the implementation of
+// TODO: In due time, this will be declared in the implementation of
 // VK_ANDROID_external_memory_android_hardware_buffer
 @platform("VK_USE_PLATFORM_ANDROID_KHR")
 @extension("VK_ANDROID_external_memory_android_hardware_buffer")
@@ -42,6 +42,7 @@ class AHardwareBuffer {}
 // Commands //
 //////////////
 
+@platform("VK_USE_PLATFORM_ANDROID_KHR")
 @extension("VK_ANDROID_frame_boundary")
 @indirect("VkDevice")
 @override

--- a/gapis/api/vulkan/templates/vulkan_layer.tmpl
+++ b/gapis/api/vulkan/templates/vulkan_layer.tmpl
@@ -72,6 +72,10 @@
 #include "vulkan/vulkan.h"
 #include "core/vulkan/layer_helpers/vulkan_layer_helpers.h"
 
+// Support VK_ANDROID_frame_boundary, which is not defined by Khronos
+struct AHardwareBuffer;
+typedef void (VKAPI_PTR *PFN_vkFrameBoundaryANDROID)(VkDevice device, VkSemaphore semaphore, VkImage image, AHardwareBuffer* buffer);
+
 #include "core/vulkan/layer_helpers/threading.h"
 
 

--- a/gapis/api/vulkan/templates/vulkan_layer.tmpl
+++ b/gapis/api/vulkan/templates/vulkan_layer.tmpl
@@ -72,9 +72,11 @@
 #include "vulkan/vulkan.h"
 #include "core/vulkan/layer_helpers/vulkan_layer_helpers.h"
 
+#if defined(__ANDROID__)
 // Support VK_ANDROID_frame_boundary, which is not defined by Khronos
 struct AHardwareBuffer;
 typedef void (VKAPI_PTR *PFN_vkFrameBoundaryANDROID)(VkDevice device, VkSemaphore semaphore, VkImage image, AHardwareBuffer* buffer);
+#endif // __ANDROID__
 
 #include "core/vulkan/layer_helpers/threading.h"
 

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -66,6 +66,7 @@ import "api/synchronization.api"
 import "api/queued_command_tracking.api"
 import "api/util.api"
 
+import "extensions/android_frame_boundary.api"
 import "extensions/ext_debug_marker.api"
 import "extensions/ext_debug_report.api"
 import "extensions/ext_debug_utils.api"
@@ -281,6 +282,7 @@ sub ref!ExtensionSet supportedDeviceExtensions() {
   supported.ExtensionNames["VK_KHR_shader_float16_int8"] = true
   supported.ExtensionNames["VK_KHR_shader_atomic_int64"] = true
   supported.ExtensionNames["VK_KHR_driver_properties"] = true
+  supported.ExtensionNames["VK_ANDROID_frame_boundary"] = true
   return supported
 }
 


### PR DESCRIPTION
VK_ANDROID_frame_boundary is a bespoke extension designed for the
needs of HWUI: add a manual frame boundary to workloads that do not
use vkQueuePresentKHR, but still render frames in sequence, one at a
time (no overlapping frames).

See the description in
gapis/api/vulkan/extensions/android_frame_boundary.api

Bug: b/156105650
Test: manual, on a modified version of our sample