### PR TITLE
Fix buffer device memory allocation during state rebuilder

### DIFF
--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -1313,8 +1313,7 @@ func (sb *stateBuilder) createBuffer(buffer BufferObjectʳ) {
 		buffer.LastBoundQueue())
 	newBuffer := buffer.VulkanHandle()
 
-	mem := GetState(sb.newState).DeviceMemories().Get(buffer.Memory().VulkanHandle())
-	if err := sb.createSameBuffer(buffer, newBuffer, mem, buffer.MemoryOffset()); err != nil {
+	if err := sb.createSameBuffer(buffer, newBuffer, buffer.Memory(), buffer.MemoryOffset()); err != nil {
 		log.E(sb.ctx, "create buffer %v failed", buffer)
 		return
 	}


### PR DESCRIPTION
This fixes crashes with this kind of stack trace:

```
<panic because mem is dereferenced>
gapis/api/vulkan/state_rebuilder.go:(*stateBuilder).createDeviceMemory(mem=nil, ...)
gapis/api/vulkan/state_rebuilder.go:(*stateBuilder).createSameBuffer(..., mem=nil, ...)
gapis/api/vulkan/state_rebuilder.go:(*stateBuilder).createBuffer()
gapis/api/vulkan/state_rebuilder.go:API.RebuildState()
```

During state rebuilding, the re-creation of Vulkan DeviceMemory is
separated between regular ones, which are recreated early in the state
rebuilding process, and ones with dedicated allocations (i.e. using
DedicatedAllocationNV or DedicatedAllocationKHR), which are re-created
only when their associated resource is re-created. In the case of
buffers, in createBuffer(), we call createSameBuffer() and we pass a
relevant DeviceMemory object. This DeviceMemory argument can have some
special values when createSameBuffer() is called from frame looping
code in `gapis/api/vulkan/looping_vulkan_control_flow_generator.go`.
But in the case of state rebuilder, we just need to pass the
DeviceMemory that is associate to the buffer.

The code used to look-up this DeviceMemory from the state rebuilder's
newState: in the case of DeviceMemory with dedicated allocation, this
returns a nil DeviceMemory since at this point only regular
DeviceMemory have been re-created in the newState. The nil
DeviceMemory leads to the crash mentioned above.

I believe this lookup in the newState is erroneously used since commit
076baaa0fec38510a7357d1f76bc0ed32f3d9f91, which probaly copy-pasted
this lookup in the newState from the patterns used in frame looping
code. In the case of state rebuilding, the DeviceMemory object should
simply be the one associated by the buffer we want to re-create. This
is what this change does: just use buffer.Memory() as the DeviceMemory
argument of createSameBuffer().

Bug: b/186156203
Test: manually test various apps impacted by this bug.