### PR TITLE
Support render VK_FORMAT_R16G16_SFLOAT images in FrameBuffer and Texture view.

### DIFF
--- a/gapic/src/main/com/google/gapid/util/Streams.java
+++ b/gapic/src/main/com/google/gapid/util/Streams.java
@@ -102,6 +102,17 @@ public class Streams {
           .setSampling(LINEAR))
       .build();
 
+  public static final Stream.Format FMT_RG16_FLOAT = Stream.Format.newBuilder()
+      .addComponents(Stream.Component.newBuilder()
+          .setChannel(Stream.Channel.Red)
+          .setDataType(F16)
+          .setSampling(LINEAR))
+      .addComponents(Stream.Component.newBuilder()
+          .setChannel(Stream.Channel.Green)
+          .setDataType(F16)
+          .setSampling(LINEAR))
+      .build();
+
   public static final Stream.Format FMT_LUMINANCE_FLOAT = Stream.Format.newBuilder()
       .addComponents(Stream.Component.newBuilder()
           .setChannel(Stream.Channel.Luminance)


### PR DESCRIPTION
Create a specific ArrayImage model for VK_FORMAT_R16G16_SFLOAT typed images, so
that 1. the image will get rendered with correct settings, 2. the image data buffer
will get decoded in the right way.

Bug: b/177572847.
Test: test with a frame capture that records VK_FORMAT_R16G16_SFLOAT typed textures.