### PR TITLE
Fix a corner case in memory block's page loading request.

### DIFF
--- a/gapic/src/main/com/google/gapid/models/Memory.java
+++ b/gapic/src/main/com/google/gapid/models/Memory.java
@@ -204,7 +204,7 @@ public class Memory extends DeviceDependentModel<Memory.Data, Memory.Source, Voi
       List<ListenableFuture<Segment>> futures = Lists.newArrayList();
       futures.add(getPage(firstPage, getOffsetInPage(offset), PAGE_SIZE - getOffsetInPage(offset)));
       for (long page = firstPage + 1, left = length - PAGE_SIZE + getOffsetInPage(offset);
-          page <= lastPage; page++, left -= PAGE_SIZE) {
+          page <= lastPage && left >= 0; page++, left -= PAGE_SIZE) {
         futures.add(getPage(page, 0, (int)Math.min(left, PAGE_SIZE)));
       }
 


### PR DESCRIPTION
When request to load memory pages, in certain conditions, the left
memory size will get assigned to a negative value based on calculations.
In such case, we shouldn't emit a memory loading request for this
negative-sized page.
Add a value check to avoid this scenario.

Bug: b/181012589.