### PR TITLE
Improve GAPIL error message when field name is not found in type

### DIFF
--- a/gapil/analysis/untracked_value.go
+++ b/gapil/analysis/untracked_value.go
@@ -72,7 +72,7 @@ func (v UntrackedValue) field(s *scope, name string) Value {
 	case *semantic.Reference:
 		return UntrackedValue{ty.To}.field(s, name)
 	}
-	panic(fmt.Errorf("Type %v does not contain fields", v.Ty.Name()))
+	panic(fmt.Errorf("Type %v does not contain a field named \"%v\"", v.Ty.Name(), name))
 }
 
 // setField simply returns a new  a UntrackedValue.


### PR DESCRIPTION
This change adds the name of the field which is not found in a given
type.

Bug: n/a
Test: manual