### PR TITLE
Disable UI support to edit shader source

### DIFF
--- a/gapic/src/main/com/google/gapid/Main.java
+++ b/gapic/src/main/com/google/gapid/Main.java
@@ -243,6 +243,7 @@ public class Main {
     Experimental.enableAngleTracing,
     Experimental.enablePerfTab,
     Experimental.enableProfileExperiments,
+    Experimental.enableUnstableFeatures,
     GapiPaths.gapidPath,
     GapiPaths.adbPath,
     GapisProcess.disableGapisTimeout,

--- a/gapic/src/main/com/google/gapid/util/Experimental.java
+++ b/gapic/src/main/com/google/gapid/util/Experimental.java
@@ -41,6 +41,9 @@ public class Experimental {
   public static final Flag<Boolean> enableProfileExperiments = Flags.value("experimental-enable-profile-experiments",
       false, "Enable Profile Experiments.");
 
+  public static final Flag<Boolean> enableUnstableFeatures = Flags.value("experimental-enable-unstable-features",
+      false, "Enable various unstable features that are not ready for use yet.");
+
   public static List<String> getGapisFlags(boolean enableAllExperimentalFeatures) {
     List<String> args = Lists.newArrayList();
     // The --experimental-enable-all flag is a sugar flag from the UI. GAPIS knows nothing about it.
@@ -76,5 +79,10 @@ public class Experimental {
   public static boolean enableProfileExperiments(Settings settings) {
     return settings.preferences().getEnableAllExperimentalFeatures() ||
         enableAll.get() || enableProfileExperiments.get();
+  }
+
+  public static boolean enableUnstableFeatures(Settings settings) {
+    return settings.preferences().getEnableAllExperimentalFeatures() ||
+        enableAll.get() || enableUnstableFeatures.get();
   }
 }

--- a/gapic/src/main/com/google/gapid/views/ShaderView.java
+++ b/gapic/src/main/com/google/gapid/views/ShaderView.java
@@ -42,6 +42,7 @@ import com.google.gapid.rpc.Rpc;
 import com.google.gapid.rpc.RpcException;
 import com.google.gapid.rpc.SingleInFlight;
 import com.google.gapid.rpc.UiCallback;
+import com.google.gapid.util.Experimental;
 import com.google.gapid.util.Loadable;
 import com.google.gapid.util.Messages;
 import com.google.gapid.widgets.LoadablePanel;
@@ -70,6 +71,7 @@ import org.eclipse.swt.widgets.TabItem;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
 
@@ -94,7 +96,7 @@ public class ShaderView extends Composite
   private final GridData crossCompileGridData;
   private final SourceViewer spirvViewer;
   private final SourceViewer sourceViewer;
-  private final Button pushButton;
+  private final Optional<Button> pushButton;
   private TabItem sourceTab;
 
   protected Service.Resource shaderResource = null;
@@ -117,7 +119,7 @@ public class ShaderView extends Composite
     spirvGroup = createGroup(tabFolder, "");
     spirvViewer =
         new SourceViewer(spirvGroup, null, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER);
-    spirvViewer.setEditable(true);
+    spirvViewer.setEditable(false);
     spirvViewer.configure(new GlslSourceConfiguration(widgets.theme));
     StyledText spirvTextWidget = spirvViewer.getTextWidget();
     spirvTextWidget.setFont(widgets.theme.monoSpaceFont());
@@ -139,7 +141,7 @@ public class ShaderView extends Composite
     crossCompileLabel.setLayoutData(crossCompileGridData);
     sourceViewer =
         new SourceViewer(sourceGroup, null, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER);
-    sourceViewer.setEditable(true);
+    sourceViewer.setEditable(false);
     sourceViewer.configure(new GlslSourceConfiguration(widgets.theme));
     sourceViewer.getControl().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
     StyledText sourceTextWidget = sourceViewer.getTextWidget();
@@ -153,16 +155,24 @@ public class ShaderView extends Composite
       }
     });
 
-    pushButton = Widgets.createButton(loading.getContents(), "Push Changes", e -> {
-      if (shaderResource != null && shaderMessage != null) {
-        models.analytics.postInteraction(View.ShaderView, ClientAction.Edit);
-        models.resources.updateResource(shaderResource, API.ResourceData.newBuilder()
-            .setShader(shaderMessage.toBuilder().setSource(spirvViewer.getDocument().get()))
-            .build());
-      }
-    });
-    pushButton.setLayoutData(new GridData(SWT.RIGHT, SWT.BOTTOM, false, false));
-    pushButton.setEnabled(false);
+    if (!Experimental.enableAll.get()) {
+      pushButton = Optional.empty();
+    } else {
+      pushButton = Optional.of(Widgets.createButton(loading.getContents(), "Push Changes", e -> {
+        if (shaderResource != null && shaderMessage != null) {
+          models.analytics.postInteraction(View.ShaderView, ClientAction.Edit);
+          models.resources.updateResource(shaderResource, API.ResourceData.newBuilder()
+              .setShader(shaderMessage.toBuilder().setSource(spirvViewer.getDocument().get()))
+              .build());
+        }
+      }));
+      pushButton.ifPresent(b -> {
+        b.setLayoutData(new GridData(SWT.RIGHT, SWT.BOTTOM, false, false));
+        b.setEnabled(false);
+      });
+      spirvViewer.setEditable(true);
+      sourceViewer.setEditable(true);
+    }
 
     statGroup = Widgets.createGroup(loading.getContents(), "Static Analysis");
     statGroup.setFont(theme.subTitleFont());
@@ -245,7 +255,7 @@ public class ShaderView extends Composite
   public void setShader(API.Shader shader) {
     loading.stopLoading();
     shaderMessage = shader;
-    pushButton.setEnabled(true);
+    pushButton.ifPresent(b -> b.setEnabled(true));
     String label = shaderResource != null ? shaderResource.getHandle() : "Shader";
     spirvGroup.setText(label);
     String spirvSource = shaderMessage.getSpirvSource();
@@ -282,7 +292,7 @@ public class ShaderView extends Composite
     if (!pinned) {
       shaderMessage = null;
     }
-    pushButton.setEnabled(false);
+    pushButton.ifPresent(b -> b.setEnabled(true));
   }
 
   private void loadShader(Service.Resource shader) {

--- a/gapic/src/main/com/google/gapid/views/ShaderView.java
+++ b/gapic/src/main/com/google/gapid/views/ShaderView.java
@@ -157,7 +157,7 @@ public class ShaderView extends Composite
 
     // TODO(b/188434910): Shader editing is disabled as it doesn't work right
     // now. Enable it once the issue is fixed.
-    if (!Experimental.enableAll.get()) {
+    if (!Experimental.enableUnstableFeatures(models.settings)) {
       pushButton = Optional.empty();
     } else {
       pushButton = Optional.of(Widgets.createButton(loading.getContents(), "Push Changes", e -> {

--- a/gapic/src/main/com/google/gapid/views/ShaderView.java
+++ b/gapic/src/main/com/google/gapid/views/ShaderView.java
@@ -294,7 +294,7 @@ public class ShaderView extends Composite
     if (!pinned) {
       shaderMessage = null;
     }
-    pushButton.ifPresent(b -> b.setEnabled(true));
+    pushButton.ifPresent(b -> b.setEnabled(false));
   }
 
   private void loadShader(Service.Resource shader) {

--- a/gapic/src/main/com/google/gapid/views/ShaderView.java
+++ b/gapic/src/main/com/google/gapid/views/ShaderView.java
@@ -155,6 +155,8 @@ public class ShaderView extends Composite
       }
     });
 
+    // TODO(b/188434910): Shader editing is disabled as it doesn't work right
+    // now. Enable it once the issue is fixed.
     if (!Experimental.enableAll.get()) {
       pushButton = Optional.empty();
     } else {


### PR DESCRIPTION
Pushing the shader changes doesn't appear to work yet. Until we fix the issue,
hide the button and make the source code not editable.

This introduces a new flag to enable features that are under development. This
is intended for minor features that need to stay disabled while they are
implemented or issues are resolved.

Bug: 188434910
Test: manual