### PR TITLE
Report render target's size for each renderpass slice in Profile tab.

### DIFF
--- a/gapic/src/main/com/google/gapid/views/ProfileView.java
+++ b/gapic/src/main/com/google/gapid/views/ProfileView.java
@@ -24,6 +24,7 @@ import static com.google.gapid.util.Loadable.MessageType.Loading;
 import static java.util.logging.Level.WARNING;
 import static java.util.stream.Collectors.toList;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
@@ -397,7 +398,16 @@ public class ProfileView extends Composite implements Tab, Capture.Listener, Pro
             data.depths[i] = s.getDepth();
             data.titles[i] = s.getLabel();
             data.categories[i] = "";
-            data.args[i] = ArgSet.EMPTY;
+            ImmutableMap.Builder<String, Object> map = ImmutableMap.builder();
+            for (Service.ProfilingData.GpuSlices.Slice.Extra extra: s.getExtrasList()) {
+              switch (extra.getValueCase()) {
+                case INT_VALUE: map.put(extra.getName(), extra.getIntValue()); break;
+                case DOUBLE_VALUE: map.put(extra.getName(), extra.getDoubleValue()); break;
+                case STRING_VALUE: map.put(extra.getName(), extra.getStringValue()); break;
+                case VALUE_NOT_SET: break;
+              }
+            }
+            data.args[i] = new ArgSet(map.build());
           }
           return data;
         });


### PR DESCRIPTION
This was already in System Profiler and we got request from users to
have the same thing in Frame Profiler. The logic of appending the size
to a renderpass slice's name is already shared by Frame Profiler and
System Profiler, but the missing part is that in Frame Profiler we
didn't have argument set information in place, and thus we missed the
width/height information. This PR fills this gap.

Bug: b/169454084.
Test: Observe slices' name in Frame Profiler - Profile tab. Test on an
adreno phone since currently we only have width/height info in argument
set from these devices.