### PR TITLE
Refactor handling of enabled dynamic states

### DIFF
--- a/gapis/api/vulkan/api/draw_commands.api
+++ b/gapis/api/vulkan/api/draw_commands.api
@@ -482,25 +482,13 @@ sub void readWriteMemoryInBoundComputeDescriptorSets() {
     lci.BufferBindingOffsets)
 }
 
-@internal class DynamicStateSet {
-  bool[9] contains
-}
-
-sub  ref!DynamicStateSet unpackDynamicState(ref!DynamicData data) {
-  obj := new!DynamicStateSet()
-  if data != null {
-    for _, _, s in data.DynamicStates {
-      if as!s32(s) < 9 {
-        obj.contains[as!s32(s)] = true
-      }
-    }
-  }
-  return obj
-}
-
 @spy_disabled
 sub void readComputeState() {
   readPushConstants(VK_PIPELINE_BIND_POINT_COMPUTE)
+}
+
+sub bool hasDynamicState(ref!GraphicsPipelineObject pipeline, VkDynamicState dynamicState) {
+  return (pipeline.DynamicState != null) && pipeline.DynamicState.Contains[dynamicState]
 }
 
 @spy_disabled
@@ -508,11 +496,10 @@ sub void readDrawState() {
   info := lastDrawInfo()
   pipeline := info.GraphicsPipeline
 
-  dynamicState := unpackDynamicState(pipeline.DynamicState)
   dyn := lastDynamicPipelineState()
 
   // read all viewports
-  if dynamicState.contains[as!u32(VK_DYNAMIC_STATE_VIEWPORT)] {
+  if hasDynamicState(pipeline, VK_DYNAMIC_STATE_VIEWPORT) {
     _ = len(dyn.Viewports)
   } else {
     if pipeline.ViewportState != null {
@@ -521,7 +508,7 @@ sub void readDrawState() {
   }
 
   // read all scissors
-  if dynamicState.contains[as!u32(VK_DYNAMIC_STATE_SCISSOR)] {
+  if hasDynamicState(pipeline, VK_DYNAMIC_STATE_SCISSOR) {
     _ = len(dyn.Scissors)
   } else {
     if pipeline.ViewportState != null {
@@ -530,14 +517,14 @@ sub void readDrawState() {
   }
 
   // read line width
-  if dynamicState.contains[as!u32(VK_DYNAMIC_STATE_LINE_WIDTH)] {
+  if hasDynamicState(pipeline, VK_DYNAMIC_STATE_LINE_WIDTH) {
     _ = dyn.LineWidth
   } else {
     _ = pipeline.RasterizationState.LineWidth
   }
 
   // read depth bias
-  if dynamicState.contains[as!u32(VK_DYNAMIC_STATE_DEPTH_BIAS)] {
+  if hasDynamicState(pipeline, VK_DYNAMIC_STATE_DEPTH_BIAS) {
     _ = dyn.DepthBiasConstantFactor
     _ = dyn.DepthBiasClamp
     _ = dyn.DepthBiasSlopeFactor
@@ -548,7 +535,7 @@ sub void readDrawState() {
   }
 
   // read blend constants
-  if dynamicState.contains[as!u32(VK_DYNAMIC_STATE_BLEND_CONSTANTS)] {
+  if hasDynamicState(pipeline, VK_DYNAMIC_STATE_BLEND_CONSTANTS) {
     _ = dyn.BlendConstants[0]
     _ = dyn.BlendConstants[1]
     _ = dyn.BlendConstants[2]
@@ -563,7 +550,7 @@ sub void readDrawState() {
   }
 
   // read depth bounds
-  if dynamicState.contains[as!u32(VK_DYNAMIC_STATE_BLEND_CONSTANTS)] {
+  if hasDynamicState(pipeline, VK_DYNAMIC_STATE_BLEND_CONSTANTS) {
     _ = dyn.MinDepthBounds
     _ = dyn.MaxDepthBounds
   } else {
@@ -574,7 +561,7 @@ sub void readDrawState() {
   }
 
   // read stencil state
-  if dynamicState.contains[as!u32(VK_DYNAMIC_STATE_BLEND_CONSTANTS)] {
+  if hasDynamicState(pipeline, VK_DYNAMIC_STATE_BLEND_CONSTANTS) {
     _ = dyn.StencilFront.compareMask
     _ = dyn.StencilFront.writeMask
     _ = dyn.StencilFront.reference

--- a/gapis/api/vulkan/api/pipeline.api
+++ b/gapis/api/vulkan/api/pipeline.api
@@ -176,7 +176,12 @@ cmd void vkDestroyPipelineLayout(
 }
 
 @internal class DynamicData {
+  // A map(u32,<value>) is needed for state rebuilder
   @unused map!(u32, VkDynamicState) DynamicStates
+  // At every draw call we need to lookup if a particular dynamic state is
+  // enabled, rather than iterating on the DynamicStates map, we use this
+  // helper map for simple lookup.
+  @unused map!(VkDynamicState, bool) Contains
 }
 
 @resource
@@ -565,10 +570,10 @@ cmd VkResult vkCreateGraphicsPipelines(
           next.Ptr = as!VulkanStructHeader*(next.Ptr)[0].PNext
         }
       }
-      states := dynamic_state_info.pDynamicStates[0:
-      dynamic_state_info.dynamicStateCount]
+      states := dynamic_state_info.pDynamicStates[0:dynamic_state_info.dynamicStateCount]
       for k in (0 .. dynamic_state_info.dynamicStateCount) {
         dynamic_data.DynamicStates[k] = states[k]
+        dynamic_data.Contains[states[k]] = true
       }
       obj.DynamicState = dynamic_data
     }

--- a/gapis/api/vulkan/resources.go
+++ b/gapis/api/vulkan/resources.go
@@ -1025,9 +1025,7 @@ func (p GraphicsPipelineObjectʳ) ResourceData(ctx context.Context, s *api.Globa
 	var boundDsets map[uint32]DescriptorSetObjectʳ
 	var renderpass RenderPassObjectʳ
 	var dynamicOffsets map[uint32]U32ːU32ːVkDeviceSizeᵐᵐ
-	// Convert the DynamicStates map to have VkDynamicState be the key
-	// for quick lookup (i.e. make it a set)
-	dynamicStates := make(map[VkDynamicState]bool)
+	var dynamicStates map[VkDynamicState]bool
 	// Use LastDrawInfos to get bound descriptor set data.
 	// TODO: Ideally we could look at just a specific pipeline/descriptor
 	// set pair.  Maybe we could modify mutate to track which what
@@ -1046,9 +1044,7 @@ func (p GraphicsPipelineObjectʳ) ResourceData(ctx context.Context, s *api.Globa
 		}
 
 		if !p.DynamicState().IsNil() {
-			for _, k := range p.DynamicState().DynamicStates().Keys() {
-				dynamicStates[p.DynamicState().DynamicStates().Get(k)] = true
-			}
+			dynamicStates = p.DynamicState().Contains().All()
 		}
 	}
 


### PR DESCRIPTION
Various dynamic states may be enabled when a graphics pipeline is
created. These states are defined as:

```
typedef enum VkDynamicState {
    VK_DYNAMIC_STATE_VIEWPORT = 0,
    VK_DYNAMIC_STATE_SCISSOR = 1,
    ... etc ...
    VK_DYNAMIC_STATE_STENCIL_REFERENCE = 8,
    // remaining states are defined by extensions, e.g.:
    // Provided by VK_EXT_line_rasterization
    VK_DYNAMIC_STATE_LINE_STIPPLE_EXT = 1000259000,
    ... etc ...
}
```

So far, we only support the core states, and the code assumes there are nine
possible states from 0 to 8, as we see below.

In practice, upon creation of the graphics pipeline, the list of dynamic state
passed as argument is stored in a map(u32,VkDynamicState):

```
@internal class DynamicData {
    @unused map!(u32, VkDynamicState) DynamicStates
}
```

Upon each draw call, we need to know whether some dynamic states are enabled or
not. To answer this, we could iterate over DynamicStates, but to avoid multiple
iterations over this map, we create a short-lived object with an array of 9
booleans indexed by the dynamic state value, so we can quickly lookup if a
given dynamic state is present or not. This is in draw_commands.api:

```
@internal class DynamicStateSet {
  bool[9] contains
}

sub  ref!DynamicStateSet unpackDynamicState(ref!DynamicData data) {
  obj := new!DynamicStateSet()
  if data != null {
    for _, _, s in data.DynamicStates {
      if as!s32(s) < 9 {
        obj.contains[as!s32(s)] = true
      }
    }
  }
  return obj
}

// This is called at every vkCmdDraw*
sub void readDrawState() {
  ...
  dynamicState := unpackDynamicState(pipeline.DynamicState)
  ...
  // Used like this to check for dynamic state
  if dynamicState.contains[as!u32(VK_DYNAMIC_STATE_VIEWPORT)] {
    ...
  }
  ...
}
```

Note that this approach using an array assumes there are only 9 dynamic states,
whose values range from 0 to 8. Note also that this creates a new, short-lived
DynamicStateSet at every draw call, which probably results in object churning
when we mutate traces with numerous draw calls.

In order to be able to handle dynamic state values from extensions (i.e., that
are not continuous after value 8, but that jumps to arbitrary values like
VK_DYNAMIC_STATE_LINE_STIPPLE_EXT = 1000259000), this change replaces the array
of booleans by a map(VkDynamicState, bool), namely the new Contains map in
DynamicData.

In order to avoid creating a short-lived object at every draw call, the new
Contains is stored in DynamicData and is set once for all upon pipeline
creation. Indeed Vulkan doesn't offer any mean to modify the set of enabled
dynamic state after pipeline creation.

We still need to keep the map(u32, VkDynamicState) DynamicStates since the
state rebuilder expects such a map to know how to re-create a GraphicsPipeline
with the same list of arguments, in the same order, for the set of dynamic
states to enable.

Bug: b/184934061
Test: Manual