### PR TITLE
Rename GPU activity to GPU queues

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
@@ -639,7 +639,7 @@ public class TraceConfigDialog extends DialogBase {
             createComposite(this, withMargin(new GridLayout(1, false), 5, 0)),
             withIndents(new GridData(), GROUP_INDENT, 0));
         if (gpuCaps.getHasRenderStage()) {
-          gpuSlices = createCheckbox(gpuGroup, "GPU activity", sGpu.getSlices());
+          gpuSlices = createCheckbox(gpuGroup, "GPU queues", sGpu.getSlices());
         } else {
           gpuSlices = null;
         }

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -290,9 +290,9 @@ public class TracerDialog {
       private static final String DURATION_PERFETTO_UNIT = "Seconds";
       private static final String START_AT_TIME_UNIT = "Seconds";
       private static final String PERFETTO_LABEL = "Profile Config: ";
-      // Quote 'GPU activity' in the warning message to match the config panel tickbox title.
+      // Quote 'GPU queues' in the warning message to match the config panel tickbox title.
       private static final String EMPTY_APP_WITH_RENDER_STAGE =
-          "Warning: cannot record 'GPU activity' when no application is selected";
+          "Warning: cannot record 'GPU queues' when no application is selected";
 
       private final String date = TRACE_DATE_FORMAT.format(new Date());
 


### PR DESCRIPTION
The term "GPU activity" appears nowhere in the results, so it's
confusing to use it in the config menu. As both Adreno and Mali return
a "GPU Queue" track when GPU activity is ticked, lets use this term to
in the config menu as well.

Bug: b/186401470
Test: manual