### PR TITLE
Fix a random Profile slice highlighting issue.

### DIFF
--- a/gapic/src/main/com/google/gapid/views/ProfileView.java
+++ b/gapic/src/main/com/google/gapid/views/ProfileView.java
@@ -200,6 +200,7 @@ public class ProfileView extends Composite implements Tab, Capture.Listener, Pro
     }
 
     public void update(Profile.Data data) {
+      tracks.clear();
       panels.clear();
 
       Service.ProfilingData.GpuSlices slices = data.getSlices();


### PR DESCRIPTION
This bug may happen when a single AGI session opens different graphics traces
consecutively. When selecting one renderpass, sometimes in the Profile tab,
slices belonging to different renderpasses will get highlighted altogether.

This bug is caused by not clearing the earlier traces' GPU track status when
loading a new graphics trace. In this way, at the slices combination stage,
those slices from previous traces will get combined as well, and their slice
ids will get wrongly used in the current trace, and thus cause wrong highlighting.

Bug: N/A.
Test: Open different traces one by one.