### PR TITLE
Also set the mip level to zero when reading from the staging image.

### DIFF
--- a/gapis/api/vulkan/transform_read_framebuffer.go
+++ b/gapis/api/vulkan/transform_read_framebuffer.go
@@ -360,6 +360,7 @@ func (t *readFramebuffer) postImageData(ctx context.Context,
 	resolveSrcLayer := layer
 	blitSrcLayer := layer
 	copySrcLayer := layer
+	copySrcLevel := level
 	if imageObject.Info().Samples() != VkSampleCountFlagBits_VK_SAMPLE_COUNT_1_BIT {
 		resolveSrcLayer = layer
 		blitSrcDepth = 0
@@ -371,6 +372,7 @@ func (t *readFramebuffer) postImageData(ctx context.Context,
 	if doBlit {
 		copySrcDepth = 0
 		copySrcLayer = 0
+		copySrcLevel = 0
 	}
 
 	origLayout := t.getLayout(ctx, inputState, cmdBuff, pendingCommandBuffers, aspect, layer, level, imageObject)
@@ -611,7 +613,7 @@ func (t *readFramebuffer) postImageData(ctx context.Context,
 		0, // bufferImageHeight
 		NewVkImageSubresourceLayers( // imageSubresource
 			VkImageAspectFlags(aspect), // aspectMask
-			level,                      // mipLevel
+			copySrcLevel,               // mipLevel
 			copySrcLayer,               // baseArrayLayer
 			1,                          // layerCount
 		),


### PR DESCRIPTION
When we need to do a blit to read back the framebuffer, the staging image will have only one layer and one level. We correctly reset the layer for the copy to 0, but didn't set the level to 0. Thus we would attempt to copy from an invalid mip level if we blitted from anything but level 0.