### PR TITLE
[GLES Cleanup] Remove gapii spy init on JNI_OnLoad

### DIFF
--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -47,16 +47,7 @@
 #endif  //  TARGET_OS == GAPID_OS_WINDOWS
 
 #if TARGET_OS == GAPID_OS_ANDROID
-
-#include <jni.h>
-#include <sys/prctl.h>
 #include <sys/system_properties.h>
-
-extern "C" jint JNI_OnLoad(JavaVM* vm, void* reserved) {
-  GAPID_INFO("JNI_OnLoad() was called. vm = %p", vm);
-  gapii::Spy::get();  // Construct the spy.
-  return JNI_VERSION_1_6;
-}
 #endif  // TARGET_OS == GAPID_OS_ANDROID
 
 namespace {


### PR DESCRIPTION
GAPID used to create the Spy upon JNI_OnLoad(), which was called when
libgapii was loaded from Java when GLES interception was initialized
using the Java debugger.

Since AGI only deals with Vulkan, this code is now irrelevant. I
double checked that it is never called when we do Vulkan capture, and
that our capture still works once this code is removed.

Bug: n/a
Test: manual