### PR TITLE
Update Perfetto for Frame Lifecycle

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
@@ -266,7 +266,7 @@ public class Tracks {
         for (FrameInfo.Event buffer : layer.bufferEvents()) {
           FrameEventsTrack track = FrameEventsTrack.forFrameEvent(data.qe, layer.layerName, buffer);
           data.tracks.addTrack(buffersGroup, track.getId(), buffer.getDisplay(),
-              single(state -> new FrameEventsPanel(state, buffer, track), true, false));
+              single(state -> new FrameEventsPanel(state, buffer, track), true, true));
         }
       }
     }

--- a/tools/build/third_party/perfetto/BUILD.bazel
+++ b/tools/build/third_party/perfetto/BUILD.bazel
@@ -41,6 +41,7 @@ go_proto_library(
         "@perfetto//:protos_perfetto_config_ftrace_protos",
         "@perfetto//:protos_perfetto_config_gpu_protos",
         "@perfetto//:protos_perfetto_config_inode_file_protos",
+        "@perfetto//:protos_perfetto_config_interceptors_protos",
         "@perfetto//:protos_perfetto_config_power_protos",
         "@perfetto//:protos_perfetto_config_process_stats_protos",
         "@perfetto//:protos_perfetto_config_profiling_protos",

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -205,8 +205,8 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
         name = "perfetto",
         locals = locals,
         remote = "https://android.googlesource.com/platform/external/perfetto",
-        commit = "c9f2c2b7eab1395bd1e29e9254dbb475a59f66b8",
-        shallow_since = "1605805465 +0000",
+        commit = "d1a7b031bbded67e0d67957974e85a83e0b815c0",
+        shallow_since = "1619185617 +0100",
     )
 
     maybe_repository(


### PR DESCRIPTION
In some devices, same buffer gets reused across multiple layers. This
breaks some internal assumption. The trace processor fix landed in
perfetto. This change updates perfetto to include the fix.

Since layer name is now displayed along with the buffer id, use right
truncate for the buffer track names.

Bug: 184037965