### PR TITLE
Show async process event tracks.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/models/AsyncInfo.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/AsyncInfo.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.perfetto.models;
+
+import static com.google.gapid.util.MoreFutures.transform;
+
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.gapid.models.Perfetto;
+
+import java.util.List;
+
+public class AsyncInfo {
+  private static final String LIST_SQL =
+      "select t.upid, t.name, t.id, max(s.depth) + 1 " +
+      "from process_track t inner join slice s on s.track_id = t.id " +
+      "group by t.upid, t.name, t.id " +
+      "order by t.upid, t.name, t.id";
+
+  public final long upid;
+  public final String name;
+  public final int maxDepth;
+  public final Track[] tracks;
+
+  public AsyncInfo(long upid, String name, int maxDepth, Track[] tracks) {
+    this.upid = upid;
+    this.name = name;
+    this.maxDepth = maxDepth;
+    this.tracks = tracks;
+  }
+
+  public static ListenableFuture<Perfetto.Data.Builder> listAsync(Perfetto.Data.Builder data) {
+    return transform(data.qe.query(LIST_SQL), res -> {
+      long groupPid = -1;
+      String groupName = null;
+      int maxDepth = 0;
+      List<Track> tracks = Lists.newArrayList();
+
+      ImmutableListMultimap.Builder<Long, AsyncInfo> asyncs = ImmutableListMultimap.builder();
+      for (int i = 0; i < res.getNumRows(); i++) {
+        long upid = res.getLong(i, 0, 0);
+        String name = res.getString(i, 1, "");
+        long id = res.getLong(i, 2, 0);
+        int depth = (int)res.getLong(i, 3, 1);
+
+        if (upid != groupPid || !name.equals(groupName)) {
+          if (!tracks.isEmpty()) {
+            asyncs.put(groupPid, new AsyncInfo(
+                groupPid, groupName, maxDepth, tracks.toArray(new Track[tracks.size()])));
+          }
+          groupPid = upid;
+          groupName = name;
+          maxDepth = 0;
+          tracks.clear();
+        }
+
+        tracks.add(new Track(id, maxDepth, depth));
+        maxDepth += depth;
+      }
+
+      if (!tracks.isEmpty()) {
+        asyncs.put(groupPid, new AsyncInfo(
+            groupPid, groupName, maxDepth, tracks.toArray(new Track[tracks.size()])));
+      }
+      return data.setAsyncs(asyncs.build());
+    });
+  }
+
+  public static class Track {
+    public final long trackId;
+    public final int depthOffset;
+    public final int depth;
+
+    public Track(long trackId, int depthOffset, int depth) {
+      this.trackId = trackId;
+      this.depthOffset = depthOffset;
+      this.depth = depth;
+    }
+  }
+}

--- a/gapic/src/main/com/google/gapid/perfetto/models/Selection.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Selection.java
@@ -179,18 +179,19 @@ public interface Selection<T extends Selection<T>> {
   }
 
   public static class Kind implements Comparable<Kind>{
-    public static final Kind Thread = new Kind(0);
-    public static final Kind ThreadState = new Kind(1);
-    public static final Kind Cpu = new Kind(2);
-    public static final Kind Gpu = new Kind(3);
-    public static final Kind VulkanEvent = new Kind(4);
-    public static final Kind Counter = new Kind(5);
-    public static final Kind FrameEvents = new Kind(6);
-    public static final Kind Memory = new Kind(7);
-    public static final Kind Battery = new Kind(8);
-    public static final Kind ProcessMemory = new Kind(9);
+    public static final Kind Thread = new Kind(1000);
+    public static final Kind ThreadState = new Kind(1010);
+    public static final Kind Cpu = new Kind(1020);
+    public static final Kind Async = new Kind(1030);
+    public static final Kind Gpu = new Kind(1040);
+    public static final Kind VulkanEvent = new Kind(1050);
+    public static final Kind Counter = new Kind(1060);
+    public static final Kind FrameEvents = new Kind(1070);
+    public static final Kind Memory = new Kind(1080);
+    public static final Kind Battery = new Kind(1090);
+    public static final Kind ProcessMemory = new Kind(1100);
 
-    public int priority;
+    private final int priority;
 
     public Kind(int priority) {
       this.priority = priority;

--- a/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
@@ -32,6 +32,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gapid.models.Perfetto;
 import com.google.gapid.perfetto.canvas.Panel;
 import com.google.gapid.perfetto.models.TrackConfig.Group;
+import com.google.gapid.perfetto.views.AsyncPanel;
 import com.google.gapid.perfetto.views.CounterPanel;
 import com.google.gapid.perfetto.views.CpuFrequencyPanel;
 import com.google.gapid.perfetto.views.CpuPanel;
@@ -335,6 +336,23 @@ public class Tracks {
           data.tracks.addTrack(parentId, track.getId(), counter.name,
               single(state -> new CounterPanel(
                   state, track, PROCESS_COUNTER_TRACK_HEIGHT), last, false));
+        }
+      }
+
+      List<AsyncInfo> asyncs = data.getAsyncs().get(process.upid);
+      if (!asyncs.isEmpty()) {
+        String parentId = summary.getId();
+        if (asyncs.size() > 3) {
+          parentId = "proc_asyncs_" + process.upid;
+          data.tracks.addLabelGroup(summary.getId(), parentId, "Process Async Events",
+              group(state -> new TitlePanel("Process Async Events"), false));
+        }
+        for (int i = 0; i < asyncs.size(); i++) {
+          AsyncInfo async = asyncs.get(i);
+          boolean last = i == asyncs.size() - 1;
+          SliceTrack track = SliceTrack.forAsync(data.qe, async);
+          data.tracks.addTrack(parentId, track.getId(), async.name,
+              single(state -> new AsyncPanel(state, async, track), last, true));
         }
       }
 

--- a/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
@@ -304,10 +304,12 @@ public class Tracks {
         String groupId = "vulkan_counters_" + process.upid;
         data.tracks.addLabelGroup(summary.getId(), groupId, "Vulkan Memory Usage",
             group(state -> new TitlePanel("Vulkan Memory Usage"), true));
-        for (CounterInfo counter : counters) {
+        for (int i = 0; i < counters.size(); i++) {
+          CounterInfo counter = counters.get(i);
+          boolean last = i == counters.size() - 1;
           CounterTrack track = new CounterTrack(data.qe, counter);
           data.tracks.addTrack(groupId, track.getId(), counter.name,
-              single(state -> new VulkanCounterPanel(state, track), false, false));
+              single(state -> new VulkanCounterPanel(state, track), last, false));
         }
       }
 
@@ -326,11 +328,13 @@ public class Tracks {
           data.tracks.addLabelGroup(summary.getId(), parentId, "Process Counters",
               group(state -> new TitlePanel("Process Counters"), false));
         }
-        for (CounterInfo counter : counters) {
+        for (int i = 0; i < counters.size(); i++) {
+          CounterInfo counter = counters.get(i);
+          boolean last = i == counters.size() - 1;
           CounterTrack track = new CounterTrack(data.qe, counter);
           data.tracks.addTrack(parentId, track.getId(), counter.name,
-              single(state -> new CounterPanel(state, track, PROCESS_COUNTER_TRACK_HEIGHT),false,
-                  false));
+              single(state -> new CounterPanel(
+                  state, track, PROCESS_COUNTER_TRACK_HEIGHT), last, false));
         }
       }
 

--- a/gapic/src/main/com/google/gapid/perfetto/views/AsyncPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/AsyncPanel.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (C) 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.perfetto.views;
+
+import static com.google.gapid.perfetto.views.Loading.drawLoading;
+import static com.google.gapid.perfetto.views.StyleConstants.SELECTION_THRESHOLD;
+import static com.google.gapid.perfetto.views.StyleConstants.TRACK_MARGIN;
+import static com.google.gapid.perfetto.views.StyleConstants.colors;
+
+import com.google.common.collect.Lists;
+import com.google.gapid.perfetto.TimeSpan;
+import com.google.gapid.perfetto.canvas.Area;
+import com.google.gapid.perfetto.canvas.Fonts;
+import com.google.gapid.perfetto.canvas.RenderContext;
+import com.google.gapid.perfetto.canvas.Size;
+import com.google.gapid.perfetto.models.AsyncInfo;
+import com.google.gapid.perfetto.models.Selection;
+import com.google.gapid.perfetto.models.SliceTrack;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Cursor;
+import org.eclipse.swt.graphics.RGBA;
+import org.eclipse.swt.widgets.Display;
+
+import java.util.List;
+
+public class AsyncPanel extends TrackPanel<AsyncPanel> implements Selectable {
+  private static final double SLICE_HEIGHT = 25 - 2 * TRACK_MARGIN;
+  private static final double HOVER_MARGIN = 10;
+  private static final double HOVER_PADDING = 4;
+  private static final int BOUNDING_BOX_LINE_WIDTH = 3;
+
+  private final AsyncInfo async;
+  protected final SliceTrack track;
+
+  protected double mouseXpos, mouseYpos;
+  protected String hoveredTitle;
+  protected String hoveredCategory;
+  protected Size hoveredSize = Size.ZERO;
+
+  public AsyncPanel(State state, AsyncInfo async, SliceTrack track) {
+    super(state);
+    this.async = async;
+    this.track = track;
+  }
+
+  @Override
+  public AsyncPanel copy() {
+    return new AsyncPanel(state, async, track);
+  }
+
+  @Override
+  public String getTitle() {
+    return async.name;
+  }
+
+  @Override
+  public String getTooltip() {
+    return "\\b" + async.name;
+  }
+
+  @Override
+  public double getHeight() {
+    return async.maxDepth * SLICE_HEIGHT;
+  }
+
+  @Override
+  protected void renderTrack(RenderContext ctx, Repainter repainter, double w, double h) {
+    ctx.trace("Async", () -> {
+      SliceTrack.Data data = track.getData(state.toRequest(), onUiThread(repainter));
+      drawLoading(ctx, data, state, h);
+
+      if (data == null) {
+        return;
+      }
+
+      TimeSpan visible = state.getVisibleTime();
+      Selection<?> selected = state.getSelection(Selection.Kind.Async);
+      List<Highlight> visibleSelected = Lists.newArrayList();
+      String[] concatedIds = data.getExtraStrings("concatedIds");
+
+      for (int i = 0; i < data.starts.length; i++) {
+        long tStart = data.starts[i];
+        long tEnd = data.ends[i];
+        int depth = data.depths[i];
+        long id = data.ids[i];
+        String title = data.titles[i];
+
+        if (tEnd <= visible.start || tStart >= visible.end) {
+          continue;
+        }
+        double rectStart = state.timeToPx(tStart);
+        double rectWidth = Math.max(1, state.timeToPx(tEnd) - rectStart);
+        double y = depth * SLICE_HEIGHT;
+
+        StyleConstants.Gradient color = getSliceColor(data.titles[i]);
+        color.applyBase(ctx);
+        ctx.fillRect(rectStart, y, rectWidth, SLICE_HEIGHT);
+
+        // Highlight slice if it's selected.
+        if (selected.contains(id)) {
+          visibleSelected.add(new Highlight(color.border, rectStart, y, rectWidth));
+        } else if (i < concatedIds.length) {
+          for (String cId : concatedIds[i].split(",")) {
+            if (selected.contains(Long.parseLong(cId))) {
+              visibleSelected.add(new Highlight(color.border, rectStart, y, rectWidth));
+              break;
+            }
+          }
+        }
+
+        // Don't render text when we have less than 7px to play with.
+        if (rectWidth < 7) {
+          continue;
+        }
+
+        ctx.setForegroundColor(colors().textMain);
+        ctx.drawText(
+            Fonts.Style.Normal, title, rectStart + 2, y + 2, rectWidth - 4, SLICE_HEIGHT - 4);
+      }
+
+      // Draw bounding rectangles after all the slices are rendered, so that the border is on the top.
+      for (Highlight highlight : visibleSelected) {
+        ctx.setForegroundColor(highlight.color);
+        ctx.drawRect(highlight.x, highlight.y, highlight.w, SLICE_HEIGHT, BOUNDING_BOX_LINE_WIDTH);
+      }
+
+      if (hoveredTitle != null) {
+        double cardW = hoveredSize.w + 2 * HOVER_PADDING;
+        double cardX = mouseXpos + HOVER_MARGIN;
+        if (cardX >= w - cardW) {
+          cardX = mouseXpos - HOVER_MARGIN - cardW;
+        }
+        ctx.setBackgroundColor(colors().hoverBackground);
+        ctx.fillRect(cardX, mouseYpos, cardW, hoveredSize.h);
+
+        ctx.setForegroundColor(colors().textMain);
+        ctx.drawText(Fonts.Style.Normal, hoveredTitle, cardX + HOVER_PADDING,
+            mouseYpos + HOVER_PADDING / 2);
+        if (!hoveredCategory.isEmpty()) {
+          ctx.setForegroundColor(colors().textAlt);
+          ctx.drawText(Fonts.Style.Normal, hoveredCategory, cardX + HOVER_PADDING,
+              mouseYpos + hoveredSize.h / 2, hoveredSize.h / 2);
+        }
+      }
+    });
+  }
+
+  @Override
+  protected Hover onTrackMouseMove(
+      Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
+    SliceTrack.Data data = track.getData(state.toRequest(), onUiThread(repainter));
+    if (data == null) {
+      return Hover.NONE;
+    }
+
+    int depth = (int)(y / SLICE_HEIGHT);
+    if (depth < 0 || depth > async.maxDepth) {
+      return Hover.NONE;
+    }
+
+    mouseXpos = x;
+    mouseYpos = depth * SLICE_HEIGHT;
+    long t = state.pxToTime(x);
+    for (int i = 0; i < data.starts.length; i++) {
+      long tStart = data.starts[i];
+      long tEnd = data.ends[i];
+      if (data.depths[i] == depth && tStart <= t && t <= tEnd) {
+        hoveredTitle = data.titles[i];
+        hoveredCategory = data.categories[i];
+        if (hoveredTitle.isEmpty()) {
+          if (hoveredCategory.isEmpty()) {
+            return Hover.NONE;
+          }
+          hoveredTitle = hoveredCategory;
+          hoveredCategory = "";
+        }
+        hoveredTitle += " (" + TimeSpan.timeToString(tEnd - tStart) + ")";
+
+        hoveredSize = Size.vertCombine(HOVER_PADDING, HOVER_PADDING / 2,
+            m.measure(Fonts.Style.Normal, hoveredTitle),
+            hoveredCategory.isEmpty() ? Size.ZERO : m.measure(Fonts.Style.Normal, hoveredCategory));
+        mouseYpos = Math.max(0, Math.min(mouseYpos - (hoveredSize.h - SLICE_HEIGHT) / 2,
+            (1 + async.maxDepth) * SLICE_HEIGHT - hoveredSize.h));
+        long id = data.ids[i];
+        String concatedId = i < data.getExtraStrings("concatedIds").length ?
+            data.getExtraStrings("concatedIds")[i] : "";
+
+        return new Hover() {
+          @Override
+          public Area getRedraw() {
+            double redrawW = HOVER_MARGIN + hoveredSize.w + 2 * HOVER_PADDING;
+            double redrawX = x;
+            if (redrawX >= state.getWidth() - redrawW) {
+              redrawX = x - redrawW;
+            }
+            return new Area(redrawX, mouseYpos, redrawW, hoveredSize.h);
+          }
+
+          @Override
+          public void stop() {
+            hoveredTitle = hoveredCategory = null;
+          }
+
+          @Override
+          public Cursor getCursor(Display display) {
+            return (id < 0 && concatedId.isEmpty()) ? null : display.getSystemCursor(SWT.CURSOR_HAND);
+          }
+
+          @Override
+          public boolean click() {
+            if (id > 0) {
+              if ((mods & SWT.MOD1) == SWT.MOD1) {
+                state.addSelection(Selection.Kind.Async, track.getSlice(id));
+              } else {
+                state.setSelection(Selection.Kind.Async, track.getSlice(id));
+              }
+              return true;
+            } else if (!concatedId.isEmpty()) {
+              if ((mods & SWT.MOD1) == SWT.MOD1) {
+                state.addSelection(Selection.Kind.Async, track.getSlices(concatedId));
+              } else {
+                state.setSelection(Selection.Kind.Async, track.getSlices(concatedId));
+              }
+              return true;
+            }
+            return false;
+          }
+        };
+      }
+    }
+    return Hover.NONE;
+  }
+
+  @Override
+  public void computeSelection(Selection.CombiningBuilder builder, Area area, TimeSpan ts) {
+    int startDepth = (int)(area.y / SLICE_HEIGHT);
+    int endDepth = (int)((area.y + area.h) / SLICE_HEIGHT);
+    if (startDepth == endDepth && area.h / SLICE_HEIGHT < SELECTION_THRESHOLD) {
+      return;
+    }
+    if (((startDepth + 1) * SLICE_HEIGHT - area.y) / SLICE_HEIGHT < SELECTION_THRESHOLD) {
+      startDepth++;
+    }
+    if ((area.y + area.h - endDepth * SLICE_HEIGHT) / SLICE_HEIGHT < SELECTION_THRESHOLD) {
+      endDepth--;
+    }
+    if (startDepth > endDepth) {
+      return;
+    }
+
+    if (endDepth >= 0) {
+      if (endDepth >= async.maxDepth) {
+        endDepth = Integer.MAX_VALUE;
+      }
+      builder.add(Selection.Kind.Async, track.getSlices(ts, startDepth, endDepth));
+    }
+  }
+
+  private static class Highlight {
+    public final RGBA color;
+    public final double x, y, w;
+
+    public Highlight(RGBA color, double x, double y, double w) {
+      this.color = color;
+      this.x = x;
+      this.y = y;
+      this.w = w;
+    }
+  }
+}

--- a/gapic/src/main/com/google/gapid/perfetto/views/TrackContainer.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TrackContainer.java
@@ -109,7 +109,7 @@ public class TrackContainer {
 
     public Single(State.ForSystemTrace state, T track, boolean sep,
         BiConsumer<T, Boolean> toggleDetails, boolean showDetails, boolean rightTruncate) {
-      this(track ,sep, toggleDetails, showDetails, new PinState(state), rightTruncate);
+      this(track, sep, toggleDetails, showDetails, new PinState(state), rightTruncate);
     }
 
     private Single(T track, boolean sep, BiConsumer<T, Boolean> toggleDetails, boolean showDetails,

--- a/gapic/src/main/com/google/gapid/views/ProfileView.java
+++ b/gapic/src/main/com/google/gapid/views/ProfileView.java
@@ -21,7 +21,6 @@ import static com.google.gapid.perfetto.views.StyleConstants.TITLE_HEIGHT;
 import static com.google.gapid.perfetto.views.StyleConstants.colors;
 import static com.google.gapid.util.Loadable.MessageType.Error;
 import static com.google.gapid.util.Loadable.MessageType.Loading;
-import static java.util.logging.Level.WARNING;
 import static java.util.stream.Collectors.toList;
 
 import com.google.common.collect.ImmutableMap;
@@ -31,8 +30,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gapid.models.Analytics;
 import com.google.gapid.models.Capture;
-import com.google.gapid.models.CommandStream;
-import com.google.gapid.models.CommandStream.CommandIndex;
 import com.google.gapid.models.Models;
 import com.google.gapid.models.Perfetto;
 import com.google.gapid.models.Profile;
@@ -57,18 +54,13 @@ import com.google.gapid.perfetto.views.State;
 import com.google.gapid.perfetto.views.TraceComposite;
 import com.google.gapid.perfetto.views.TrackPanel;
 import com.google.gapid.proto.service.Service;
-import com.google.gapid.rpc.Rpc;
-import com.google.gapid.rpc.RpcException;
-import com.google.gapid.rpc.UiCallback;
 import com.google.gapid.util.Loadable;
 import com.google.gapid.util.Messages;
-import com.google.gapid.util.MoreFutures;
 import com.google.gapid.util.Scheduler;
 import com.google.gapid.widgets.LoadablePanel;
 import com.google.gapid.widgets.Theme;
 import com.google.gapid.widgets.Widgets;
 
-import java.util.concurrent.ExecutionException;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -78,7 +70,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
-import java.util.logging.Level;
 
 public class ProfileView extends Composite implements Tab, Capture.Listener, Profile.Listener, State.Listener {
   private final Models models;
@@ -337,7 +328,7 @@ public class ProfileView extends Composite implements Tab, Capture.Listener, Pro
       private final List<Service.ProfilingData.GpuSlices.Slice> slices;
 
       protected GpuSliceTrack(long trackId, List<Service.ProfilingData.GpuSlices.Slice> slices) {
-        super(trackId);
+        super("slices_" + trackId);
         this.slices = slices;
       }
 


### PR DESCRIPTION
These are similar to thread tracks, except the events are async, which requires combining the data from multiple tracks, since slices in a single track cannot overlap.

Bug: http://b/188813975