### PR TITLE
Avoid unnamed columns in CombinedCounterTrack SQL

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/models/CombinedCountersTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/CombinedCountersTrack.java
@@ -77,7 +77,7 @@ public abstract class CombinedCountersTrack
         .append("lead(ts, 1, (select end_ts from trace_bounds)) over win - ts dur");
     for (int i = 0; i < columns.length; i++) {
       if (columns[i].isNil()) {
-        sb.append(", ").append(columns[i].sqlDefault);
+        sb.append(", ").append(columns[i].sqlDefault).append(" v_").append(i);
       } else {
         sb.append(", last_non_null(v_").append(i).append(") over win v_").append(i);
       }


### PR DESCRIPTION
When creating the buildViewSql query for CombinedCounterTrack, we had
unnamed columns that lead to errors later on.

For instance, on a given trace, we had:

    create view vals_mem_6 as
      select
        ...
	last_non_null(v_0) over win v_0,
	last_non_null(v_1) over win v_1,
	0, # This results in an unnamed column
        ...
      from
        ...

And later this query, which uses vals_mem_6, was failing:

    create virtual table span_mem_6 using span_join(vals_mem_6, window_mem_6))

It looks like the perfetto-specific span_join does not play well with
unnamed columns.

This change makes sure to name all columns, even the zeroed ones.

Bug: n/a
Test: manual