### PR TITLE
Fix a bug when setting the end of the framebuffer histogram's default range.

### DIFF
--- a/gapic/src/main/com/google/gapid/image/Histogram.java
+++ b/gapic/src/main/com/google/gapid/image/Histogram.java
@@ -18,12 +18,15 @@ package com.google.gapid.image;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toSet;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.gapid.image.Image.PixelInfo;
 import com.google.gapid.proto.stream.Stream;
 import com.google.gapid.proto.stream.Stream.Channel;
 import com.google.gapid.util.Range;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
@@ -71,8 +74,8 @@ public class Histogram {
       return Range.IDENTITY;
     }
 
-    double rangeMin = getPercentile(1, false);
-    double rangeMax = getPercentile(99, true);
+    double rangeMin = getPercentile(1, false, false);
+    double rangeMax = getPercentile(99, true, true);
 
     // Snap the range to the limits if they're close enough.
     if (mapper.normalize(rangeMin) < snapThreshold) {
@@ -87,13 +90,25 @@ public class Histogram {
 
   /**
    * @param percentile the percentile value ranging from 0 to 100.
+   * @param lastBin if true, for all the percentile bins from different channels, choose the last
+   * bin, otherwise choose the first bin.
    * @param high if true, return the upper limit on the percentile's bin, otherwise the lower limit.
    * @return the absolute pixel value at the specified percentile in the histogram.
    */
-  private double getPercentile(int percentile, boolean high) {
-    int bin = bins.getPercentileBin(percentile, channels);
-    return (bin < 0) ? mapper.limits.max :
-        getValueFromNormalizedX((bin + (high ? 1 : 0)) / (double)bins.count());
+  private double getPercentile(int percentile, boolean lastBin, boolean high) {
+    List<Integer> percentileBins = Lists.newArrayList();
+    for (Stream.Channel c : channels) {
+      int bin = bins.getPercentileBin(percentile, c);
+      if (bin >= 0) {
+        percentileBins.add(bin);
+      }
+    }
+    if (percentileBins.isEmpty()) {
+      return mapper.limits.max;
+    } else {
+      int chosenBin = lastBin ? Collections.max(percentileBins) : Collections.min(percentileBins);
+      return getValueFromNormalizedX((chosenBin + (high ? 1 : 0)) / (double)bins.count());
+    }
   }
 
   /**
@@ -353,21 +368,14 @@ public class Histogram {
     /**
      * Returns the index of the bin which matches the given percentile, or -1.
      */
-    public int getPercentileBin(int percentile, Set<Stream.Channel> channels) {
-      int highestCount = 0;
-      for (Stream.Channel c : channels) {
-        highestCount = Math.max(highestCount, total[getChannelIdx(c)]);
-      }
-
-      int threshold = percentile * highestCount / 100;
-      int[] sum = new int[Stream.Channel.values().length];
+    public int getPercentileBin(int percentile, Stream.Channel channel) {
+      int cIdx = getChannelIdx(channel);
+      int threshold = percentile * total[getChannelIdx(channel)] / 100;
+      int sum = 0;
       for (int b = 0; b < bins.length; b++) {
-        for (Stream.Channel c : channels) {
-          int cIdx = getChannelIdx(c);
-          int s = sum[cIdx] += bins[b][cIdx];
-          if (s >= threshold) {
-            return b;
-          }
+        sum += bins[b][cIdx];
+        if (sum >= threshold) {
+          return b;
         }
       }
       return -1;

--- a/gapic/src/main/com/google/gapid/image/Histogram.java
+++ b/gapic/src/main/com/google/gapid/image/Histogram.java
@@ -74,8 +74,8 @@ public class Histogram {
       return Range.IDENTITY;
     }
 
-    double rangeMin = getPercentile(1, false, false);
-    double rangeMax = getPercentile(99, true, true);
+    double rangeMin = getPercentile(1, false);
+    double rangeMax = getPercentile(99, true);
 
     // Snap the range to the limits if they're close enough.
     if (mapper.normalize(rangeMin) < snapThreshold) {
@@ -92,10 +92,9 @@ public class Histogram {
    * @param percentile the percentile value ranging from 0 to 100.
    * @param lastBin if true, for all the percentile bins from different channels, choose the last
    * bin, otherwise choose the first bin.
-   * @param high if true, return the upper limit on the percentile's bin, otherwise the lower limit.
    * @return the absolute pixel value at the specified percentile in the histogram.
    */
-  private double getPercentile(int percentile, boolean lastBin, boolean high) {
+  private double getPercentile(int percentile, boolean lastBin) {
     List<Integer> percentileBins = Lists.newArrayList();
     for (Stream.Channel c : channels) {
       int bin = bins.getPercentileBin(percentile, c);
@@ -107,7 +106,8 @@ public class Histogram {
       return mapper.limits.max;
     } else {
       int chosenBin = lastBin ? Collections.max(percentileBins) : Collections.min(percentileBins);
-      return getValueFromNormalizedX((chosenBin + (high ? 1 : 0)) / (double)bins.count());
+      // If to choose lastBin, return the upper limit of the bin, otherwise the lower limit.
+      return getValueFromNormalizedX((chosenBin + (lastBin ? 1 : 0)) / (double)bins.count());
     }
   }
 


### PR DESCRIPTION
AGI will calculate and set default histogram range in framebuffer view and the general
intention is to set the range's end to the bin at 99% percentile in the histogram.

However, different channels will reach 99% percentile at different bin, and previously,
because of an early return, when iterating through the bins, if AGI found any of the
channels already reaches 99% percentile, it will immediately return that bin as the end
of the whole range. This will cause trouble in cases where different channels reaches
99% at very different bins. e.g. for a R16G16 image, the blue channel is always 0,
so 100% of the pixels falls at the value 0, and thus blue channel's 99% percentile bin reaches
early at bin 0, if we use this as the default histogram range's end, it will erase detail
for the red and yellow channel.

Ideally the range's end should be the last 99% percentile bin across all channels, so
that the main distribution of all channels will get displayed.This PR makes sure the range
starts at the *first* 1% percentile bin, and ends at the *last* 99% percentile bin.

Bug: b/177572847.