### PR TITLE
Keep only one per-thread persistent CallObserver

### DIFF
--- a/gapii/cc/call_observer.h
+++ b/gapii/cc/call_observer.h
@@ -49,19 +49,13 @@ class CallObserver : public context_t {
 
   typedef std::function<void(slice_t*)> OnSliceEncodedCallback;
 
-  CallObserver(SpyBase* spy_p, CallObserver* parent, uint8_t api);
+  CallObserver(SpyBase* spy_p, uint8_t api);
 
   ~CallObserver();
 
-  inline CallObserver* getParent() { return mParent; }
-
-  // setCurrentCommandName sets the name of the current command that is being
-  // observed by this observer. The storage of cmd_name must remain valid for
-  // the lifetime of this observer object, ideally it should be static
-  // string.
-  void setCurrentCommandName(const char* cmd_name) {
-    mCurrentCommandName = cmd_name;
-  }
+  // beginCommand re-initialize the call observer when there is a new command to
+  // observe. It receives the new command's name (e.g. "vkQueueSubmit").
+  void beginCommand(const char* name);
 
   const char* getCurrentCommandName() { return mCurrentCommandName; }
 
@@ -199,9 +193,6 @@ class CallObserver : public context_t {
 
   // A pointer to the spy instance.
   SpyBase* mSpy;
-
-  // A pointer to the parent CallObserver.
-  CallObserver* mParent;
 
   // The encoder stack.
   std::stack<PackEncoder::SPtr> mEncoderStack;

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -65,7 +65,7 @@ const uint32_t kMaxFramebufferObservationHeight = 2560;
 
 const int32_t kSuspendIndefinitely = -1;
 
-thread_local gapii::CallObserver* tl_callObserver = nullptr;
+thread_local std::unique_ptr<gapii::CallObserver> tl_callObserver;
 
 }  // anonymous namespace
 
@@ -243,11 +243,11 @@ CallObserver* Spy::enter(const char* name, uint32_t api) {
   // case in AGI, which only handles Vulkan): it creates a fresh observer
   // (per-thread, since tl_callObserver is thread_local) for that API the first
   // time and reuses it in subsequent calls.
-  if (tl_callObserver == nullptr) {
-    tl_callObserver = new CallObserver(this, api);
+  if (!tl_callObserver) {
+    tl_callObserver.set(new CallObserver(this, api));
   }
   tl_callObserver->beginCommand(name);
-  return tl_callObserver;
+  return tl_callObserver.get();
 }
 
 void Spy::exit() { unlock(); }

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -244,7 +244,7 @@ CallObserver* Spy::enter(const char* name, uint32_t api) {
   // (per-thread, since tl_callObserver is thread_local) for that API the first
   // time and reuses it in subsequent calls.
   if (!tl_callObserver) {
-    tl_callObserver.set(new CallObserver(this, api));
+    tl_callObserver.reset(new CallObserver(this, api));
   }
   tl_callObserver->beginCommand(name);
   return tl_callObserver.get();

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -187,7 +187,7 @@ Spy::Spy()
     core::Debugger::waitForAttach();
   }
 
-  auto context = enter("init", 0);
+  auto context = enter("init", VulkanSpy::kApiIndex);
   VulkanSpy::init();
   SpyBase::init(context);
   exit();
@@ -348,7 +348,7 @@ void Spy::onPostEndOfFrame() {
         set_suspended(false);
         exit();
         saveInitialState();
-        enter("RecreateState", 2);
+        enter("RecreateState", VulkanSpy::kApiIndex);
       }
     }
   } else {


### PR DESCRIPTION
This change removes the code related to stacking of call
observers (e.g. the logic involving mParent): that stacking was a
reminiscence of a graphics API (GVR I think) needs, where commands
could call other commands in a nested way.

In addition, rather than creating a new CallObserver each time we
enter a command, this change also use persistent, per-thread call
observers. They are stored in the thread-local `tl_callObserver`,
which used to be named `gContext`. This avoids to create and destroy a
CallObserver for each observed command.

This is based on a cherry-pick of
https://github.com/AWoloszyn/gapid/commit/6f66f91fe0b2c641d62d847042c82e555aea7ae8

Bug: b/151400181
Test: manual