### PR TITLE
Fix infinite loop when resolving piplines/meshes for command 0.

### DIFF
--- a/gapis/resolve/mesh.go
+++ b/gapis/resolve/mesh.go
@@ -63,8 +63,8 @@ func meshFor(ctx context.Context, o interface{}, p *path.Mesh, r *path.ResolveCo
 		}
 
 		cmd := append([]uint64{}, o.Commands.From...) // make a copy of o.Commands.From
-		for i := o.Commands.To[lastSubcommand]; i >= o.Commands.From[lastSubcommand]; i-- {
-			cmd[lastSubcommand] = i
+		for i := int64(o.Commands.To[lastSubcommand]); i >= int64(o.Commands.From[lastSubcommand]); i-- {
+			cmd[lastSubcommand] = uint64(i)
 			p := o.Commands.Capture.Command(cmd[0], cmd[1:]...).Mesh(p.Options)
 			if mesh, err := meshFor(ctx, cmds[o.Commands.From[0]], p, r); err != api.ErrMeshNotAvailable {
 				return mesh, err

--- a/gapis/resolve/pipeline.go
+++ b/gapis/resolve/pipeline.go
@@ -77,8 +77,8 @@ func pipelinesFor(ctx context.Context, o interface{}, p *path.Pipelines, r *path
 		}
 
 		cmd := append([]uint64{}, o.Commands.From...) // make a copy of o.Commands.From
-		for i := o.Commands.To[lastSubcommand]; i >= o.Commands.From[lastSubcommand]; i-- {
-			cmd[lastSubcommand] = i
+		for i := int64(o.Commands.To[lastSubcommand]); i >= int64(o.Commands.From[lastSubcommand]); i-- {
+			cmd[lastSubcommand] = uint64(i)
 			p := o.Commands.Capture.Command(cmd[0], cmd[1:]...).Pipelines()
 			if pl, err := pipelinesFor(ctx, cmds[o.Commands.From[0]], p, r); err != api.ErrPipelineNotAvailable {
 				return pl, err


### PR DESCRIPTION
If command 0 was included in the range of commands to resolve the meshes or piplines for, we would end up looping infinitely, as the loop iterator was unsigned.