### PR TITLE
Cleanup gapis build-time config options and document them in DEVDOC

### DIFF
--- a/DEVDOC.md
+++ b/DEVDOC.md
@@ -246,6 +246,11 @@ If you want to analyze a replay crash with a debugger, on **64 bits Android** (f
 
 Note that while you attach the debugger and setup the breakpoint, the server might timeout waiting for a gRPC connection. You may increase this timeout by editing the `gapir/client:gRPCConnectTimeout` constant.
 
+## GAPIS build-time options to help with debugging
+
+See `gapis/config/config.go` for a list of various build-time config options
+that can help with debugging.
+
 ## How to profile AGI internals
 
 ### GAPIS

--- a/gapis/config/config.go
+++ b/gapis/config/config.go
@@ -27,10 +27,12 @@ const (
 	// dependency graph.
 	DisableDeadCodeElimination = false
 
-	// DeadSubCmdElimination prevents the elimination of subcommands in DCE.
+	// DeadSubCmdElimination prevents the elimination of subcommands in dead
+	// code elimination.
 	DeadSubCmdElimination = false
 
-	// DebugDeadCodeElimination activates various debug logs related to DCE.
+	// DebugDeadCodeElimination activates various debug logs related to dead
+	// code elimination.
 	DebugDeadCodeElimination = false
 
 	// DumpReplayProfile dumps the perfetto trace of a replay profile.
@@ -40,7 +42,7 @@ const (
 	DumpValidationTrace = false
 
 	// AllInitialCommandsLive forces all initial commands to be considered as
-	// live when computing DCE.
+	// live when computing dead code elimination.
 	AllInitialCommandsLive = false
 
 	// LogExtrasInTransforms logs all commands' extras together with transforms.
@@ -60,7 +62,7 @@ const (
 	LogTransformsToFile = false
 
 	// LogTransformsToCapture creates a gfxtrace that stores the commands
-	// obtained after each transformation has been applied.
+	// obtained after all transforms have been applied.
 	LogTransformsToCapture = false
 
 	// LogInitialCmdsToCapture creates a gfxtrace that stores initial commands.

--- a/gapis/config/config.go
+++ b/gapis/config/config.go
@@ -16,25 +16,53 @@
 package config
 
 const (
-	DebugReplay                = false
-	DebugReplayBuilder         = false
+	// DebugReplay activates various debug logs related to replay.
+	DebugReplay = false
+
+	// DebugReplayBuilder activates various debug logs and checks related to the
+	// creation of a replay payload.
+	DebugReplayBuilder = false
+
+	// DisableDeadCodeElimination prevents the early computation of the
+	// dependency graph.
 	DisableDeadCodeElimination = false
-	DeadSubCmdElimination      = false
-	DebugDeadCodeElimination   = false
-	DebugDependencyGraph       = false
-	DumpReplayProfile          = false
-	DumpValidationTrace        = true
-	AllInitialCommandsLive     = false
-	LogExtrasInTransforms      = false // Logs all commands' extras together with transforms
-	LogMemoryInExtras          = false // Logs all commands' read/write memory observation together with extras
-	// Logs all mappings at the end of the replay from original trace
-	// handles to replay client handles (if handles are reused in the trace
-	// it will only print the last mapping).  Only works for Vulkan.
-	LogMappingsToFile        = false
-	LogTransformsToFile      = false
-	LogTransformsToCapture   = false
-	LogInitialCmdsIssues     = false
-	LogInitialCmdsToCapture  = false
-	SeparateMutateStates     = false
-	CheckRebuiltStateMatches = false
+
+	// DeadSubCmdElimination prevents the elimination of subcommands in DCE.
+	DeadSubCmdElimination = false
+
+	// DebugDeadCodeElimination activates various debug logs related to DCE.
+	DebugDeadCodeElimination = false
+
+	// DumpReplayProfile dumps the perfetto trace of a replay profile.
+	DumpReplayProfile = false
+
+	// DumpValidationTrace dumps the perfetto trace of a validation profile.
+	DumpValidationTrace = false
+
+	// AllInitialCommandsLive forces all initial commands to be considered as
+	// live when computing DCE.
+	AllInitialCommandsLive = false
+
+	// LogExtrasInTransforms logs all commands' extras together with transforms.
+	LogExtrasInTransforms = false
+
+	// LogMemoryInExtras logs all commands' read/write memory observation
+	// together with extras.
+	LogMemoryInExtras = false
+
+	// LogMappingsToFile logs all mappings at the end of the replay from
+	// original trace handles to replay client handles (if handles are reused in
+	// the trace it will only print the last mapping).  Only works for Vulkan.
+	LogMappingsToFile = false
+
+	// LogTransformsToFile logs all commands seen by each transform into a
+	// separate file for each transform.
+	LogTransformsToFile = false
+
+	// LogTransformsToCapture creates a gfxtrace that stores the commands
+	// obtained after each transformation has been applied.
+	LogTransformsToCapture = false
+
+	// LogInitialCmdsToCapture creates a gfxtrace that stores initial commands.
+	LogInitialCmdsToCapture = false
 )

--- a/gapis/resolve/dependencygraph2/dependency_graph_builder.go
+++ b/gapis/resolve/dependencygraph2/dependency_graph_builder.go
@@ -25,7 +25,6 @@ import (
 	"github.com/google/gapid/core/math/interval"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/capture"
-	"github.com/google/gapid/gapis/config"
 	"github.com/google/gapid/gapis/memory"
 )
 
@@ -380,12 +379,6 @@ func BuildDependencyGraph(ctx context.Context, config DependencyGraphConfig,
 	}
 
 	return graph, nil
-}
-
-func (b *dependencyGraphBuilder) debug(ctx context.Context, fmt string, args ...interface{}) {
-	if config.DebugDependencyGraph || (len(b.cmdCtx().subCmdIdx) == 4 && b.cmdCtx().subCmdIdx[0] == 351 && b.cmdCtx().subCmdIdx[3] == 1) {
-		log.D(ctx, fmt, args...)
-	}
 }
 
 func (b *dependencyGraphBuilder) cmdCtx() CmdContext {


### PR DESCRIPTION
Cleanup details:

- Remove all obsolete configs that do not appear anywhere else in the
  code.

- Also remove DebugDependencyGraph since
  dependencyGraphBuilder.debug() was never used, and seemed to be a
  leftover from some debugging session

- Set DumpValidationTrace to false, as we don't want this to be set in
  our dev-release builds

- Add a proper documentation for each config option

Bug: n/a