### PR TITLE
Add gapis --android-serial flag to limit device scanning

### DIFF
--- a/cmd/gapis/main.go
+++ b/cmd/gapis/main.go
@@ -54,6 +54,7 @@ var (
 	gapirAuthToken   = flag.String("gapir-auth-token", "", "_The connection authorization token for gapir")
 	gapirArgStr      = flag.String("gapir-args", "", "_The arguments to be passed to the host-run gapir")
 	scanAndroidDevs  = flag.Bool("monitor-android-devices", true, "Server will scan for locally connected Android devices")
+	androidSerial    = flag.String("android-serial", "", "Server will only consider the Android device with this serial id")
 	addLocalDevice   = flag.Bool("add-local-device", true, "Server can trace and replay locally")
 	idleTimeout      = flag.Duration("idle-timeout", 0, "_Closes GAPIS if the server is not repeatedly pinged within this duration (e.g. '30s', '2m'). Default: 0 (no timeout).")
 	adbPath          = flag.String("adb", "", "Path to the adb executable; leave empty to search the environment")
@@ -115,6 +116,10 @@ func run(ctx context.Context) error {
 	}
 
 	wg := sync.WaitGroup{}
+
+	if *androidSerial != "" {
+		adb.LimitToSerial(*androidSerial)
+	}
 
 	if *scanAndroidDevs {
 		wg.Add(1)

--- a/core/os/android/adb/adb_data_test.go
+++ b/core/os/android/adb/adb_data_test.go
@@ -53,6 +53,7 @@ screen_off_locked_device    offline
 screen_off_unlocked_device  offline
 screen_on_locked_device     offline
 screen_on_unlocked_device   device
+serial_do_match             device
 `)
 	emptyDevices = stub.RespondTo(adbPath.System()+` devices`, `
 List of devices attached

--- a/core/os/android/adb/device_test.go
+++ b/core/os/android/adb/device_test.go
@@ -74,3 +74,25 @@ func TestParseDevices(t_ *testing.T) {
 	assert.For(ctx, "not connected").ThatError(err).HasMessage(`Process returned error
    Cause: Not connected`)
 }
+
+func TestLimitToSerial(t_ *testing.T) {
+	ctx := log.Testing(t_)
+
+	// Make sure to remove the limitation so further tests work fine
+	defer adb.LimitToSerial("")
+
+	got, err := adb.Devices(ctx)
+	assert.For(ctx, "No serial limitation").ThatError(err).Succeeded()
+	assert.For(ctx, "No serial limitation").ThatInteger(len(got)).IsAtLeast(2)
+
+	adb.LimitToSerial("serial_do_match")
+	got, err = adb.Devices(ctx)
+	assert.For(ctx, "LimitToSerial do match").ThatError(err).Succeeded()
+	assert.For(ctx, "LimitToSerial do match").ThatInteger(len(got)).Equals(1)
+	assert.For(ctx, "LimitToSerial do match").ThatString(got.FindBySerial("serial_do_match").Instance().Serial).Equals("serial_do_match")
+
+	adb.LimitToSerial("serial_do_not_match")
+	got, err = adb.Devices(ctx)
+	assert.For(ctx, "LimitToSerial do not match").ThatError(err).Succeeded()
+	assert.For(ctx, "LimitToSerial do not match").ThatSlice(got).IsEmpty()
+}


### PR DESCRIPTION
This flags let the user tell GAPIS to not scan devices other than a
specific one, and thus avoid haing GAPIS install its APK (as part of
device scanning) to all the connected devices.

Bug: b/185349557
Test: core/os/android/adb:LimitToSerialTest, manual