### PR TITLE
Show ANGLE installation message if ANGLE is missing

### DIFF
--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -745,7 +745,8 @@ public class TracerDialog {
         boolean showAngleWarning = false;
         if (isAngle(config)) {
           DeviceCaptureInfo dev = devices.get(device.getCombo().getSelectionIndex());
-          if (dev.device.getConfiguration().getAngle().getVersion() <
+          if (dev.device.getConfiguration().getAngle().getVersion() == 0 ||
+              dev.device.getConfiguration().getAngle().getVersion() <
               settings.preferences().getLatestAngleRelease().getVersion()) {
             showAngleWarning = true;
           }


### PR DESCRIPTION
If ANGLE is not installed and the ANGLE version is missing in settings,
both the current and latest version number is 0. Show the ANGLE
installation message in this case.

Note that this will spawn a browser to install ANGLE manually at this
point.