### PR TITLE
Re-install gapid apk if path is not queryable

### DIFF
--- a/gapidapk/gapidapk.go
+++ b/gapidapk/gapidapk.go
@@ -128,7 +128,10 @@ func ensureInstalled(ctx context.Context, d adb.Device, abi *device.ABI) (*APK, 
 
 		apkPath, err := gapid.Path(ctx)
 		if err != nil {
-			return nil, log.Err(ctx, err, "Obtaining GAPID package path")
+			// This might happen if gapid is installed only for the work profile
+			log.I(ctx, "Uninstalling existing gapid.apk as path not queryable.")
+			gapid.Uninstall(ctx)
+			continue
 		}
 		log.I(ctx, "Found gapid package...")
 


### PR DESCRIPTION
On an Android device with work profile it can happen that the gapid apk is installed only for the work profile, for example if the user manually deletes the apk in the settings from the user profile. In this case AGI will still find it, but is not able to query its path. Instead of giving up, this PR uninstalls the apk and continues the attempts to install it.

Might fix b/180757454