### PR TITLE
Add gapit trim_initial_state

### DIFF
--- a/cmd/gapit/BUILD.bazel
+++ b/cmd/gapit/BUILD.bazel
@@ -50,7 +50,7 @@ go_library(
         "sxs_video.go",
         "trace.go",
         "trim.go",
-        "trim_initial_state.go",
+        "trim_state.go",
         "unpack.go",
         "validate_gpu_profiling.go",
         "video.go",

--- a/cmd/gapit/BUILD.bazel
+++ b/cmd/gapit/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
         "sxs_video.go",
         "trace.go",
         "trim.go",
+        "trim_initial_state.go",
         "unpack.go",
         "validate_gpu_profiling.go",
         "video.go",

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -413,7 +413,7 @@ type (
 		CommandFilterFlags
 		CaptureFileFlags
 	}
-	TrimInitialStateFlags struct {
+	TrimStateFlags struct {
 		Gapis GapisFlags
 		Gapir GapirFlags
 		Out   string `help:"gfxtrace file to save the trimmed capture"`

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -413,6 +413,12 @@ type (
 		CommandFilterFlags
 		CaptureFileFlags
 	}
+	TrimInitialStateFlags struct {
+		Gapis GapisFlags
+		Gapir GapirFlags
+		Out   string `help:"gfxtrace file to save the trimmed capture"`
+		CaptureFileFlags
+	}
 	GetTimestampsFlags struct {
 		Gapis     GapisFlags
 		Gapir     GapirFlags

--- a/cmd/gapit/trim_initial_state.go
+++ b/cmd/gapit/trim_initial_state.go
@@ -1,0 +1,67 @@
+// Copyright (C) 2021 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"io/ioutil"
+
+	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/log"
+)
+
+type trimInitialStateVerb struct{ TrimInitialStateFlags }
+
+func init() {
+	verb := &trimInitialStateVerb{}
+	app.AddVerb(&app.Verb{
+		Name:      "trim_initial_state",
+		ShortHelp: "(WIP) Trims a gfx trace's initial state to the resources actually used by the commands",
+		Action:    verb,
+	})
+}
+
+func (verb *trimInitialStateVerb) Run(ctx context.Context, flags flag.FlagSet) error {
+	if flags.NArg() != 1 {
+		app.Usage(ctx, "Exactly one gfx trace file expected, got %d", flags.NArg())
+		return nil
+	}
+
+	client, capture, err := getGapisAndLoadCapture(ctx, verb.Gapis, verb.Gapir, flags.Arg(0), verb.CaptureFileFlags)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	c, err := client.TrimCaptureInitialState(ctx, capture)
+	if err != nil {
+		return log.Errf(ctx, err, "TrimCaptureInitialState(%v)", capture)
+	}
+
+	data, err := client.ExportCapture(ctx, c)
+	if err != nil {
+		return log.Errf(ctx, err, "ExportCapture(%v)", c)
+	}
+
+	output := verb.Out
+	if output == "" {
+		output = "initialStateTrimmed.gfxtrace"
+	}
+	if err := ioutil.WriteFile(output, data, 0666); err != nil {
+		return log.Errf(ctx, err, "Writing file: %v", output)
+	}
+	return nil
+}

--- a/cmd/gapit/trim_state.go
+++ b/cmd/gapit/trim_state.go
@@ -23,18 +23,18 @@ import (
 	"github.com/google/gapid/core/log"
 )
 
-type trimInitialStateVerb struct{ TrimInitialStateFlags }
+type trimStateVerb struct{ TrimStateFlags }
 
 func init() {
-	verb := &trimInitialStateVerb{}
+	verb := &trimStateVerb{}
 	app.AddVerb(&app.Verb{
-		Name:      "trim_initial_state",
-		ShortHelp: "(WIP) Trims a gfx trace's initial state to the resources actually used by the commands",
+		Name:      "trim_state",
+		ShortHelp: "Trims a gfx trace's initial state to the resources actually used by the commands",
 		Action:    verb,
 	})
 }
 
-func (verb *trimInitialStateVerb) Run(ctx context.Context, flags flag.FlagSet) error {
+func (verb *trimStateVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	if flags.NArg() != 1 {
 		app.Usage(ctx, "Exactly one gfx trace file expected, got %d", flags.NArg())
 		return nil

--- a/gapis/api/state.go
+++ b/gapis/api/state.go
@@ -84,6 +84,10 @@ type State interface {
 	// It can fill in any derived data which we choose not to serialize,
 	// or it can apply backward-compatibility fixes for older traces.
 	SetupInitialState(ctx context.Context, state *GlobalState)
+
+	// TrimInitialState removes some parts of the state that are
+	// not used by the capture commands.
+	TrimInitialState(ctx context.Context, p *path.Capture) error
 }
 
 // NewStateWithEmptyAllocator returns a new, default-initialized State object,

--- a/gapis/api/test/test.go
+++ b/gapis/api/test/test.go
@@ -54,6 +54,11 @@ func (s *State) Root(ctx context.Context, p *path.State, r *path.ResolveConfig) 
 // or it can apply backward-compatibility fixes for older traces.
 func (*State) SetupInitialState(ctx context.Context, state *api.GlobalState) {}
 
+// TrimInitialState is needed to implement the State interface.
+func (*State) TrimInitialState(ctx context.Context, capturePath *path.Capture) error {
+	return nil
+}
+
 func (i Remapped) remap(cmd api.Cmd, s *api.GlobalState) (interface{}, bool) {
 	return i, true
 }

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -78,6 +78,137 @@ func (s *State) SetupInitialState(ctx context.Context, state *api.GlobalState) {
 	}
 }
 
+// TrimInitialState scans the capture commands to see which parts of the initial
+// state are actually used, and removes some unused parts from it.
+//
+// Note: the current approach consists in "manually" monitoring which Vulkan
+// objects are being used in callbacks passed to sync.MutateWithSubcommands,
+// however this basically re-encode some state tracking logic found in the API
+// files. A better way would be to use an api.StateWatcher and rely on api.RefID
+// to track which objects are accessed: this would avoid to re-encode state
+// tracking logic here. There might be some pitfalls though, e.g. when a command
+// just reads the handle of an object, the state watcher would not mark an
+// access to that object. For instance, when creating a derivate pipeline, a
+// VkPipeline handle is used in BasePipelineHandle, the API implementation reads
+// this handle, but does not access the corresponding object. So using
+// api.StateWatcher might need some wider design considerations.
+func (s *State) TrimInitialState(ctx context.Context, capturePath *path.Capture) error {
+	// Parts of the state we want to record the usage of.
+	descriptorSets := map[VkDescriptorSet]struct{}{}
+	pipelines := map[VkPipeline]struct{}{}
+
+	// Record usage in initial state.
+	for _, i := range s.LastComputeInfos().All() {
+		pipelines[i.ComputePipeline().VulkanHandle()] = struct{}{}
+	}
+	for _, i := range s.LastDrawInfos().All() {
+		for _, d := range i.DescriptorSets().All() {
+			descriptorSets[d.VulkanHandle()] = struct{}{}
+		}
+		pipelines[i.GraphicsPipeline().VulkanHandle()] = struct{}{}
+	}
+
+	// Record usage in the trace commands
+	// top-level commands
+	postCmdCb := func(s *api.GlobalState, subCmdIdx api.SubCmdIdx, cmd api.Cmd) {
+		switch cmd := cmd.(type) {
+		case *VkFreeDescriptorSets:
+			count := cmd.DescriptorSetCount()
+			ds, err := cmd.PDescriptorSets().Slice(0, (uint64)(count), s.MemoryLayout).Read(ctx, cmd, s, nil)
+			if err != nil {
+				panic("Read error")
+			}
+			for _, d := range ds {
+				descriptorSets[d] = struct{}{}
+			}
+
+		case *VkDestroyPipeline:
+			pipelines[cmd.Pipeline()] = struct{}{}
+		}
+
+	}
+	// sub-commands
+	postSubCmdCb := func(state *api.GlobalState, subCmdIdx api.SubCmdIdx, cmd api.Cmd, i interface{}) {
+		vkState := GetState(state)
+		cmdRef, ok := i.(CommandReferenceʳ)
+		if !ok {
+			panic("In Vulkan, MutateWithSubcommands' postSubCmdCb 'interface{}' is not a CommandReferenceʳ")
+		}
+		cmdArgs := GetCommandArgs(ctx, cmdRef, vkState)
+
+		switch args := cmdArgs.(type) {
+		case VkCmdBindDescriptorSetsArgsʳ:
+			for _, d := range args.DescriptorSets().All() {
+				descriptorSets[d] = struct{}{}
+			}
+
+		case VkCmdBindPipelineArgsʳ:
+			pipelines[args.Pipeline()] = struct{}{}
+		}
+	}
+	c, err := capture.ResolveGraphicsFromPath(ctx, capturePath)
+	if err != nil {
+		return err
+	}
+	if err := sync.MutateWithSubcommands(ctx, capturePath, c.Commands, postCmdCb, nil, postSubCmdCb); err != nil {
+		return err
+	}
+
+	// Transitive dependencies
+
+	// Each pipeline may be derived from a base pipeline, in which case this
+	// base pipeline must be added to the list of used pipelines. Loop on this
+	// until we have a stable number of pipelines.
+	for numPipelines := 0; numPipelines != len(pipelines); {
+		numPipelines = len(pipelines)
+		for p := range pipelines {
+			// For both graphics and compute derivative pipelines which are
+			// created using BasePipelineIndex, our API implementation makes
+			// sure that the relevant pipeline handle is set in BasePipeline.
+			// Thus, we can safely use the value in BasePipeline. See the
+			// post-fence code in vkCreate*Pipelines in
+			// gapis/api/vulkan/api/pipeline.api
+			g := s.GraphicsPipelines().Get(p)
+			if !g.IsNil() && (VkPipelineCreateFlagBits(g.Flags())&VkPipelineCreateFlagBits_VK_PIPELINE_CREATE_DERIVATIVE_BIT) != 0 {
+				pipelines[g.BasePipeline()] = struct{}{}
+			}
+			c := s.ComputePipelines().Get(p)
+			if !c.IsNil() && (VkPipelineCreateFlagBits(c.Flags())&VkPipelineCreateFlagBits_VK_PIPELINE_CREATE_DERIVATIVE_BIT) != 0 {
+				pipelines[c.BasePipeline()] = struct{}{}
+			}
+		}
+	}
+
+	// Remove unused parts.
+	var startSize int
+
+	startSize = s.DescriptorSets().Len()
+	for h := range s.DescriptorSets().All() {
+		if _, ok := descriptorSets[h]; !ok {
+			s.DescriptorSets().Remove(h)
+		}
+	}
+	log.I(ctx, "Trim initial state: DescriptorSets: %v/%v kept", s.DescriptorSets().Len(), startSize)
+
+	startSize = s.GraphicsPipelines().Len()
+	for h := range s.GraphicsPipelines().All() {
+		if _, ok := pipelines[h]; !ok {
+			s.GraphicsPipelines().Remove(h)
+		}
+	}
+	log.I(ctx, "Trim initial state: GraphicsPipelines: %v/%v kept", s.GraphicsPipelines().Len(), startSize)
+
+	startSize = s.ComputePipelines().Len()
+	for h := range s.ComputePipelines().All() {
+		if _, ok := pipelines[h]; !ok {
+			s.ComputePipelines().Remove(h)
+		}
+	}
+	log.I(ctx, "Trim initial state: ComputePipelines: %v/%v kept", s.ComputePipelines().Len(), startSize)
+
+	return nil
+}
+
 func (API) GetFramebufferAttachmentInfos(
 	ctx context.Context,
 	state *api.GlobalState) (info []api.FramebufferAttachmentInfo, err error) {

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -98,14 +98,14 @@ func (s *State) TrimInitialState(ctx context.Context, capturePath *path.Capture)
 	pipelines := map[VkPipeline]struct{}{}
 
 	// Record usage in initial state.
-	for _, i := range s.LastComputeInfos().All() {
-		pipelines[i.ComputePipeline().VulkanHandle()] = struct{}{}
+	for _, ci := range s.LastComputeInfos().All() {
+		pipelines[ci.ComputePipeline().VulkanHandle()] = struct{}{}
 	}
-	for _, i := range s.LastDrawInfos().All() {
-		for _, d := range i.DescriptorSets().All() {
+	for _, di := range s.LastDrawInfos().All() {
+		for _, d := range di.DescriptorSets().All() {
 			descriptorSets[d.VulkanHandle()] = struct{}{}
 		}
-		pipelines[i.GraphicsPipeline().VulkanHandle()] = struct{}{}
+		pipelines[di.GraphicsPipeline().VulkanHandle()] = struct{}{}
 	}
 
 	// Record usage in the trace commands

--- a/gapis/client/client.go
+++ b/gapis/client/client.go
@@ -505,6 +505,19 @@ func (c *client) SplitCapture(ctx context.Context, rng *path.Commands) (*path.Ca
 	return res.GetCapture(), nil
 }
 
+func (c *client) TrimCaptureInitialState(ctx context.Context, p *path.Capture) (*path.Capture, error) {
+	res, err := c.client.TrimCaptureInitialState(ctx, &service.TrimCaptureInitialStateRequest{
+		Capture: p,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := res.GetError(); err != nil {
+		return nil, err.Get()
+	}
+	return res.GetCapture(), nil
+}
+
 func (c *client) UpdateSettings(ctx context.Context, req *service.UpdateSettingsRequest) error {
 	res, err := c.client.UpdateSettings(ctx, req)
 	if err != nil {

--- a/gapis/resolve/dependencygraph2/dependency_graph_test.go
+++ b/gapis/resolve/dependencygraph2/dependency_graph_test.go
@@ -77,6 +77,8 @@ func (TestRef) Root(ctx context.Context, p *path.State, r *path.ResolveConfig) (
 
 func (TestRef) SetupInitialState(ctx context.Context, state *api.GlobalState) {}
 
+func (TestRef) TrimInitialState(ctx context.Context, p *path.Capture) error { return nil }
+
 func newTestRef() TestRef {
 	return TestRef{api.NewRefID()}
 }

--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -591,6 +591,15 @@ func (s *grpcServer) SplitCapture(ctx xctx.Context, req *service.SplitCaptureReq
 	return &service.SplitCaptureResponse{Res: &service.SplitCaptureResponse_Capture{Capture: res}}, nil
 }
 
+func (s *grpcServer) TrimCaptureInitialState(ctx xctx.Context, req *service.TrimCaptureInitialStateRequest) (*service.TrimCaptureInitialStateResponse, error) {
+	defer s.inRPC()()
+	res, err := s.handler.TrimCaptureInitialState(s.bindCtx(ctx), req.Capture)
+	if err := service.NewError(err); err != nil {
+		return &service.TrimCaptureInitialStateResponse{Res: &service.TrimCaptureInitialStateResponse_Error{Error: err}}, nil
+	}
+	return &service.TrimCaptureInitialStateResponse{Res: &service.TrimCaptureInitialStateResponse_Capture{Capture: res}}, nil
+}
+
 func (s *grpcServer) TraceTargetTreeNode(ctx xctx.Context, req *service.TraceTargetTreeNodeRequest) (*service.TraceTargetTreeNodeResponse, error) {
 	defer s.inRPC()()
 	res, err := s.handler.TraceTargetTreeNode(s.bindCtx(ctx), req)

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -310,11 +310,17 @@ func (s *server) TrimCaptureInitialState(ctx context.Context, p *path.Capture) (
 		return nil, err
 	}
 
-	for _, api := range c.APIs {
-		c.InitialState.APIs[api].TrimInitialState(ctx, p)
+	initialState := c.CloneInitialState()
+	for _, state := range initialState.APIs {
+		state.TrimInitialState(ctx, p)
 	}
 
-	return c.Path(ctx)
+	newCapture, err := capture.NewGraphicsCapture(ctx, c.Name(), c.Header, initialState, c.Commands)
+	if err != nil {
+		return nil, err
+	}
+
+	return newCapture.Path(ctx)
 }
 
 func (s *server) GetGraphVisualization(ctx context.Context, p *path.Capture, format service.GraphFormat) ([]byte, error) {

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -303,6 +303,20 @@ func (s *server) SplitCapture(ctx context.Context, rng *path.Commands) (*path.Ca
 	}
 }
 
+func (s *server) TrimCaptureInitialState(ctx context.Context, p *path.Capture) (*path.Capture, error) {
+	ctx = log.Enter(ctx, "TrimCaptureInitialState")
+	c, err := capture.ResolveGraphicsFromPath(ctx, p)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, api := range c.APIs {
+		c.InitialState.APIs[api].TrimInitialState(ctx, p)
+	}
+
+	return c.Path(ctx)
+}
+
 func (s *server) GetGraphVisualization(ctx context.Context, p *path.Capture, format service.GraphFormat) ([]byte, error) {
 	ctx = status.Start(ctx, "RPC GetGraphVisualization")
 	defer status.Finish(ctx)

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -184,6 +184,10 @@ type Service interface {
 	// Split out a new capture containing a subset of another capture's commands.
 	SplitCapture(ctx context.Context, rng *path.Commands) (*path.Capture, error)
 
+	// TrimCaptureInitialState returns a new capture with an initial state
+	// trimmed from resources not needed by the capture commands.
+	TrimCaptureInitialState(ctx context.Context, p *path.Capture) (*path.Capture, error)
+
 	// ValidateDevice validates the GPU profiling capabilities of the given device and returns
 	// an error if validation failed or the GPU profiling data is invalid.
 	ValidateDevice(ctx context.Context, d *path.Device) error

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -638,6 +638,12 @@ service Gapid {
   rpc SplitCapture(SplitCaptureRequest) returns (SplitCaptureResponse) {
   }
 
+  // TrimCaptureInitialState returns a new capture with an initial state trimmed
+  // from resources not needed by the capture commands.
+  rpc TrimCaptureInitialState(TrimCaptureInitialStateRequest)
+      returns (TrimCaptureInitialStateResponse) {
+  }
+
   ///////////////////////////////////////////////////////////////
   // Below are debugging APIs which may be removed in the future.
   ///////////////////////////////////////////////////////////////
@@ -1317,6 +1323,17 @@ message SplitCaptureRequest {
 }
 
 message SplitCaptureResponse {
+  oneof res {
+    path.Capture capture = 1;
+    Error error = 2;
+  }
+}
+
+message TrimCaptureInitialStateRequest {
+  path.Capture capture = 1;
+}
+
+message TrimCaptureInitialStateResponse {
   oneof res {
     path.Capture capture = 1;
     Error error = 2;


### PR DESCRIPTION
The new gapit verb trim_initial_state takes a capture, records which
parts of the initial state are actually used by the capture commands,
and returns a new capture where some unused parts of the initial state
have been removed.

This first version removes unused descriptor sets and unused
pipelines.

This trimming should help reducing the memory consumed by GAPIS. On a
capture that has thousands of unused descriptor sets and pipelines,
the memory consumed by GAPIS after opening the trace in the UI drops
by 10% VIRT (total virtual memory) and 25% for RES (resident memory)
when using the trimmed version of the capture.

Bug: b/178699413, b/157557996