### PR TITLE
Fix display of representations for OpenGL draw commands/groups

### DIFF
--- a/gapis/resolve/thumbnail.go
+++ b/gapis/resolve/thumbnail.go
@@ -131,10 +131,15 @@ func CommandTreeNodeThumbnail(
 	switch item := item.(type) {
 	case api.CmdIDGroup:
 		thumbnail := []uint64{uint64(item.Range.Last())}
+
 		if userData, ok := item.UserData.(*CmdGroupData); ok {
 			thumbnail = []uint64{uint64(userData.Representation)}
 		} else if len(absID) > 0 {
-			thumbnail = append(absID, uint64(item.Range.Last()))
+			if aliasRepId := getOpenGLAliasRepresentation(p.Indices, &item, cmdTree); aliasRepId != api.CmdNoID {
+				thumbnail = append(absID, uint64(aliasRepId))
+			} else {
+				thumbnail = append(absID, uint64(item.Range.Last()))
+			}
 		}
 		return CommandThumbnail(ctx, w, h, f, noOpt, cmdTree.path.Capture.Command(thumbnail[0], thumbnail[1:]...), r)
 	case api.SubCmdIdx:


### PR DESCRIPTION
In an ANGLE AGI trace, the thumbnail/resources of the containing OpenGL group and the OpenGL drawcall displayed out-of-date
data. Updated these representations at query-time to reflect the correct Vulkan state.

Passed presubmit tests.

Fixes #669 
