### PR TITLE
Allow suboptimal `vkQueuePresentKHR`

### DIFF
--- a/cmd/vulkan_sample/main.cpp
+++ b/cmd/vulkan_sample/main.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <math.h>
+
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
@@ -22,7 +23,6 @@
 #include <iostream>
 #include <string>
 #include <unordered_set>
-
 #include <vector>
 #if _WIN32
 #include <windows.h>
@@ -30,11 +30,13 @@
 #elif defined(__ANDROID__)
 #include <android/log.h>
 #include <dlfcn.h>
+
 #include "android_native_app_glue.h"
 #define VK_USE_PLATFORM_ANDROID_KHR
 #elif defined(__linux__)
 #include <dlfcn.h>
 #include <xcb/xcb.h>
+
 #include <iostream>
 #define VK_USE_PLATFORM_XCB_KHR
 #endif
@@ -59,6 +61,126 @@ const uint32_t fragment_shader[] =
     ;
 
 const static VkFormat kDepthFormat = VK_FORMAT_D16_UNORM;
+
+static const char* vk_result_to_string(VkResult result) {
+  switch (result) {
+    case VK_SUCCESS:
+      return "Command successfully completed";
+    case VK_NOT_READY:
+      return "A fence or query has not yet completed";
+    case VK_TIMEOUT:
+      return "A wait operation has not completed in the specified time";
+    case VK_EVENT_SET:
+      return "An event is signaled";
+    case VK_EVENT_RESET:
+      return "An event is unsignaled";
+    case VK_INCOMPLETE:
+      return "A return array was too small for the result";
+    case VK_SUBOPTIMAL_KHR:
+      return "A swapchain no longer matches the surface properties exactly, "
+             "but can still be used to present to the surface successfully.";
+#ifdef VK_THREAD_IDLE_KHR
+    case VK_THREAD_IDLE_KHR:
+      return "A deferred operation is not complete but there is currently no "
+             "work for this thread to do at the time of this call.";
+#endif
+#ifdef VK_THREAD_DONE_KHR
+    case VK_THREAD_DONE_KHR:
+      return "A deferred operation is not complete but there is no work "
+             "remaining to assign to additional threads.";
+#endif
+#ifdef VK_OPERATION_DEFERRED_KHR
+    case VK_OPERATION_DEFERRED_KHR:
+      return "A deferred operation was requested and at least some of the work "
+             "was deferred.";
+#endif
+#ifdef VK_OPERATION_NOT_DEFERRED_KHR
+    case VK_OPERATION_NOT_DEFERRED_KHR:
+      return "A deferred operation was requested and no operations were "
+             "deferred.";
+#endif
+#ifdef VK_PIPELINE_COMPILE_REQUIRED_EXT
+    case VK_PIPELINE_COMPILE_REQUIRED_EXT:
+      return "A requested pipeline creation would have required compilation, "
+             "but the application requested compilation to not be performed.";
+#endif
+    case VK_ERROR_OUT_OF_HOST_MEMORY:
+      return "A host memory allocation has failed.";
+    case VK_ERROR_OUT_OF_DEVICE_MEMORY:
+      return "A device memory allocation has failed.";
+    case VK_ERROR_INITIALIZATION_FAILED:
+      return "Initialization of an object could not be completed for "
+             "implementation-specific reasons.";
+    case VK_ERROR_DEVICE_LOST:
+      return "The logical or physical device has been lost. See Lost Device";
+    case VK_ERROR_MEMORY_MAP_FAILED:
+      return "Mapping of a memory object has failed.";
+    case VK_ERROR_LAYER_NOT_PRESENT:
+      return "A requested layer is not present or could not be loaded.";
+    case VK_ERROR_EXTENSION_NOT_PRESENT:
+      return "A requested extension is not supported.";
+    case VK_ERROR_FEATURE_NOT_PRESENT:
+      return "A requested feature is not supported.";
+    case VK_ERROR_INCOMPATIBLE_DRIVER:
+      return "The requested version of Vulkan is not supported by the driver "
+             "or is otherwise incompatible for implementation-specific "
+             "reasons.";
+    case VK_ERROR_TOO_MANY_OBJECTS:
+      return "Too many objects of the type have already been created.";
+    case VK_ERROR_FORMAT_NOT_SUPPORTED:
+      return "A requested format is not supported on this device.";
+    case VK_ERROR_FRAGMENTED_POOL:
+      return "A pool allocation has failed due to fragmentation of the pool's "
+             "memory. This must only be returned if no attempt to allocate "
+             "host or device memory was made to accommodate the new "
+             "allocation. This should be returned in preference to "
+             "VK_ERROR_OUT_OF_POOL_MEMORY, but only if the implementation is "
+             "certain that the pool allocation failure was due to "
+             "fragmentation.";
+    case VK_ERROR_SURFACE_LOST_KHR:
+      return "A surface is no longer available.";
+    case VK_ERROR_NATIVE_WINDOW_IN_USE_KHR:
+      return "The requested window is already in use by Vulkan or another API "
+             "in a manner which prevents it from being used again.";
+    case VK_ERROR_OUT_OF_DATE_KHR:
+      return "A surface has changed in such a way that it is no longer "
+             "compatible with the swapchain, and further presentation requests "
+             "using the swapchain will fail. Applications must query the new "
+             "surface properties and recreate their swapchain if they wish to "
+             "continue presenting to the surface.";
+    case VK_ERROR_INCOMPATIBLE_DISPLAY_KHR:
+      return "The display used by a swapchain does not use the same "
+             "presentable image layout, or is incompatible in a way that "
+             "prevents sharing an image.";
+    case VK_ERROR_INVALID_SHADER_NV:
+      return "One or more shaders failed to compile or link. More details are "
+             "reported back to the application via VK_EXT_debug_report if "
+             "enabled.";
+    case VK_ERROR_OUT_OF_POOL_MEMORY:
+      return "A pool memory allocation has failed. This must only be returned "
+             "if no attempt to allocate host or device memory was made to "
+             "accommodate the new allocation. If the failure was definitely "
+             "due to fragmentation of the pool, VK_ERROR_FRAGMENTED_POOL "
+             "should be returned instead.";
+    case VK_ERROR_INVALID_EXTERNAL_HANDLE:
+      return "An external handle is not a valid handle of the specified type.";
+    case VK_ERROR_FRAGMENTATION:
+      return "A descriptor pool creation has failed due to fragmentation.";
+    case VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS:
+      return "A buffer creation or memory allocation failed because the "
+             "requested address is not available. A shader group handle "
+             "assignment failed because the requested shader group handle "
+             "information is no longer valid.";
+    case VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT:
+      return "An operation on a swapchain created with "
+             "VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT failed as it "
+             "did not have exlusive full-screen access. This may occur due to "
+             "implementation-dependent reasons, outside of the application's "
+             "control.";
+    default:
+      return "Unknown VkResult";
+  }
+}
 
 #if _WIN32
 HWND kNativeWindowHandle;
@@ -423,13 +545,24 @@ int main(int argc, const char** argv) {
           dlsym(kVulkanLibraryHandle, "vkGetInstanceProcAddr"));
 #endif
 
-#define REQUIRE_SUCCESS(fn)                          \
-  do {                                               \
-    if (VK_SUCCESS != fn) {                          \
-      write_error(kOutHandle, "Vulkan Error: " #fn); \
-      return -1;                                     \
-    }                                                \
+#define REQUIRE_RESULT(fn, ...)                           \
+  do {                                                    \
+    const VkResult valid[] = {__VA_ARGS__};               \
+    const size_t size = sizeof(valid) / sizeof(valid[0]); \
+    const VkResult res = fn;                              \
+    bool ok = false;                                      \
+    for (size_t i = 0; i < size && !ok; ++i) {            \
+      ok = (res == valid[i]);                             \
+    }                                                     \
+    if (!ok) {                                            \
+      std::string msg = "Vulkan Error: " #fn ": ";        \
+      msg += vk_result_to_string(res);                    \
+      write_error(kOutHandle, msg.data());                \
+      return -1;                                          \
+    }                                                     \
   } while (0)
+
+#define REQUIRE_SUCCESS(fn) REQUIRE_RESULT(fn, VK_SUCCESS)
 
 #define LOAD_INSTANCE_FUNCTION(name, instance) \
   PFN_##name name =                            \
@@ -1711,8 +1844,9 @@ int main(int argc, const char** argv) {
                                   &next_image,
                                   &result};
 
-    REQUIRE_SUCCESS(vkQueuePresentKHR(queue, &present_info));
-    REQUIRE_SUCCESS(result);
+    REQUIRE_RESULT(vkQueuePresentKHR(queue, &present_info), VK_SUCCESS,
+                   VK_SUBOPTIMAL_KHR);
+    REQUIRE_RESULT(result, VK_SUCCESS, VK_SUBOPTIMAL_KHR);
   }
 
   return 0;


### PR DESCRIPTION
Adds `vkResult` message conversion in the error message.
Helps quickly diagnose the crash reason.