### PR TITLE
Handle a corner case where GPU counter spec is nil at the perftab backend.

### DIFF
--- a/gapis/trace/android/adreno/profiling_data.go
+++ b/gapis/trace/android/adreno/profiling_data.go
@@ -282,8 +282,10 @@ func processCounters(ctx context.Context, processor *perfetto.Processor, desc *d
 	descriptions := tracksColumns[3].GetStringValues()
 
 	nameToSpec := map[string]*device.GpuCounterDescriptor_GpuCounterSpec{}
-	for _, spec := range desc.Specs {
-		nameToSpec[spec.Name] = spec
+	if desc != nil {
+		for _, spec := range desc.Specs {
+			nameToSpec[spec.Name] = spec
+		}
 	}
 
 	for i := uint64(0); i < numTracksRows; i++ {

--- a/gapis/trace/android/mali/profiling_data.go
+++ b/gapis/trace/android/mali/profiling_data.go
@@ -276,8 +276,10 @@ func processCounters(ctx context.Context, processor *perfetto.Processor, desc *d
 	descriptions := tracksColumns[3].GetStringValues()
 
 	nameToSpec := map[string]*device.GpuCounterDescriptor_GpuCounterSpec{}
-	for _, spec := range desc.Specs {
-		nameToSpec[spec.Name] = spec
+	if desc != nil {
+		for _, spec := range desc.Specs {
+			nameToSpec[spec.Name] = spec
+		}
 	}
 
 	for i := uint64(0); i < numTracksRows; i++ {


### PR DESCRIPTION
This bug is observed in our nightly swarming result.

Bug: b/180059345, b/180332153.