### PR TITLE
Stop ignoring unsupported sTypes in pNext structs.

### DIFF
--- a/gapis/api/vulkan/api/buffer.api
+++ b/gapis/api/vulkan/api/buffer.api
@@ -323,7 +323,6 @@ sub void BindBufferMemory2(
                 dg.Binding.Bindings[j] = indices[j]
               }
             }
-            default: {}
           }
           next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
         }

--- a/gapis/api/vulkan/api/buffer.api
+++ b/gapis/api/vulkan/api/buffer.api
@@ -190,8 +190,8 @@ cmd VkResult vkCreateBufferView(
     next := MutableVoidPtr(as!void*(buffer_view_create_info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // TODO: handle extensions for VkBufferViewCreateInfo
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
@@ -313,7 +313,6 @@ sub void BindBufferMemory2(
         next := MutableVoidPtr(as!void*(info.pNext))
         for i in (0 .. numPNext) {
           sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-          _ = sType
           switch sType {
             case VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_DEVICE_GROUP_INFO: {
               ext := as!VkBindBufferMemoryDeviceGroupInfo*(next.Ptr)[0:1][0]

--- a/gapis/api/vulkan/api/command_buffer_control.api
+++ b/gapis/api/vulkan/api/command_buffer_control.api
@@ -471,7 +471,6 @@ cmd VkResult vkBeginCommandBuffer(
             DeviceMask: ext.deviceMask,
           )
         }
-        default: {}
       }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }

--- a/gapis/api/vulkan/api/command_buffer_control.api
+++ b/gapis/api/vulkan/api/command_buffer_control.api
@@ -64,8 +64,8 @@ cmd VkResult vkCreateCommandPool(
     next := MutableVoidPtr(as!void*(create_info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // TODO: handle extensions for VkCommandPoolCreateInfo
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
@@ -391,8 +391,8 @@ cmd VkResult vkAllocateCommandBuffers(
     next := MutableVoidPtr(as!void*(allocateInfo.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // TODO: handle extensions for VkCommandBufferAllocateInfo
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
@@ -463,7 +463,6 @@ cmd VkResult vkBeginCommandBuffer(
     next := MutableVoidPtr(as!void*(info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
       switch sType {
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_COMMAND_BUFFER_BEGIN_INFO: {
           ext := as!VkDeviceGroupCommandBufferBeginInfo*(next.Ptr)[0:1][0]
@@ -496,8 +495,8 @@ cmd VkResult vkBeginCommandBuffer(
         next := MutableVoidPtr(as!void*(inheritanceInfo.pNext))
         for i in (0 .. numPNext) {
           sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-          _ = sType
-          // TODO: handle extensions for VkCommandBufferInheritanceInfo
+          switch (sType) {
+          }
           next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
         }
       }

--- a/gapis/api/vulkan/api/descriptor.api
+++ b/gapis/api/vulkan/api/descriptor.api
@@ -72,8 +72,8 @@ cmd VkResult vkCreateDescriptorSetLayout(
     next := MutableVoidPtr(as!void*(info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // TODO: handle extensions for VkDescriptorSetLayoutCreateInfo
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
@@ -153,8 +153,8 @@ cmd VkResult vkCreateDescriptorPool(
     next := MutableVoidPtr(as!void*(info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // TODO: handle extensions for VkDescriptorPoolCreateInfo
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
@@ -267,8 +267,8 @@ cmd VkResult vkAllocateDescriptorSets(
     next := MutableVoidPtr(as!void*(info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // TODO: handle extensions for VkDescriptorSetAllocateInfo
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
@@ -555,8 +555,8 @@ cmd void vkUpdateDescriptorSets(
       next := MutableVoidPtr(as!void*(w.pNext))
       for i in (0 .. numPNext) {
         sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-        _ = sType
-        // TODO: handle extensions for VkWriteDescriptorSet
+        switch (sType) {
+        }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
     }
@@ -571,8 +571,8 @@ cmd void vkUpdateDescriptorSets(
       next := MutableVoidPtr(as!void*(c.pNext))
       for i in (0 .. numPNext) {
         sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-        _ = sType
-        // TODO: handle extensions for VkCopyDescriptorSet
+        switch (sType) {
+        }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
     }
@@ -968,7 +968,8 @@ sub void GetDescriptorSetLayoutSupport(
     next := MutableVoidPtr(as!void*(info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
@@ -983,7 +984,8 @@ sub void GetDescriptorSetLayoutSupport(
     next := MutableVoidPtr(as!void*(support.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }

--- a/gapis/api/vulkan/api/device.api
+++ b/gapis/api/vulkan/api/device.api
@@ -260,9 +260,6 @@ sub ref!DeviceObject createDeviceObject(const VkDeviceCreateInfo* data) {
             ShaderInt8: ext.shaderInt8,
           )
         }
-        default: {
-          // do nothing
-        }
       }
       // TODO: handle extensions for VkDeviceCreateInfo
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext

--- a/gapis/api/vulkan/api/device.api
+++ b/gapis/api/vulkan/api/device.api
@@ -260,6 +260,9 @@ sub ref!DeviceObject createDeviceObject(const VkDeviceCreateInfo* data) {
             ShaderInt8: ext.shaderInt8,
           )
         }
+        case VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO: {
+          // Ignore.
+        }
       }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }

--- a/gapis/api/vulkan/api/device.api
+++ b/gapis/api/vulkan/api/device.api
@@ -261,7 +261,6 @@ sub ref!DeviceObject createDeviceObject(const VkDeviceCreateInfo* data) {
           )
         }
       }
-      // TODO: handle extensions for VkDeviceCreateInfo
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
@@ -276,8 +275,8 @@ sub ref!DeviceObject createDeviceObject(const VkDeviceCreateInfo* data) {
       next := MutableVoidPtr(as!void*(queue_info.pNext))
       for i in (0 .. numPNext) {
         sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-        _ = sType
-        // TODO: handle extensions for VkDeviceQueueCreateInfo
+        switch (sType) {
+        }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
     }

--- a/gapis/api/vulkan/api/image.api
+++ b/gapis/api/vulkan/api/image.api
@@ -656,7 +656,6 @@ cmd VkResult vkCreateSampler(
           }
         }
       }
-      // TODO: handle extensions for VkSamplerCreateInfo
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }

--- a/gapis/api/vulkan/api/image.api
+++ b/gapis/api/vulkan/api/image.api
@@ -655,9 +655,6 @@ cmd VkResult vkCreateSampler(
             sampler.YcbcrConversion = SamplerYcbcrConversions[conversion]
           }
         }
-        default: {
-          // do nothing
-        }
       }
       // TODO: handle extensions for VkSamplerCreateInfo
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
@@ -869,7 +866,6 @@ sub void BindImageMemory2(
                 dg.Binding.SplitInstanceBindings[j] = regions[j]
               }
             }
-            default: {}
           }
           next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
         }

--- a/gapis/api/vulkan/api/instance.api
+++ b/gapis/api/vulkan/api/instance.api
@@ -109,8 +109,8 @@ sub ref!InstanceObject createInstanceObject(const VkInstanceCreateInfo* createIn
     next := MutableVoidPtr(as!void*(info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // TODO: handle extensions for VkInstanceCreateInfo
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
@@ -149,8 +149,8 @@ sub ref!ApplicationInfo readVkApplicationInfo(const VkApplicationInfo* applicati
     next := MutableVoidPtr(as!void*(info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // TODO: handle extensions for VkApplicationInfo
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }

--- a/gapis/api/vulkan/api/instance.api
+++ b/gapis/api/vulkan/api/instance.api
@@ -110,6 +110,9 @@ sub ref!InstanceObject createInstanceObject(const VkInstanceCreateInfo* createIn
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
       switch (sType) {
+        case VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO: {
+          // Ignore.
+        }
       }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }

--- a/gapis/api/vulkan/api/memory.api
+++ b/gapis/api/vulkan/api/memory.api
@@ -218,8 +218,8 @@ cmd VkResult vkFlushMappedMemoryRanges(
       next := MutableVoidPtr(as!void*(flushRange.pNext))
       for i in (0 .. numPNext) {
         sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-        _ = sType
-        // TODO: handle extensions for VkMappedMemoryRange
+        switch (sType) {
+        }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
     }

--- a/gapis/api/vulkan/api/pipeline.api
+++ b/gapis/api/vulkan/api/pipeline.api
@@ -272,7 +272,6 @@ cmd VkResult vkCreateGraphicsPipelines(
             read(pcfcie[0:1])
           }
         }
-        // TODO: handle extensions for VkGraphicsPipelineCreateInfo
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
     }
@@ -290,8 +289,8 @@ cmd VkResult vkCreateGraphicsPipelines(
         next := MutableVoidPtr(as!void*(stage_create_info.pNext))
         for i in (0 .. numPNext) {
           sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-          _ = sType
-          // TODO: handle extensions for VkPipelineShaderStageCreateInfo
+          switch (sType) {
+          }
           next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
         }
       }
@@ -348,8 +347,8 @@ cmd VkResult vkCreateGraphicsPipelines(
       next := MutableVoidPtr(as!void*(vertex_input_state.pNext))
       for i in (0 .. numPNext) {
         sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-        _ = sType
-        // TODO: handle extensions for VkPipelineVertexInputStateCreateInfo
+        switch (sType) {
+        }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
     }
@@ -375,8 +374,8 @@ cmd VkResult vkCreateGraphicsPipelines(
       next := MutableVoidPtr(as!void*(input_assembly_state.pNext))
       for i in (0 .. numPNext) {
         sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-        _ = sType
-        // TODO: handle extensions for VkPipelineInputAssemblyStateCreateInfo
+        switch (sType) {
+        }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
     }
@@ -412,8 +411,8 @@ cmd VkResult vkCreateGraphicsPipelines(
         next := MutableVoidPtr(as!void*(pipeline_viewport_state_create_info.pNext))
         for i in (0 .. numPNext) {
           sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-          _ = sType
-          // TODO: handle extensions for VkPipelineViewportStateCreateInfo
+          switch (sType) {
+          }
           next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
         }
       }
@@ -466,8 +465,8 @@ cmd VkResult vkCreateGraphicsPipelines(
       next := MutableVoidPtr(as!void*(rasterization_state.pNext))
       for i in (0 .. numPNext) {
         sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-        _ = sType
-        // TODO: handle extensions for VkPipelineRasterizationStateCreateInfo
+        switch (sType) {
+        }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
     }
@@ -487,8 +486,8 @@ cmd VkResult vkCreateGraphicsPipelines(
         next := MutableVoidPtr(as!void*(multisample_state.pNext))
         for i in (0 .. numPNext) {
           sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-          _ = sType
-          // TODO: handle extensions for VkPipelineMultisampleStateCreateInfo
+          switch (sType) {
+          }
           next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
         }
       }
@@ -511,8 +510,8 @@ cmd VkResult vkCreateGraphicsPipelines(
         next := MutableVoidPtr(as!void*(depth_stencil_state.pNext))
         for i in (0 .. numPNext) {
           sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-          _ = sType
-          // TODO: handle extensions for VkPipelineDepthStencilStateCreateInfo
+          switch (sType) {
+          }
           next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
         }
       }
@@ -540,8 +539,8 @@ cmd VkResult vkCreateGraphicsPipelines(
         next := MutableVoidPtr(as!void*(color_blend_state.pNext))
         for i in (0 .. numPNext) {
           sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-          _ = sType
-          // TODO: handle extensions for VkPipelineColorBlendStateCreateInfo
+          switch (sType) {
+          }
           next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
         }
       }
@@ -561,8 +560,8 @@ cmd VkResult vkCreateGraphicsPipelines(
         next := MutableVoidPtr(as!void*(dynamic_state_info.pNext))
         for i in (0 .. numPNext) {
           sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-          _ = sType
-          // TODO: handle extensions for VkPipelineDynamicStateCreateInfo
+          switch (sType) {
+          }
           next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
         }
       }
@@ -671,8 +670,8 @@ cmd VkResult vkCreateComputePipelines(
       next := MutableVoidPtr(as!void*(stage_create_info.pNext))
       for i in (0 .. numPNext) {
         sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-        _ = sType
-        // TODO: handle extensions for VkPipelineShaderStageCreateInfo
+        switch (sType) {
+        }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
     }
@@ -808,8 +807,8 @@ cmd VkResult vkCreateShaderModule(
     next := MutableVoidPtr(as!void*(create_info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // TODO: handle extensions for VkShaderModuleCreateInfo
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
@@ -863,8 +862,8 @@ cmd VkResult vkCreatePipelineCache(
     next := MutableVoidPtr(as!void*(create_info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // TODO: handle extensions for VkPipelineCacheCreateInfo
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }

--- a/gapis/api/vulkan/api/pipeline.api
+++ b/gapis/api/vulkan/api/pipeline.api
@@ -271,7 +271,6 @@ cmd VkResult vkCreateGraphicsPipelines(
             pcfcie := as!const VkPipelineCreationFeedbackCreateInfoEXT*(next.Ptr)
             read(pcfcie[0:1])
           }
-          default: {}
         }
         // TODO: handle extensions for VkGraphicsPipelineCreateInfo
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
@@ -613,7 +612,6 @@ cmd VkResult vkCreateGraphicsPipelines(
             write(pcfcie.pPipelineCreationFeedback[0:1])
             write(pcfcie.pPipelineStageCreationFeedbacks[0:pcfcie.pipelineStageCreationFeedbackCount])
           }
-          default: {}
         }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
@@ -656,7 +654,6 @@ cmd VkResult vkCreateComputePipelines(
             pcfcie := as!const VkPipelineCreationFeedbackCreateInfoEXT*(next.Ptr)
             read(pcfcie[0:1])
           }
-          default: {}
         }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
@@ -748,7 +745,6 @@ cmd VkResult vkCreateComputePipelines(
             write(pcfcie.pPipelineCreationFeedback[0:1])
             write(pcfcie.pPipelineStageCreationFeedbacks[0:pcfcie.pipelineStageCreationFeedbackCount])
           }
-          default: {}
         }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }

--- a/gapis/api/vulkan/api/properties_features_requirements.api
+++ b/gapis/api/vulkan/api/properties_features_requirements.api
@@ -978,6 +978,9 @@ sub void GetBufferMemoryRequirements2(
     for i in (0 .. nPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0]
       switch (sType) {
+        case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS: {
+          _ = as!VkMemoryDedicatedRequirements*(next.Ptr)[0]
+        }
       }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0].PNext
     }

--- a/gapis/api/vulkan/api/properties_features_requirements.api
+++ b/gapis/api/vulkan/api/properties_features_requirements.api
@@ -501,7 +501,6 @@ sub void GetPhysicalDeviceImageFormatProperties2(
               _ = ext.pViewFormats[0:ext.viewFormatCount]
             }
           }
-          default: {}
         }
         // TODO: handle extensions for VkPhysicalDeviceImageFormatInfo2
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext

--- a/gapis/api/vulkan/api/properties_features_requirements.api
+++ b/gapis/api/vulkan/api/properties_features_requirements.api
@@ -341,7 +341,6 @@ sub void GetPhysicalDeviceFeatures2(
   }
   features := pFeatures[0]
   if (physicalDevice in PhysicalDevices) {
-    // TODO: handle pNext
     if features.pNext != null {
       numPNext := numberOfPNext(
         as!const void*(features.pNext))
@@ -394,7 +393,6 @@ sub void GetPhysicalDeviceFeatures2(
   if (physicalDevice in PhysicalDevices) {
     pFeatures[0] = ?
     newFeatures := pFeatures[0]
-    // TODO: handle pNext
     if newFeatures.pNext != null {
       numPNext := numberOfPNext(
         as!const void*(newFeatures.pNext))
@@ -502,7 +500,6 @@ sub void GetPhysicalDeviceImageFormatProperties2(
             }
           }
         }
-        // TODO: handle extensions for VkPhysicalDeviceImageFormatInfo2
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
     }
@@ -591,7 +588,6 @@ sub void GetPhysicalDeviceProperties2(
       props := pProperties[0]
       phyDev := PhysicalDevices[physicalDevice]
       phyDev.PhysicalDeviceProperties = props.properties
-      // TODO: handle pNext
       if props.pNext != null {
         numPNext := numberOfPNext(as!const void*(props.pNext))
         next := MutableVoidPtr(as!void*(props.pNext))
@@ -741,8 +737,8 @@ sub void GetPhysicalDeviceSparseImageFormatProperties2(
     next := MutableVoidPtr(as!void*(info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // TODO: handle extensions for VkPhysicalDeviceSparseImageFormatInfo2KHR
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
@@ -827,8 +823,8 @@ sub void GetPhysicalDeviceExternalBufferProperties(
       next := MutableVoidPtr(as!void*(info.pNext))
       for i in (0 .. numPNext) {
         sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-        _ = sType
-        // handle future extensions VkPhysicalDeviceExternalBufferInfo
+        switch (sType) {
+        }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
     }
@@ -845,8 +841,8 @@ sub void GetPhysicalDeviceExternalBufferProperties(
     next := MutableVoidPtr(props.pNext)
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // handle future extensions for VkExternalBufferProperties
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
@@ -878,8 +874,8 @@ sub void GetPhysicalDeviceExternalSemaphoreProperties(
       next := MutableVoidPtr(as!void*(info.pNext))
       for i in (0 .. numPNext) {
         sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-        _ = sType
-        // handle future extensions for VkPhysicalDeviceExternalSemaphoreInfo
+        switch (sType) {
+        }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
     }
@@ -896,8 +892,8 @@ sub void GetPhysicalDeviceExternalSemaphoreProperties(
     next := MutableVoidPtr(props.pNext)
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // handle future extensions for VkExternalSemaphoreProperties
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
@@ -929,8 +925,8 @@ sub void GetPhysicalDeviceExternalFenceProperties(
       next := MutableVoidPtr(as!void*(info.pNext))
       for i in (0 .. numPNext) {
         sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-        _ = sType
-        // handle future extensions for VkPhysicalDeviceExternalFenceInfo
+        switch (sType) {
+        }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
     }
@@ -947,8 +943,8 @@ sub void GetPhysicalDeviceExternalFenceProperties(
     next := MutableVoidPtr(props.pNext)
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // handle future extensions for VkExternalFenceProperties
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
@@ -975,14 +971,14 @@ sub void GetBufferMemoryRequirements2(
     VkMemoryRequirements2*                 pMemoryRequirements) {
   if !(device in Devices) { vkErrorInvalidDevice(device) }
   info := pInfo[0]
-  // TODO: handle pNext
-
   memReqs := pMemoryRequirements[0]
   if memReqs.pNext != null {
     nPNext := numberOfPNext(as!const void*(memReqs.pNext))
     next := MutableVoidPtr(as!void*(memReqs.pNext))
     for i in (0 .. nPNext) {
-      _ = as!const VkStructureType*(next.Ptr)[0]
+      sType := as!const VkStructureType*(next.Ptr)[0]
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0].PNext
     }
   }
@@ -991,7 +987,6 @@ sub void GetBufferMemoryRequirements2(
 
   if pMemoryRequirements == null { vkErrorNullPointer("VkMemoryRequirements2(KHR)") }
   pMemoryRequirements[0] = ?
-  // TODO: handle pNext for 'memReq'
   memReq := pMemoryRequirements[0]
   if !(info.buffer in Buffers) { vkErrorInvalidBuffer(info.buffer) }
   // TODO: Do the touch of the buffer object once we extract the memory
@@ -1121,8 +1116,8 @@ sub void GetImageSparseMemoryRequirements2(
     next := MutableVoidPtr(as!void*(info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // TODO: handle extensions for VkImageSparseMemoryRequirementsInfo2
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }

--- a/gapis/api/vulkan/api/query_pool.api
+++ b/gapis/api/vulkan/api/query_pool.api
@@ -74,8 +74,8 @@ cmd VkResult vkCreateQueryPool(
     next := MutableVoidPtr(as!void*(info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // TODO: handle extensions for VkQueryPoolCreateInfo
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }

--- a/gapis/api/vulkan/api/queue.api
+++ b/gapis/api/vulkan/api/queue.api
@@ -105,7 +105,6 @@ cmd VkResult vkQueueSubmit(
       next := MutableVoidPtr(as!void*(info.pNext))
       for i in (0 .. numPNext) {
         sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-        _ = sType
         switch sType {
           case VK_STRUCTURE_TYPE_DEVICE_GROUP_SUBMIT_INFO: {
             ext := as!VkDeviceGroupSubmitInfo*(next.Ptr)[0:1][0]
@@ -275,11 +274,9 @@ cmd VkResult vkQueueBindSparse(
       next := MutableVoidPtr(as!void*(info.pNext))
       for i in (0 .. numPNext) {
         sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-        _ = sType
         switch sType {
           case VK_STRUCTURE_TYPE_DEVICE_GROUP_BIND_SPARSE_INFO: {
-            s := as!VkDeviceGroupBindSparseInfo*(next.Ptr)[0:1][0]
-            _ = s
+            _ = as!VkDeviceGroupBindSparseInfo*(next.Ptr)[0:1][0]
           }
         }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext

--- a/gapis/api/vulkan/api/queue.api
+++ b/gapis/api/vulkan/api/queue.api
@@ -128,7 +128,6 @@ cmd VkResult vkQueueSubmit(
               }
             }
           }
-          default: {}
         }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
@@ -178,7 +177,7 @@ cmd VkResult vkQueueSubmit(
         }
       }
     }
-    
+
     executeSubmit(queue, subm)
     nextSubcontext()
   }
@@ -282,7 +281,6 @@ cmd VkResult vkQueueBindSparse(
             s := as!VkDeviceGroupBindSparseInfo*(next.Ptr)[0:1][0]
             _ = s
           }
-          default: {}
         }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
@@ -318,7 +316,7 @@ cmd VkResult vkQueueBindSparse(
     }
     clear(LastBoundQueue.ReadCoherentBuffers)
     queuedBinds := new!QueuedSparseBinds()
-    
+
     bufferBinds := info.pBufferBinds[0:info.bufferBindCount]
     for j in (0 .. info.bufferBindCount) {
       bufferBindInfo := bufferBinds[j]

--- a/gapis/api/vulkan/api/renderpass_framebuffer.api
+++ b/gapis/api/vulkan/api/renderpass_framebuffer.api
@@ -76,8 +76,8 @@ cmd VkResult vkCreateFramebuffer(
     next := MutableVoidPtr(as!void*(create_info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // TODO: handle extensions for VkFramebufferCreateInfo
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
@@ -348,7 +348,6 @@ cmd void vkCmdBeginRenderPass(
       next := MutableVoidPtr(as!void*(begin_info.pNext))
       for i in (0 .. numPNext) {
         sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-        _ = sType
         switch sType {
           case VK_STRUCTURE_TYPE_DEVICE_GROUP_RENDER_PASS_BEGIN_INFO: {
             ext := as!VkDeviceGroupRenderPassBeginInfo*(next.Ptr)[0:1][0]

--- a/gapis/api/vulkan/api/renderpass_framebuffer.api
+++ b/gapis/api/vulkan/api/renderpass_framebuffer.api
@@ -360,7 +360,6 @@ cmd void vkCmdBeginRenderPass(
               args.DeviceGroupBeginInfo.RenderAreas[j] = rects[j]
             }
           }
-          default: {}
         }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }

--- a/gapis/api/vulkan/api/synchronization.api
+++ b/gapis/api/vulkan/api/synchronization.api
@@ -488,9 +488,9 @@ cmd void vkCmdWaitEvents(
     for i in (0 .. imageMemoryBarrierCount) {
       args.ImageMemoryBarriers[i] = imageMemoryBarriers[i]
       img := Images[args.ImageMemoryBarriers[i].image]
-      RecordLayoutTransition(cb, 
+      RecordLayoutTransition(cb,
         img,
-        args.ImageMemoryBarriers[i].subresourceRange, 
+        args.ImageMemoryBarriers[i].subresourceRange,
         args.ImageMemoryBarriers[i].newLayout
       )
     }
@@ -615,9 +615,9 @@ cmd void vkCmdPipelineBarrier(
     for i in (0 .. imageMemoryBarrierCount) {
       args.ImageMemoryBarriers[i] = imageMemoryBarriers[i]
       img := Images[args.ImageMemoryBarriers[i].image]
-      RecordLayoutTransition(cb, 
+      RecordLayoutTransition(cb,
         img,
-        args.ImageMemoryBarriers[i].subresourceRange, 
+        args.ImageMemoryBarriers[i].subresourceRange,
         args.ImageMemoryBarriers[i].newLayout
       )
     }

--- a/gapis/api/vulkan/api/synchronization.api
+++ b/gapis/api/vulkan/api/synchronization.api
@@ -64,8 +64,8 @@ cmd VkResult vkCreateFence(
     next := MutableVoidPtr(as!void*(create_info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // TODO: handle extensions for VkFenceCreateInfo
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
@@ -191,8 +191,8 @@ cmd VkResult vkCreateSemaphore(
     next := MutableVoidPtr(as!void*(create_info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // TODO: handle extensions for VkSemaphoreCreateInfo
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
@@ -277,8 +277,8 @@ cmd VkResult vkCreateEvent(
     next := MutableVoidPtr(as!void*(create_info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // TODO: handle extensions for VkEventCreateInfo
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
@@ -532,8 +532,8 @@ sub void handleMemoryBarriersPNext(const VkMemoryBarrier* pBarriers, u32 count) 
       next := MutableVoidPtr(as!void*(b.pNext))
       for i in (0 .. numPNext) {
         sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-        _ = sType
-        // TODO: handle extensions for VkMemoryBarrier
+        switch (sType) {
+        }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
     }
@@ -550,8 +550,8 @@ sub void handleBufferMemoryBarriersPNext(const VkBufferMemoryBarrier* pBarriers,
       next := MutableVoidPtr(as!void*(b.pNext))
       for i in (0 .. numPNext) {
         sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-        _ = sType
-        // TODO: handle extensions for VkBufferMemoryBarrier
+        switch (sType) {
+        }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
     }
@@ -568,8 +568,8 @@ sub void handleImageMemoryBarriersPNext(const VkImageMemoryBarrier* pBarriers, u
       next := MutableVoidPtr(as!void*(b.pNext))
       for i in (0 .. numPNext) {
         sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-        _ = sType
-        // TODO: handle extensions for VkImageMemoryBarrier
+        switch (sType) {
+        }
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
     }

--- a/gapis/api/vulkan/extensions/khr_get_surface_capabilities2.api
+++ b/gapis/api/vulkan/extensions/khr_get_surface_capabilities2.api
@@ -81,12 +81,12 @@ cmd VkResult vkGetPhysicalDeviceSurfaceCapabilities2KHR(
     next := MutableVoidPtr(as!void*(info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // TODO: handle extensions for VkPhysicalDeviceSurfaceInfo2KHR
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
-  
+
   if !(info.surface in Surfaces) { vkErrorInvalidSurface(info.surface) }
   if pSurfaceCapabilities == null { vkErrorNullPointer("VkSurfaceCapabilitiesKHR") }
   pSurfaceCapabilities[0] = ?
@@ -112,8 +112,8 @@ cmd VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(
     next := MutableVoidPtr(as!void*(info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // TODO: handle extensions for VkPhysicalDeviceSurfaceInfo2KHR
+      switch (sType) {
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }

--- a/gapis/api/vulkan/extensions/khr_swapchain.api
+++ b/gapis/api/vulkan/extensions/khr_swapchain.api
@@ -335,14 +335,12 @@ cmd VkResult vkQueuePresentKHR(
     next := MutableVoidPtr(as!void*(info.pNext))
     for i in (0 .. numPNext) {
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      _ = sType
-      // TODO: handle extensions for queue present
-      // Example: Device Gropu Extension
-      // switch sType {
-      //   case VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_INFO_KHR: {
-      //   ext := as!VkDeviceGroupPresentInfoKHR*(next.Ptr)[0]
-      //  }
-      // }
+      switch (sType) {
+        // TODO: handle device group extension
+        // case VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_INFO_KHR: {
+        //   ext := as!VkDeviceGroupPresentInfoKHR*(next.Ptr)[0]
+        // }
+      }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }

--- a/gapis/api/vulkan/synthetic.api
+++ b/gapis/api/vulkan/synthetic.api
@@ -191,11 +191,11 @@ cmd VkResult ReplayCreateSwapchain(
       sType := as!const VkStructureType*(next.Ptr)[0:1][0]
       switch sType {
         case VK_STRUCTURE_TYPE_VIRTUAL_SWAPCHAIN_PNEXT: {
-	  ext := as!VirtualSwapchainPNext*(next.Ptr)[0:1][0]
-	  if ext.surfaceCreateInfo != null {
+          ext := as!VirtualSwapchainPNext*(next.Ptr)[0:1][0]
+          if ext.surfaceCreateInfo != null {
             _ = as!VkStructureType*(ext.surfaceCreateInfo)[0:1][0]
           }
-	}
+        }
       }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }


### PR DESCRIPTION
Before this, any unknown sType structs in pNext chains would be ignored. Now, mutate will fail on unknown sTypes. This is preferable, since we were likely not observer memory properly, when ignoring, which could lead to odd/crashing behavior in the replayer.