### PR TITLE
Add trace option: name of the process to capture

### DIFF
--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -334,6 +334,7 @@ type (
 		PipeName        string `help:"The name of the pipe to connect/listen to."`
 		Perfetto        string `help:"File containing the Perfetto configuration proto."`
 		WaitForDebugger bool   `help:"Make GAPII wait for a debugger to attach"`
+		ProcessName     string `help:"Name of the process to capture. Default to empty, i.e. capture any process. Useful for games that fork processes."`
 	}
 	BenchmarkFlags struct {
 		Gapis      GapisFlags

--- a/cmd/gapit/trace.go
+++ b/cmd/gapit/trace.go
@@ -246,6 +246,7 @@ func (verb *traceVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		PipeName:                     verb.PipeName,
 		DisableCoherentMemoryTracker: verb.Disable.CoherentMemoryTracker,
 		WaitForDebugger:              verb.WaitForDebugger,
+		ProcessName:                  verb.ProcessName,
 	}
 	target(options)
 

--- a/core/cc/android/process_name.cpp
+++ b/core/cc/android/process_name.cpp
@@ -24,8 +24,15 @@ static const size_t MAX_PATH = 4096;
 
 std::string get_process_name() {
   std::ifstream t("/proc/self/cmdline");
-  return std::string((std::istreambuf_iterator<char>(t)),
-                     std::istreambuf_iterator<char>());
+  std::string name;
+  // Watch out: the string returned by reading /proc/self/cmdline contains '\0'
+  // characters to delimit the command line arguments (see man proc), make sure
+  // to stop at the first '\0' to only extract the process name.
+  auto it = std::istreambuf_iterator<char>(t);
+  while (it != std::istreambuf_iterator<char>() && *it != '\0') {
+    name += *it++;
+  }
+  return name;
 }
 
 uint64_t get_process_id() { return static_cast<uint64_t>(getpid()); }

--- a/core/cc/socket_connection.cpp
+++ b/core/cc/socket_connection.cpp
@@ -370,6 +370,7 @@ std::unique_ptr<Connection> SocketConnection::createPipe(const char* pipename,
   }
 #endif
 
+  // Rely on zero-initialization here to assume pipe.sun_path is zeroed.
   struct sockaddr_un pipe {};
   pipe.sun_family = AF_UNIX;
   strncpy(pipe.sun_path + (abstract ? 1 : 0), pipename,

--- a/gapic/src/main/com/google/gapid/settings.proto
+++ b/gapic/src/main/com/google/gapid/settings.proto
@@ -119,6 +119,7 @@ message Trace {
   string friendly_name = 16;
   Duration gfx_duration = 17;
   Duration profile_duration = 18;
+  string process_name = 19;
 }
 
 message Perfetto {

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -961,6 +961,7 @@ public class TracerDialog {
         trace.setHideUnknownExtensions(hideUnknownExtensions.getSelection());
         trace.setOutDir(directory.getText());
         trace.setFriendlyName(friendlyName);
+        trace.setProcessName(processName.getText());
 
         Service.TraceOptions.Builder options = Service.TraceOptions.newBuilder()
             .setDevice(dev.path)

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -308,6 +308,7 @@ public class TracerDialog {
       private final Label targetLabel;
       private final Text arguments;
       private final Text cwd;
+      private final Text processName;
       private final Text envVars;
       private final Combo startType;
       private final Spinner startFrame;
@@ -405,6 +406,11 @@ public class TracerDialog {
         createLabel(appGroup, "Additional Arguments:");
         arguments = withLayoutData(createTextbox(appGroup, trace.getArguments()),
             new GridData(SWT.FILL, SWT.FILL, true, false));
+
+        createLabel(appGroup, "Process name:");
+        processName = withLayoutData(createTextbox(appGroup, trace.getProcessName()),
+            new GridData(SWT.FILL, SWT.FILL, true, false));
+        processName.setEnabled(false);
 
         createLabel(appGroup, "Working Directory:");
         cwd = withLayoutData(createTextbox(appGroup, trace.getCwd()),
@@ -677,6 +683,9 @@ public class TracerDialog {
         boolean appRequired = config != null && config.getRequiresApplication();
         targetLabel.setText(TARGET_LABEL + (appRequired ? "*:" : ":"));
         targetLabel.requestLayout();
+
+        boolean canSelectProcessName = config != null && config.getCanSelectProcessName();
+        processName.setEnabled(canSelectProcessName);
 
         boolean isPerfetto = isPerfetto(config);
         SettingsProto.Trace.DurationOrBuilder dur = isPerfetto ?
@@ -962,7 +971,8 @@ public class TracerDialog {
             .setFramesToCapture(duration.getSelection())
             .setNoBuffer(withoutBuffering.getSelection())
             .setHideUnknownExtensions(hideUnknownExtensions.getSelection())
-            .setServerLocalSavePath(output.getAbsolutePath());
+            .setServerLocalSavePath(output.getAbsolutePath())
+            .setProcessName(processName.getText());
 
         if (dev.config.getCanSpecifyCwd()) {
           trace.setCwd(cwd.getText());

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -50,6 +50,7 @@
 
 #include <jni.h>
 #include <sys/prctl.h>
+#include <sys/system_properties.h>
 
 extern "C" jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   GAPID_INFO("JNI_OnLoad() was called. vm = %p", vm);
@@ -64,6 +65,16 @@ const uint32_t kMaxFramebufferObservationWidth = 3840;
 const uint32_t kMaxFramebufferObservationHeight = 2560;
 
 const int32_t kSuspendIndefinitely = -1;
+
+#if TARGET_OS == GAPID_OS_ANDROID
+// Android: system property holding the name of the process to capture.
+// Mirrored in gapii/client/adb.go
+const char* kCaptureProcessNameSystemProperty = "debug.agi.procname";
+#else
+// Desktop: environment variable holding the name of the process to capture.
+// Mirrored in gapis/trace/desktop/trace.go
+const char* kCaptureProcessNameEnvVar = "GAPID_CAPTURE_PROCESS_NAME";
+#endif  // TARGET_OS == GAPID_OS_ANDROID
 
 thread_local gapii::CallObserver* gContext = nullptr;
 
@@ -97,12 +108,34 @@ Spy::Spy()
       mObserveFrameFrequency(0),
       mObserveDrawFrequency(0),
       mFrameNumber(0) {
+  // Start by checking whether to capture the current process: compare the
+  // current process name with the "capture_proc_name" that we get from the
+  // environment. An empty "capture_proc_name" means capture any process. This
+  // is useful for games where the process initially started by AGI creates an
+  // other process where the actual game rendering happens.
   bool this_executable = true;
-  char* pn = getenv("GAPID_CAPTURE_PROCESS_NAME");
-  if (pn) {
-    auto proc_name = core::get_process_name();
-    this_executable = (proc_name == pn);
+  auto this_proc_name = core::get_process_name();
+  GAPID_INFO("this process name: %s", this_proc_name.c_str());
+
+#if TARGET_OS == GAPID_OS_ANDROID
+  // PROP_VALUE_MAX is defined in <sys/system_properties.h>
+  char capture_proc_name[PROP_VALUE_MAX];
+  __system_property_get(kCaptureProcessNameSystemProperty, capture_proc_name);
+#else
+  const char* capture_proc_name = getenv(kCaptureProcessNameEnvVar);
+  // Make sure capture_proc_name is not null, since the code below assumes so.
+  if (!capture_proc_name) {
+    capture_proc_name = "";
   }
+#endif
+
+  if (strlen(capture_proc_name)) {
+    this_executable = (!strcmp(this_proc_name.c_str(), capture_proc_name));
+    GAPID_INFO("capture process name: %s (%s this process name)",
+               capture_proc_name,
+               this_executable ? "same as" : "different from");
+  }
+
   if (this_executable) {
 #if TARGET_OS == GAPID_OS_ANDROID
     // Use a "localabstract" pipe on Android to prevent depending on the traced

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -130,9 +130,7 @@ Spy::Spy()
   // nullptr raises a compilation warning that is treated as an error.
   if (((const char*)capture_proc_name != nullptr) &&
       (capture_proc_name[0] != '\0')) {
-    // Use strcmp() since string.compare() does not work for these strings, see
-    // NDK issue: https://github.com/android/ndk/issues/1494
-    this_executable = (!strcmp(this_proc_name.c_str(), capture_proc_name));
+    this_executable = (!this_proc_name.compare(capture_proc_name));
     GAPID_INFO("capture process name: %s (%s this process name)",
                capture_proc_name,
                this_executable ? "same as" : "different from");

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -123,13 +123,15 @@ Spy::Spy()
   __system_property_get(kCaptureProcessNameSystemProperty, capture_proc_name);
 #else
   const char* capture_proc_name = getenv(kCaptureProcessNameEnvVar);
-  // Make sure capture_proc_name is not null, since the code below assumes so.
-  if (!capture_proc_name) {
-    capture_proc_name = "";
-  }
 #endif
 
-  if (strlen(capture_proc_name)) {
+  // The cast to (const char*) is necessary for Android, where capture_proc_name
+  // is declared as a char array, such that comparing it (without cast) to
+  // nullptr raises a compilation warning that is treated as an error.
+  if (((const char*)capture_proc_name != nullptr) &&
+      (capture_proc_name[0] != '\0')) {
+    // Use strcmp() since string.compare() does not work for these strings, see
+    // NDK issue: https://github.com/android/ndk/issues/1494
     this_executable = (!strcmp(this_proc_name.c_str(), capture_proc_name));
     GAPID_INFO("capture process name: %s (%s this process name)",
                capture_proc_name,

--- a/gapii/client/capture.go
+++ b/gapii/client/capture.go
@@ -78,6 +78,8 @@ type Options struct {
 	EnableAngle bool
 	// The name of the pipe to connect/listen to.
 	PipeName string
+	// Name of the process to capture (non-empty to indicate a specific process)
+	ProcessName string
 }
 
 const sizeGap = 1024 * 1024 * 5

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -431,6 +431,8 @@ message TraceTypeCapabilities {
   bool can_enable_unsupported_extensions = 4;
   // Does this trace require starting an application.
   bool requires_application = 6;
+  // Can select a specific process name
+  bool can_select_process_name = 7;
 }
 
 // MultiResourceData represents the state of resources at a single point in a
@@ -1408,6 +1410,8 @@ message TraceOptions {
   bool wait_for_debugger = 26;
   // The config to use if doing a Perfetto trace.
   perfetto.protos.TraceConfig perfetto_config = 24;
+  // The name of the process to capture (empty for capturing any process).
+  string process_name = 27;
 }
 
 enum TraceEvent {

--- a/gapis/trace/desktop/trace.go
+++ b/gapis/trace/desktop/trace.go
@@ -39,6 +39,12 @@ import (
 	"github.com/google/gapid/gapis/trace/tracer"
 )
 
+const (
+	// captureProcessNameEnvVar is the environment variable holding the name of
+	// the process to capture. Mirrored in gapii/cc/spy.cpp.
+	captureProcessNameEnvVar = "GAPID_CAPTURE_PROCESS_NAME"
+)
+
 type DesktopTracer struct {
 	b bind.Device
 }
@@ -240,6 +246,9 @@ func (t *DesktopTracer) SetupTrace(ctx context.Context, o *service.TraceOptions)
 
 	for _, x := range o.Environment {
 		env.Add(x)
+	}
+	if o.ProcessName != "" {
+		env.Add(captureProcessNameEnvVar + "=" + o.ProcessName)
 	}
 	var p tracer.Process
 	var boundPort int

--- a/gapis/trace/tracer/default_api_trace_options.go
+++ b/gapis/trace/tracer/default_api_trace_options.go
@@ -25,6 +25,7 @@ func VulkanTraceOptions() *service.TraceTypeCapabilities {
 		Api:                            "Vulkan",
 		CanEnableUnsupportedExtensions: true,
 		RequiresApplication:            true,
+		CanSelectProcessName:           true,
 	}
 }
 
@@ -35,6 +36,7 @@ func AngleTraceOptions() *service.TraceTypeCapabilities {
 		Api:                            "OpenGL on ANGLE",
 		CanEnableUnsupportedExtensions: true,
 		RequiresApplication:            true,
+		CanSelectProcessName:           true,
 	}
 }
 
@@ -44,5 +46,6 @@ func PerfettoTraceOptions() *service.TraceTypeCapabilities {
 		Type:                           service.TraceType_Perfetto,
 		CanEnableUnsupportedExtensions: false,
 		RequiresApplication:            false,
+		CanSelectProcessName:           false,
 	}
 }

--- a/gapis/trace/tracer/tracer.go
+++ b/gapis/trace/tracer/tracer.go
@@ -145,5 +145,6 @@ func GapiiOptions(o *service.TraceOptions) gapii.Options {
 		o.AdditionalCommandLineArgs,
 		enableAngle,
 		o.PipeName,
+		o.ProcessName,
 	}
 }


### PR DESCRIPTION
Some games may start with a first process (or Android activity), and
then fork another process/activity where the actual game rendering
happens. If the starting process also uses Vulkan, then it is likely
to be the first to establish a gapii-gapis connection, such that AGI
won't be able to capture the actual game.

This change adds a "process name" trace option to indicate the name of
the process to capture. This is a new text entry in the UI's
TracerDialog. The value gets propagated as a trace option through
gapis, and is eventually passed to gapii: via an Android system
property on Android, or via an environment variable (refactoring the
existing `GAPID_CAPTURE_PROCESS_NAME` mechanism) on Desktop. The gapii
Spy, upon creation, looks for this process name and only establish a
connection with gapis if the current process name matches the one to
capture, or if the capture process name is empty.

This was motivated by a Unity game which forks a new process whose
name is `com.example.game:UnityKillsMe`, where the game is actually
rendered. This seems to be a way to include Unity games into an
Android app, the `UnityKillsMe` suffix lets Unity take care of killing
the forked activity upon app shutdown.

Bug: b/177363287
Test: manual