### PR TITLE
Ensure the port message always is on its own line.

### DIFF
--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -66,7 +66,7 @@ func NewWithListener(ctx context.Context, l net.Listener, cfg Config, srvChan ch
 		done <- grpcutil.ServeWithListener(ctx, l, func(ctx context.Context, listener net.Listener, server *grpc.Server) error {
 			if addr, ok := listener.Addr().(*net.TCPAddr); ok {
 				// The following message is parsed by launchers to detect the selected port. DO NOT CHANGE!
-				fmt.Printf("Bound on port '%d'\n", addr.Port)
+				fmt.Printf("\nBound on port '%d'\n", addr.Port)
 			}
 			service.RegisterGapidServer(server, s)
 			if srvChan != nil {


### PR DESCRIPTION
Don't assume that `fmt.Printf` starts on a new line, in case it gets invoked in-between a log message printing its message and its new-line.

Bug: http://b/144158856