### PR TITLE
[GLES cleanup] Remove obsolete references to LibGAPII

### DIFF
--- a/gapidapk/gapidapk.go
+++ b/gapidapk/gapidapk.go
@@ -180,18 +180,8 @@ func (a APK) LibsPath(abi *device.ABI) string {
 	return a.path + "/lib/" + abi.Name
 }
 
-// LibGAPIIPath returns the path on the Android device to the GAPII dynamic
-// library file.
-// gapid.apk must be installed for this path to be valid.
-func (a APK) LibGAPIIPath(abi *device.ABI) string {
-	return a.LibsPath(abi) + "/" + LibGAPIIName
-}
-
 const (
-	// LibGAPIIName is the name of the GAPII dynamic library file.
-	LibGAPIIName = "libgapii.so"
-
-	// GraphicsSpyLayerName is the name of the graphics spy layer.
+	// GraphicsSpyLayerName is the name of the graphics spy Vulkan layer.
 	GraphicsSpyLayerName = "GraphicsSpy"
 )
 
@@ -204,15 +194,6 @@ func PackageName(abi *device.ABI) string {
 		return "com.google.android.gapid.arm64v8a"
 	default:
 		return fmt.Sprintf("com.google.android.gapid.%v", abi.Name)
-	}
-}
-
-// LayerName returns the name of the layer to use for Vulkan vs GLES.
-func LayerName(vulkan bool) string {
-	if vulkan {
-		return GraphicsSpyLayerName
-	} else {
-		return LibGAPIIName
 	}
 }
 

--- a/gapii/client/adb.go
+++ b/gapii/client/adb.go
@@ -143,7 +143,7 @@ func Start(ctx context.Context, p *android.InstalledPackage, a *android.Activity
 	}
 
 	log.I(ctx, "Setting up Layer")
-	cu, err := android.SetupLayers(ctx, d, p.Name, []string{gapidapk.PackageName(abi)}, []string{gapidapk.LayerName(true)})
+	cu, err := android.SetupLayers(ctx, d, p.Name, []string{gapidapk.PackageName(abi)}, []string{gapidapk.GraphicsSpyLayerName})
 	if err != nil {
 		return nil, cleanup.Invoke(ctx), log.Err(ctx, err, "Failed when setting up layers")
 	}


### PR DESCRIPTION
LibGAPII used to be the library used to do GLES capture in GAPID, it
is now obsolete.

Bug: n/a
Test: manual: trace-replay of Vulkan still works fine.