### PR TITLE
Mock support of VkImages with Android external format

### DIFF
--- a/gapii/cc/vulkan_mid_execution.cpp
+++ b/gapii/cc/vulkan_mid_execution.cpp
@@ -931,8 +931,16 @@ void VulkanSpy::serializeGPUBuffers(StateSerializer* serializer) {
         device_functions.vkQueueWaitIdle(queue->mVulkanHandle);
       };
 
-      for (auto& family_copies : copies) {
-        copyImageToBuffer(family_copies.second, queues[family_copies.first]);
+      if (image_info.mAndroidExternalFormat) {
+        // We cannot copy from images with an Android external format, it is
+        // forbidden by the spec and in practice it can lead to GPU hangs.
+        // TODO(b/148857112): retrieve the data by sampling the image.
+        // For now, mock support by zeroing image data.
+        memset(stage.GetMappedMemory(), 0, offset);
+      } else {
+        for (auto& family_copies : copies) {
+          copyImageToBuffer(family_copies.second, queues[family_copies.first]);
+        }
       }
 
       uint8_t* pData = reinterpret_cast<uint8_t*>(stage.GetMappedMemory());

--- a/gapii/cc/vulkan_mid_execution.cpp
+++ b/gapii/cc/vulkan_mid_execution.cpp
@@ -936,6 +936,9 @@ void VulkanSpy::serializeGPUBuffers(StateSerializer* serializer) {
         // forbidden by the spec and in practice it can lead to GPU hangs.
         // TODO(b/148857112): retrieve the data by sampling the image.
         // For now, mock support by zeroing image data.
+        GAPID_WARNING(
+            "Mock support of image with Android external format, image data is "
+            "zeroed.");
         memset(stage.GetMappedMemory(), 0, offset);
       } else {
         for (auto& family_copies : copies) {


### PR DESCRIPTION
It is not possible to read directly from VkImages with an Android
external format (which are backed by an Android Hardware Buffer (AHB)
which has an external formal). To unblock the early analysis of some
apps using such kind of images, this change mocks support by actually
returning zeroed data for such images.

The proper way to retrieve such image data is to sample them, this is
tracked by b/148857112. However, there's likely other aspects to take
care of for properly re-creating such image data at replay time.

For now, this small change enables to unblock the early analysis of
some apps.

Bug: b/184956053