### PR TITLE
[WIP] Be robust to unexpected CmdSubmissionKey occurences

### DIFF
--- a/gapis/trace/android/adreno/profiling_data.go
+++ b/gapis/trace/android/adreno/profiling_data.go
@@ -153,6 +153,10 @@ func processGpuSlices(ctx context.Context, processor *perfetto.Processor, captur
 			if indices, ok := syncData.SubmissionIndices[key]; ok && names[i] == renderPassSliceName {
 				var idx []uint64
 				if c, ok := subCommandGroupMap[key]; ok { // Sometimes multiple renderPass slices shares the same renderPass and renderTarget.
+					if c >= len(indices) {
+						log.E(ctx, "CmdSubmissionKey %v appears more often in profiling results than expected")
+						c = len(indices) - 1
+					}
 					idx = indices[c]
 				} else {
 					idx = indices[0]


### PR DESCRIPTION
A certain app leads to the value of `c` being outside the range of
`indices`. Be robust to this case. That's probably not the proper fix.

Bug: b/18728916