### PR TITLE
Support downloading Perfetto trace data during capture.

### DIFF
--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -400,10 +400,13 @@ func (b *binding) QueryPerfettoServiceState(ctx context.Context) (*device.Perfet
 	}
 	result.GpuProfiling = gpu
 
-	// SurfaceFlinger frame lifecycle perfetto producer is mandated by Android 11 CTS, hence it will
-	// always exist.
 	if b.Instance().GetConfiguration().GetOS().GetAPIVersion() >= 30 {
+		// SurfaceFlinger frame lifecycle perfetto producer is mandated by Android 11 CTS, hence it will
+		// always exist.
 		result.HasFrameLifecycle = true
+
+		// This has anecdotally not worked well in Q, but appears to be fine in R.
+		result.CanDownloadWhileTracing = true
 	}
 
 	services, err := b.Shell("service", "list").Call(ctx)

--- a/core/os/device/device.proto
+++ b/core/os/device/device.proto
@@ -187,6 +187,7 @@ message PerfettoCapability {
   bool can_specify_atrace_apps = 3;
   bool has_frame_lifecycle = 4;
   bool has_power_rail = 5;
+  bool can_download_while_tracing = 6;
 }
 
 message GPUProfiling {

--- a/core/os/device/device.proto
+++ b/core/os/device/device.proto
@@ -185,8 +185,8 @@ message PerfettoCapability {
   GPUProfiling gpu_profiling = 1;
   VulkanProfilingLayers vulkan_profile_layers = 2;
   bool can_specify_atrace_apps = 3;
-  bool hasFrameLifecycle = 4;
-  bool hasPowerRail = 5;
+  bool has_frame_lifecycle = 4;
+  bool has_power_rail = 5;
 }
 
 message GPUProfiling {

--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
@@ -38,6 +38,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.logging.Level.WARNING;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
+import static perfetto.protos.PerfettoConfig.TraceConfig.BufferConfig.FillPolicy.RING_BUFFER;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
@@ -88,7 +89,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import perfetto.protos.PerfettoConfig;
-import perfetto.protos.PerfettoConfig.TraceConfig.BufferConfig.FillPolicy;
 
 public class TraceConfigDialog extends DialogBase {
   protected static final Logger LOG = Logger.getLogger(TraceConfigDialog.class.getName());
@@ -345,11 +345,11 @@ public class TraceConfigDialog extends DialogBase {
     // Buffer 0 (default): main buffer.
     config.addBuffers(PerfettoConfig.TraceConfig.BufferConfig.newBuilder()
         .setSizeKb(MAIN_BUFFER_SIZE)
-        .setFillPolicy(FillPolicy.DISCARD));
+        .setFillPolicy(RING_BUFFER));
     // Buffer 1: Initial process metadata.
     config.addBuffers(PerfettoConfig.TraceConfig.BufferConfig.newBuilder()
         .setSizeKb(PROC_BUFFER_SIZE)
-        .setFillPolicy(FillPolicy.DISCARD));
+        .setFillPolicy(RING_BUFFER));
 
     config.setFlushPeriodMs(FLUSH_PERIOD);
     config.setDurationMs(duration);

--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
@@ -353,7 +353,8 @@ public class TraceConfigDialog extends DialogBase {
 
     config.setFlushPeriodMs(FLUSH_PERIOD);
     config.setDurationMs(duration);
-    if (duration > MAX_IN_MEM_DURATION) {
+
+    if (duration > MAX_IN_MEM_DURATION && !caps.getCanDownloadWhileTracing()) {
       config.setWriteIntoFile(true);
       config.setFileWritePeriodMs(WRITE_PERIOD);
       config.setMaxFileSizeBytes(MAX_FILE_SIZE);

--- a/gapic/src/main/com/google/gapid/settings.proto
+++ b/gapic/src/main/com/google/gapid/settings.proto
@@ -177,6 +177,8 @@ message Perfetto {
   }
   Vulkan vulkan = 5;
 
+  bool force_tracing_to_file = 8;
+
   perfetto.protos.TraceConfig custom_config = 6;
   bool use_custom = 7;
 }

--- a/gapis/perfetto/BUILD.bazel
+++ b/gapis/perfetto/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
     deps = [
         "//core/app:go_default_library",
         "//core/event/task:go_default_library",
+        "//core/fault:go_default_library",
         "//core/log:go_default_library",
         "//gapis/perfetto/client:go_default_library",
         "//gapis/perfetto/service:go_default_library",


### PR DESCRIPTION
When using the direct client, if we're on R+ and not tracing into a file, download the trace data during capture via the ReadBuffers RPC.