### PR TITLE
Remove AHardwareBuffer from vkFrameBoundaryANDROID

### DIFF
--- a/gapii/cc/vulkan_extras.inc
+++ b/gapii/cc/vulkan_extras.inc
@@ -162,5 +162,4 @@ void parseShaderModule(
 // the next layer/ICD implementation of that function.
 void SpyOverride_vkFrameBoundaryANDROID(VkDevice device,
                                         VkSemaphore semaphore,
-                                        VkImage image,
-                                        AHardwareBuffer* buffer) {}
+                                        VkImage image) {}

--- a/gapis/api/vulkan/extensions/android_frame_boundary.api
+++ b/gapis/api/vulkan/extensions/android_frame_boundary.api
@@ -21,22 +21,11 @@
 //
 // As this extension won't be defined by Khronos vulkan headers, use this:
 //
-// typedef void (VKAPI_PTR *PFN_vkFrameBoundaryANDROID)(VkDevice device, VkSemaphore semaphore, VkImage image, AHardwareBuffer* buffer);
+// typedef void (VKAPI_PTR *PFN_vkFrameBoundaryANDROID)(VkDevice device, VkSemaphore semaphore, VkImage image);
 //
 // Make sure to load this function only when the device supports
 // "VK_ANDROID_frame_boundary", this support will be present only when AGI's
 // spy vulkan layer is present (i.e., when AGI traces the app).
-
-/////////////
-// Structs //
-/////////////
-
-// TODO: In due time, this will be declared in the implementation of
-// VK_ANDROID_external_memory_android_hardware_buffer
-@platform("VK_USE_PLATFORM_ANDROID_KHR")
-@extension("VK_ANDROID_external_memory_android_hardware_buffer")
-@forwarddecl
-class AHardwareBuffer {}
 
 //////////////
 // Commands //
@@ -50,8 +39,7 @@ class AHardwareBuffer {}
 cmd void vkFrameBoundaryANDROID(
     VkDevice                device,
     VkSemaphore             semaphore,
-    VkImage                 image,
-    AHardwareBuffer*        buffer) {
+    VkImage                 image) {
 
   if !(device in Devices) { vkErrorInvalidDevice(device) }
   if !(semaphore in Semaphores) { vkErrorInvalidSemaphore(semaphore) }

--- a/gapis/api/vulkan/templates/vulkan_layer.tmpl
+++ b/gapis/api/vulkan/templates/vulkan_layer.tmpl
@@ -74,8 +74,7 @@
 
 #if defined(__ANDROID__)
 // Support VK_ANDROID_frame_boundary, which is not defined by Khronos
-struct AHardwareBuffer;
-typedef void (VKAPI_PTR *PFN_vkFrameBoundaryANDROID)(VkDevice device, VkSemaphore semaphore, VkImage image, AHardwareBuffer* buffer);
+typedef void (VKAPI_PTR *PFN_vkFrameBoundaryANDROID)(VkDevice device, VkSemaphore semaphore, VkImage image);
 #endif // __ANDROID__
 
 #include "core/vulkan/layer_helpers/threading.h"


### PR DESCRIPTION
We agreed with pmuetschard@ that we can do without it.

Bug: n/a