### PR TITLE
Fix the DebugMarker layer template. 

### DIFF
--- a/core/vulkan/vk_debug_marker_layer/cc/debug_marker_layer.tmpl
+++ b/core/vulkan/vk_debug_marker_layer/cc/debug_marker_layer.tmpl
@@ -66,8 +66,8 @@ vkEnumerateDeviceExtensionProperties
   {{end}}
 {{end}}
 
-{{Global "Vulkan.OverrideFunctions" (Strings (Macro "ALL_DEBUG_FUNCTIONS") | SplitEOL)}}
-{{Global "Vulkan.ImplementedFunctions" (Strings (Macro "ALL_DEBUG_FUNCTIONS") | SplitEOL)}}
+{{Global "Vulkan.OverrideFunctions" (Strings (Macro "ALL_DEBUG_FUNCTIONS") | SplitEOL | TrimLeft " ")}}
+{{Global "Vulkan.ImplementedFunctions" (Strings (Macro "ALL_DEBUG_FUNCTIONS") | SplitEOL | TrimLeft " ")}}
 
 {{Include "../../../../gapis/api/vulkan/templates/vulkan_layer.tmpl"}}
 


### PR DESCRIPTION
The list of functions is made up of multiple lists, each of which starts with extra whitespace. This caused the first function of each list to have extra whitespace and thus not match the correct name.

Also adds labels to the spinning cube app.