### PR TITLE
Avoid a full device scanning to get hostname

### DIFF
--- a/cmd/gapis/BUILD.bazel
+++ b/cmd/gapis/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
         "//core/log:go_default_library",
         "//core/os/android/adb:go_default_library",
         "//core/os/device/bind:go_default_library",
-        "//core/os/device/host:go_default_library",
         "//core/os/device/remotessh:go_default_library",
         "//core/os/file:go_default_library",
         "//core/text:go_default_library",

--- a/cmd/gapis/main.go
+++ b/cmd/gapis/main.go
@@ -32,7 +32,6 @@ import (
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/android/adb"
 	"github.com/google/gapid/core/os/device/bind"
-	"github.com/google/gapid/core/os/device/host"
 	"github.com/google/gapid/core/os/device/remotessh"
 	"github.com/google/gapid/core/os/file"
 	"github.com/google/gapid/core/text"
@@ -137,9 +136,14 @@ func run(ctx context.Context) error {
 		onDeviceScanDone(ctx)
 	})
 
+	hostname, err := os.Hostname()
+	if err != nil {
+		return log.Err(ctx, err, "Failed to retrieve hostname")
+	}
+
 	return server.Listen(ctx, *rpc, server.Config{
 		Info: &service.ServerInfo{
-			Name:              host.Instance(ctx).Name,
+			Name:              hostname,
 			VersionMajor:      uint32(app.Version.Major),
 			VersionMinor:      uint32(app.Version.Minor),
 			VersionPoint:      uint32(app.Version.Point),


### PR DESCRIPTION
We can start GAPIS with `--add-local-device=false` to tell it to
ignore the host device. However, when we start the server, we used to
call host.Instance() which effectively operates a full scan of the
host to get e.g. Vulkan driver version etc, even though we only used
that call to get the hostname.

This change just uses Golang's standard os.Hostname() to retrieve the
hostname used for the server.

Among other things, this lets us avoid warnings from Mesa Vulkan by
starting gapis with `--add-local-device=false`. These warnings looks
like:

```
MESA-INTEL: warning: Performance support disabled, consider sysctl dev.i915.perf_stream_paranoid=0

WARNING: lavapipe is not a conformant vulkan implementation, testing use only.
```

Some users though these could be bugs related to AGI.

Bug: b/190624894
Test: manual, using
`./gapit validate_gpu_profiling --gapis-args '--add-local-device=false' -serial A1B2C3D4`
to validate a given Android device without having Mesa warnings in the
gapis logs.