### PR TITLE
Fix ETC converter initialization

### DIFF
--- a/core/image/etc/etc.go
+++ b/core/image/etc/etc.go
@@ -33,21 +33,21 @@ import (
 
 var (
 	// ETC2
-	ETC2_RGB_U8_NORM         = image.NewETC2_RGB_U8_NORM("ETC2_RGB_U8_NORM")
-	ETC2_RGBA_U8_NORM        = image.NewETC2_RGBA_U8_NORM("ETC2_RGBA_U8_NORM")
-	ETC2_RGBA_U8U8U8U1_NORM  = image.NewETC2_RGBA_U8U8U8U1_NORM("ETC2_RGBA_U8U8U8U1_NORM")
-	ETC2_SRGB_U8_NORM        = image.NewETC2_SRGB_U8_NORM("ETC2_SRGB_U8_NORM")
-	ETC2_SRGBA_U8_NORM       = image.NewETC2_SRGBA_U8_NORM("ETC2_SRGBA_U8_NORM")
-	ETC2_SRGBA_U8U8U8U1_NORM = image.NewETC2_SRGBA_U8U8U8U1_NORM("ETC2_SRGBA_U8U8U8U1_NORM")
+	ETC2_RGB_U8_NORM         = NewETC2_RGB_U8_NORM("ETC2_RGB_U8_NORM")
+	ETC2_RGBA_U8_NORM        = NewETC2_RGBA_U8_NORM("ETC2_RGBA_U8_NORM")
+	ETC2_RGBA_U8U8U8U1_NORM  = NewETC2_RGBA_U8U8U8U1_NORM("ETC2_RGBA_U8U8U8U1_NORM")
+	ETC2_SRGB_U8_NORM        = NewETC2_SRGB_U8_NORM("ETC2_SRGB_U8_NORM")
+	ETC2_SRGBA_U8_NORM       = NewETC2_SRGBA_U8_NORM("ETC2_SRGBA_U8_NORM")
+	ETC2_SRGBA_U8U8U8U1_NORM = NewETC2_SRGBA_U8U8U8U1_NORM("ETC2_SRGBA_U8U8U8U1_NORM")
 
 	// EAC
-	ETC2_R_U11_NORM  = image.NewETC2_R_U11_NORM("ETC2_R_U11_NORM")
-	ETC2_RG_U11_NORM = image.NewETC2_RG_U11_NORM("ETC2_RG_U11_NORM")
-	ETC2_R_S11_NORM  = image.NewETC2_R_S11_NORM("ETC2_R_S11_NORM")
-	ETC2_RG_S11_NORM = image.NewETC2_RG_S11_NORM("ETC2_RG_S11_NORM")
+	ETC2_R_U11_NORM  = NewETC2_R_U11_NORM("ETC2_R_U11_NORM")
+	ETC2_RG_U11_NORM = NewETC2_RG_U11_NORM("ETC2_RG_U11_NORM")
+	ETC2_R_S11_NORM  = NewETC2_R_S11_NORM("ETC2_R_S11_NORM")
+	ETC2_RG_S11_NORM = NewETC2_RG_S11_NORM("ETC2_RG_S11_NORM")
 
 	// ETC 1
-	ETC1_RGB_U8_NORM = image.NewETC1_RGB_U8_NORM("ETC1_RGB_U8_NORM")
+	ETC1_RGB_U8_NORM = NewETC1_RGB_U8_NORM("ETC1_RGB_U8_NORM")
 	formatToCEnum    = map[interface{}]C.enum_etc_format{
 		ETC2_RGB_U8_NORM:         C.ETC2_RGB_U8_NORM,
 		ETC2_RGBA_U8_NORM:        C.ETC2_RGBA_U8_NORM,
@@ -62,6 +62,40 @@ var (
 		ETC1_RGB_U8_NORM:         C.ETC1_RGB_U8_NORM,
 	}
 )
+
+func NewETC2_RGB_U8_NORM(name string) *image.Format {
+	return image.NewETC2_RGB_U8_NORM(name)
+}
+func NewETC2_RGBA_U8_NORM(name string) *image.Format {
+	return image.NewETC2_RGBA_U8_NORM(name)
+}
+func NewETC2_RGBA_U8U8U8U1_NORM(name string) *image.Format {
+	return image.NewETC2_RGBA_U8U8U8U1_NORM(name)
+}
+func NewETC2_SRGB_U8_NORM(name string) *image.Format {
+	return image.NewETC2_SRGB_U8_NORM(name)
+}
+func NewETC2_SRGBA_U8_NORM(name string) *image.Format {
+	return image.NewETC2_SRGBA_U8_NORM(name)
+}
+func NewETC2_SRGBA_U8U8U8U1_NORM(name string) *image.Format {
+	return image.NewETC2_SRGBA_U8U8U8U1_NORM(name)
+}
+func NewETC2_R_U11_NORM(name string) *image.Format {
+	return image.NewETC2_R_U11_NORM(name)
+}
+func NewETC2_RG_U11_NORM(name string) *image.Format {
+	return image.NewETC2_RG_U11_NORM(name)
+}
+func NewETC2_R_S11_NORM(name string) *image.Format {
+	return image.NewETC2_R_S11_NORM(name)
+}
+func NewETC2_RG_S11_NORM(name string) *image.Format {
+	return image.NewETC2_RG_S11_NORM(name)
+}
+func NewETC1_RGB_U8_NORM(name string) *image.Format {
+	return image.NewETC1_RGB_U8_NORM(name)
+}
 
 type converterLayout struct {
 	uncompressed *image.Format

--- a/gapis/api/vulkan/BUILD.bazel
+++ b/gapis/api/vulkan/BUILD.bazel
@@ -129,6 +129,7 @@ go_library(
         "//core/event/task:go_default_library",  # keep
         "//core/image:go_default_library",
         "//core/image/astc:go_default_library",
+        "//core/image/etc:go_default_library",
         "//core/log:go_default_library",
         "//core/math/interval:go_default_library",
         "//core/math/u64:go_default_library",  # keep

--- a/gapis/api/vulkan/resources.go
+++ b/gapis/api/vulkan/resources.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/gapid/core/data/id"
 	"github.com/google/gapid/core/image"
 	"github.com/google/gapid/core/image/astc"
+	"github.com/google/gapid/core/image/etc"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/stream/fmts"
 	"github.com/google/gapid/gapis/api"
@@ -364,25 +365,25 @@ func getImageFormatFromVulkanFormat(vkfmt VkFormat) (*image.Format, error) {
 	case VkFormat_VK_FORMAT_BC7_SRGB_BLOCK:
 		return nil, &unsupportedVulkanFormatError{Format: vkfmt}
 	case VkFormat_VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK:
-		return image.NewETC2_RGB_U8_NORM("VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK"), nil
+		return etc.NewETC2_RGB_U8_NORM("VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK"), nil
 	case VkFormat_VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK:
-		return image.NewETC2_RGB_U8_NORM("VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK"), nil
+		return etc.NewETC2_RGB_U8_NORM("VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK"), nil
 	case VkFormat_VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK:
-		return image.NewETC2_RGBA_U8U8U8U1_NORM("VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK"), nil
+		return etc.NewETC2_RGBA_U8U8U8U1_NORM("VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK"), nil
 	case VkFormat_VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK:
-		return image.NewETC2_RGBA_U8U8U8U1_NORM("VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK"), nil
+		return etc.NewETC2_RGBA_U8U8U8U1_NORM("VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK"), nil
 	case VkFormat_VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK:
-		return image.NewETC2_SRGBA_U8_NORM("VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK"), nil
+		return etc.NewETC2_SRGBA_U8_NORM("VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK"), nil
 	case VkFormat_VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK:
-		return image.NewETC2_SRGBA_U8_NORM("VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK"), nil
+		return etc.NewETC2_SRGBA_U8_NORM("VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK"), nil
 	case VkFormat_VK_FORMAT_EAC_R11_UNORM_BLOCK:
-		return image.NewETC2_R_U11_NORM("VK_FORMAT_EAC_R11_UNORM_BLOCK"), nil
+		return etc.NewETC2_R_U11_NORM("VK_FORMAT_EAC_R11_UNORM_BLOCK"), nil
 	case VkFormat_VK_FORMAT_EAC_R11_SNORM_BLOCK:
-		return image.NewETC2_R_S11_NORM("VK_FORMAT_EAC_R11_SNORM_BLOCK"), nil
+		return etc.NewETC2_R_S11_NORM("VK_FORMAT_EAC_R11_SNORM_BLOCK"), nil
 	case VkFormat_VK_FORMAT_EAC_R11G11_UNORM_BLOCK:
-		return image.NewETC2_RG_U11_NORM("VK_FORMAT_EAC_R11G11_UNORM_BLOCK"), nil
+		return etc.NewETC2_RG_U11_NORM("VK_FORMAT_EAC_R11G11_UNORM_BLOCK"), nil
 	case VkFormat_VK_FORMAT_EAC_R11G11_SNORM_BLOCK:
-		return image.NewETC2_RG_S11_NORM("VK_FORMAT_EAC_R11G11_SNORM_BLOCK"), nil
+		return etc.NewETC2_RG_S11_NORM("VK_FORMAT_EAC_R11G11_SNORM_BLOCK"), nil
 	case VkFormat_VK_FORMAT_ASTC_4x4_UNORM_BLOCK:
 		return astc.NewRGBA_4x4("VK_FORMAT_ASTC_4x4_UNORM_BLOCK"), nil
 	case VkFormat_VK_FORMAT_ASTC_4x4_SRGB_BLOCK:


### PR DESCRIPTION
Image Format conversion in AGI done by the converters that are
registered in init time of Go Packages. There are details about this
but simply init function in go packages runs before main when the
packages are loaded.

Recently #651 moved ETC conversion to its own packages similar to ASTC
but different from ASTC, image creation remained in the parent package.
As all the conversion functions called via register map that has registered
during the init, this causes no function from the etc package, which ended up
with it's not being loaded therefore no converter registered.

This is a workaround that just create translator functions to reflect the image
create functions in the parent package and uses those functions in Vulkan/resources
to ensure the package is initialized.

This is suboptimal and only a workaround. I am creating another PR with a refactor
of the image formats. This is only a workaround until the other one can be merged.

b/184954321