### PR TITLE
Avoid the need to restart AGI after installing ANGLE

### DIFF
--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -183,7 +183,14 @@ func (b *binding) InstallAPK(ctx context.Context, path string, reinstall bool, g
 	// Because adb root/unroot is outside the program's state there's not much we can do to prevent this
 	// race conditon though. Someone could always run adb from a terminal at a bad time...
 	b.Unroot(ctx)
-	return b.Command("install", args...).Run(ctx)
+	if err := b.Command("install", args...).Run(ctx); err != nil {
+		return err
+	}
+
+	// We've just installed an APK, likely ANGLE, so rescan this device info.
+	rescanDevice(ctx, b)
+
+	return nil
 }
 
 // SELinuxEnforcing returns true if the device is currently in a

--- a/core/os/android/adb/device.go
+++ b/core/os/android/adb/device.go
@@ -350,6 +350,15 @@ func scanDevices(ctx context.Context) error {
 	return nil
 }
 
+// rescanDevice force-refresh the device info for a particular device.
+func rescanDevice(ctx context.Context, d bind.Device) error {
+	registry.RemoveDevice(ctx, d)
+	cacheMutex.Lock()
+	delete(cache, d.Instance().Serial)
+	cacheMutex.Unlock()
+	return scanDevices(ctx)
+}
+
 func parseDevices(ctx context.Context, out string) (map[string]bind.Status, error) {
 	a := strings.SplitAfter(out, "List of devices attached")
 	if len(a) != 2 {


### PR DESCRIPTION
Before this change, if you start AGI with a device that has no ANGLE,
then use AGI to install ANGLE, then try and start an ANGLE trace,
you'll get a "ANGLE requested but no ANGLE package found" error. This
is because installing ANGLE doesn't update the device info, such that
AGI still thinks ANGLE is not present on the device.

The way device info is stored is non-trivial: there's a background
task (see monitorAndroidDevices()) that monitors devices and store
them in a "registry" that is queried when we list devices. It sounds
like the proper way to update device info is to remove the device from
the registry, and let the monitor re-scan it accordingly. It sounds
relevant to do it after any APK install that may change the device
info.

On the UI side, we also need to make sure to refresh the device info
after installing ANGLE.

Bug: b/186611374
Test: manual, making sure to run AGI on a device with no ANGLE on it.