### PR TITLE
Prefer write typed observations over reads.

### DIFF
--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -262,6 +262,8 @@ message TypedMemoryRange {
   uint64 root = 3;
   // The structured value of the typed memory observation.
   memory_box.Value value = 4;
+  // Whether this is a write (true) or read (false) observation.
+  bool write = 5;
 }
 
 message Messages {


### PR DESCRIPTION
This adds a flag to the typed observation indicating whether they are write vs read observations. The server, however, currently still filters them and returns only one of them, but it will now prefer the write over the read.