### PR TITLE
Improve error message for app crash during capture

### DIFF
--- a/gapii/client/capture.go
+++ b/gapii/client/capture.go
@@ -144,7 +144,7 @@ func handleCommError(ctx context.Context, commErr error, anyDataReceived bool) (
 		abort = true
 		// Most of the time, this error happens when the app crashed: rather
 		// than reporting just "EOF", hint that this was probably a crash.
-		err = log.Err(ctx, commErr, "It looks like the app terminated (crashed?) before we could finish the capture")
+		err = log.Err(ctx, commErr, "The application exited during the capture")
 	case commErr != nil && anyDataReceived:
 		netErr, isnet := commErr.(net.Error)
 		if !isnet || (!netErr.Temporary() && !netErr.Timeout()) {

--- a/gapii/client/capture.go
+++ b/gapii/client/capture.go
@@ -142,7 +142,9 @@ func handleCommError(ctx context.Context, commErr error, anyDataReceived bool) (
 	case errors.Cause(commErr) == io.EOF:
 		log.E(ctx, "unexpected end of stream")
 		abort = true
-		err = commErr
+		// Most of the time, this error happens when the app crashed: rather
+		// than reporting just "EOF", hint that this was probably a crash.
+		err = log.Err(ctx, commErr, "It looks like the app terminated (crashed?) before we could finish the capture")
 	case commErr != nil && anyDataReceived:
 		netErr, isnet := commErr.(net.Error)
 		if !isnet || (!netErr.Temporary() && !netErr.Timeout()) {


### PR DESCRIPTION
When the app being captured crashes, the error message presented to
the end user only said "EOF". This change indicate that such errors
are likely to be app early termination / app crash.

Bug: b/179234685
Test: Manual