### PR TITLE
Integrate Perfetto's existing power rail data into AGI.

### DIFF
--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -354,6 +354,14 @@ func (b *binding) QueryPerfettoServiceState(ctx context.Context) (*device.Perfet
 	if b.Instance().GetConfiguration().GetOS().GetAPIVersion() >= 30 {
 		result.HasFrameLifecycle = true
 	}
+
+	services, err := b.Shell("service", "list").Call(ctx)
+	if err != nil {
+		return result, log.Errf(ctx, err, "Failed to query service list when trying to know power rail capability.")
+	}
+	if strings.Contains(services, "android.hardware.power.stats.IPowerStats/default") {
+		result.HasPowerRail = true
+	}
 	return result, nil
 }
 

--- a/core/os/device/device.proto
+++ b/core/os/device/device.proto
@@ -186,6 +186,7 @@ message PerfettoCapability {
   VulkanProfilingLayers vulkan_profile_layers = 2;
   bool can_specify_atrace_apps = 3;
   bool hasFrameLifecycle = 4;
+  bool hasPowerRail = 5;
 }
 
 message GPUProfiling {

--- a/gapic/src/main/com/google/gapid/perfetto/views/StyleConstants.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/StyleConstants.java
@@ -39,6 +39,7 @@ public class StyleConstants {
   public static final double TRACK_MARGIN = 4;
   public static final double DEFAULT_COUNTER_TRACK_HEIGHT = 45;
   public static final double PROCESS_COUNTER_TRACK_HEIGHT = 30;
+  public static final double POWER_RAIL_COUNTER_TRACK_HEIGHT = 30;
   public static final double HIGHLIGHT_EDGE_NEARBY_WIDTH = 10;
   public static final double SELECTION_THRESHOLD = 0.333;
   public static final double ZOOM_FACTOR_SCALE = 0.05;

--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
@@ -321,7 +321,8 @@ public class TraceConfigDialog extends DialogBase {
               .setName("android.power")
               .getAndroidPowerConfigBuilder()
                   .setBatteryPollMs(p.getBatteryOrBuilder().getRate())
-                  .addAllBatteryCounters(Arrays.asList(BAT_COUNTERS));
+                  .addAllBatteryCounters(Arrays.asList(BAT_COUNTERS))
+                  .setCollectPowerRails(true);
     }
 
     if (p.getVulkanOrBuilder().getEnabled()) {

--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
@@ -322,7 +322,7 @@ public class TraceConfigDialog extends DialogBase {
               .getAndroidPowerConfigBuilder()
                   .setBatteryPollMs(p.getBatteryOrBuilder().getRate())
                   .addAllBatteryCounters(Arrays.asList(BAT_COUNTERS))
-                  .setCollectPowerRails(true);
+                  .setCollectPowerRails(p.getBatteryOrBuilder().getCollectPowerRail());
     }
 
     if (p.getVulkanOrBuilder().getEnabled()) {
@@ -597,6 +597,8 @@ public class TraceConfigDialog extends DialogBase {
     private final Button bat;
     private final Label[] batLabels;
     private final Spinner batRate;
+    private final Button batPowerRail;
+
     private final Button vulkan;
     private final Button vulkanCPUTiming;
     private final Button vulkanCPUTimingDevice;
@@ -740,11 +742,14 @@ public class TraceConfigDialog extends DialogBase {
       bat = createCheckbox(this, "Battery", sBatt.getEnabled(), e -> updateBat());
       batLabels = new Label[2];
       Composite batGroup = withLayoutData(
-          createComposite(this, withMargin(new GridLayout(3, false), 5, 0)),
+          createComposite(this, withMargin(new GridLayout(4, false), 5, 0)),
           withIndents(new GridData(), GROUP_INDENT, 0));
       batLabels[0] = createLabel(batGroup, "Poll Rate:");
       batRate = createSpinner(batGroup, sBatt.getRate(), 250, 60000);
       batLabels[1] = createLabel(batGroup, "ms");
+      batPowerRail = createCheckbox(batGroup, "Collect Power Rails",
+          caps.getHasPowerRail()&& sBatt.getCollectPowerRail());
+      batPowerRail.setVisible(caps.getHasPowerRail());
 
       Device.VulkanProfilingLayers vkLayers = caps.getVulkanProfileLayers();
       if (vkLayers.getCpuTiming() || vkLayers.getMemoryTracker()) {
@@ -863,6 +868,7 @@ public class TraceConfigDialog extends DialogBase {
       sMem.setRate(memRate.getSelection());
       sBatt.setEnabled(bat.getSelection());
       sBatt.setRate(batRate.getSelection());
+      sBatt.setCollectPowerRail(batPowerRail.getSelection());
 
       if (vulkan != null) {
         sVk.setEnabled(vulkan.getSelection());
@@ -968,6 +974,7 @@ public class TraceConfigDialog extends DialogBase {
       for (Label label : batLabels) {
         label.setEnabled(enabled);
       }
+      batPowerRail.setEnabled(enabled);
     }
   }
 

--- a/gapic/src/main/com/google/gapid/settings.proto
+++ b/gapic/src/main/com/google/gapid/settings.proto
@@ -150,6 +150,7 @@ message Perfetto {
   message Battery {
     bool enabled = 1;
     int32 rate = 2;
+    bool collectPowerRail = 3;
   }
   Battery battery = 4;
 


### PR DESCRIPTION
If a device has the capability to capture power rail data, give users the option
to profile it in System Profiler. And for a given perfetto trace, if it contains 
power.rail.* information, let AGI visualize it in counter track format.

Bug: b/177067971, #1.
Test: will need certain devices for testing, the device requirement is in the bug ticket's #8.