### PR TITLE
Smoketests: look up Vulkan command name

### DIFF
--- a/cmd/smoketests/main.go
+++ b/cmd/smoketests/main.go
@@ -161,7 +161,7 @@ func testTrace(ctx context.Context, nbErr *int, gapitPath string, tracepath stri
 		{"commands", "-groupbyusermarkers", tracepath},
 		{"commands", "-groupbysubmission", tracepath},
 		{"commands", "-maxchildren", "1", tracepath},
-		{"commands", "-name", "glBindFramebuffer", tracepath},
+		{"commands", "-name", "vkQueueSubmit", tracepath},
 		{"commands", "-observations-ranges", tracepath},
 		{"commands", "-observations-data", tracepath},
 		{"commands", "-raw", tracepath},


### PR DESCRIPTION
Update the smoketests to lookup a command name matching a Vulkan
command, rather than a GL one.

Bug: N/A