### PR TITLE
Fix an AGI freezing and OOM problem when loading block memory.

### DIFF
--- a/gapic/src/main/com/google/gapid/views/MemoryView.java
+++ b/gapic/src/main/com/google/gapid/views/MemoryView.java
@@ -676,17 +676,16 @@ public class MemoryView extends Composite
     }
 
     @Override
-    public void paint(BigInteger xOffset, BigInteger yOffset, GC gc) {
+    public void paint(BigInteger xOffset, BigInteger yOffset, GC gc, Rectangle area) {
       if (model == null) {
         return;
       }
 
       gc.setFont(font);
-      Rectangle clip = gc.getClipping();
-      BigInteger startY = yOffset.add(BigInteger.valueOf(top(clip)));
+      BigInteger startY = yOffset.add(BigInteger.valueOf(top(area)));
       long startRow = startY.divide(lineHeightBig)
           .max(BigInteger.ZERO).min(BigInteger.valueOf(model.getLineCount() - 1)).longValueExact();
-      long endRow = startY.add(BigInteger.valueOf(clip.height + lineHeight - 1))
+      long endRow = startY.add(BigInteger.valueOf(area.height + lineHeight - 1))
           .divide(lineHeightBig)
           .max(BigInteger.ZERO).min(BigInteger.valueOf(model.getLineCount())).longValueExact();
 

--- a/gapic/src/main/com/google/gapid/widgets/InfiniteScrolledComposite.java
+++ b/gapic/src/main/com/google/gapid/widgets/InfiniteScrolledComposite.java
@@ -70,7 +70,7 @@ public class InfiniteScrolledComposite extends ScrolledComposite {
 
     updateMinSize();
     addListener(SWT.Resize, e -> updateMinSize());
-    canvas.addListener(SWT.Paint, e -> contents.paint(xHandler.offset, yHandler.offset, e.gc));
+    canvas.addListener(SWT.Paint, e -> contents.paint(xHandler.offset, yHandler.offset, e.gc, e.getBounds()));
   }
 
   public BigPoint getLocation(Event e) {
@@ -160,7 +160,7 @@ public class InfiniteScrolledComposite extends ScrolledComposite {
     /**
      * Paints the contents at the given location using the given graphics context.
      */
-    public void paint(BigInteger xOffset, BigInteger yOffset, GC gc);
+    public void paint(BigInteger xOffset, BigInteger yOffset, GC gc, Rectangle area);
   }
 
   /**


### PR DESCRIPTION
This bug may happen when AGI has Memory tab checked, but not put at front.

When block memory UI tries to repaint, it will 1.check repainting area, 2.
calculate repainting memory range accordingly, 3.query the server to load the
memory range.
In AGI, we have been using gc.getClipping() to do the step #1 for quite some
time, but recently we find that it will not do #1 correctly when the Memory tab
is hidden in the back, and thus the following steps will get wrong and cause
incorrect server query. (It's possible but not sure, that SWT handles gc.getClipping()
differently in newer version and thus this bug surfaces recently.) This PR tries
to do the step #1 based on another data source and thus solve the problem.

Test: This bug may happen when AGI has Memory tab checked, but not put at
front. Reproduced on MacOS BigSur.
Bug: b/181012589.