### PR TITLE
Hide the report tab

### DIFF
--- a/gapic/src/main/com/google/gapid/GraphicsTraceView.java
+++ b/gapic/src/main/com/google/gapid/GraphicsTraceView.java
@@ -211,6 +211,10 @@ public class GraphicsTraceView extends Composite
       if (type == MainTab.Type.Performance && !Experimental.enablePerfTab(models.settings)) {
         continue;
       }
+      // TODO(b/188416598): Improve report quality and enable the report tab again.
+      if (type == MainTab.Type.Report && !Experimental.enableUnstableFeatures(models.settings)) {
+        continue;
+      }
       Action action = type.createAction(shown -> {
         if (shown) {
           showTab(type);
@@ -264,6 +268,10 @@ public class GraphicsTraceView extends Composite
       allTabs.removeAll(hidden);
       if (!Experimental.enablePerfTab(models.settings)) {
         allTabs.remove(MainTab.Type.Performance);
+      }
+      // TODO(b/188416598): Improve report quality and enable the report tab again.
+      if (!Experimental.enableUnstableFeatures(models.settings)) {
+        allTabs.remove(MainTab.Type.Report);
       }
       Iterator<String> structs = Splitter.on(';')
           .trimResults()


### PR DESCRIPTION
The report tab is using an old version of the vulkan validation layer,
which are buggy and may report false positives. Hide the report tab
until this issue is fixed.

Bug: 188416598
Test: manual