### PR TITLE
In perftab, add recommended presets based on vendor provided counter type metadata.

### DIFF
--- a/gapic/src/main/com/google/gapid/views/PerformanceView.java
+++ b/gapic/src/main/com/google/gapid/views/PerformanceView.java
@@ -89,6 +89,7 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.layout.RowData;
 import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
@@ -129,12 +130,12 @@ public class PerformanceView extends Composite
         new GridData(SWT.FILL, SWT.BOTTOM, true, true));
     splitter.setWeights(new int[] { 70, 30 });
 
-    int numberOfButtons = 3;
+    int numberOfButtonsPerRow = 2;
     if (Experimental.enableProfileExperiments(models.settings)) {
-      numberOfButtons = 4;
+      numberOfButtonsPerRow = 3;
     }
 
-    Composite buttonsComposite = createComposite(top, new GridLayout(numberOfButtons, false));
+    Composite buttonsComposite = createComposite(top, new GridLayout(numberOfButtonsPerRow, false));
     buttonsComposite.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, true, false));
 
     Button toggleButton = createButton(buttonsComposite, SWT.FLAT, "Estimate / Confidence Range",
@@ -161,7 +162,7 @@ public class PerformanceView extends Composite
     filterButton.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
 
     presetsBar = new PresetsBar(buttonsComposite, models.settings, widgets.theme);
-    presetsBar.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, true, false));
+    presetsBar.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, true, false, numberOfButtonsPerRow, 1));
 
     tree = createTreeViewer(top, SWT.NONE);
 
@@ -391,7 +392,6 @@ public class PerformanceView extends Composite
   private class PresetsBar extends Composite {
     private final Settings settings;
     private final Theme theme;
-    private List<Button> buttons = Lists.newArrayList();
 
     public PresetsBar(Composite parent, Settings settings, Theme theme) {
       super(parent, SWT.NONE);
@@ -406,10 +406,9 @@ public class PerformanceView extends Composite
     }
 
     public void refresh() {
-      for (Button button : buttons) {
-        button.dispose();
+      for (Control children : this.getChildren()) {
+        children.dispose();
       }
-      buttons.clear();
       createPresetButtons();
       redraw();
       requestLayout();
@@ -436,23 +435,29 @@ public class PerformanceView extends Composite
         }
       });
       addButton.setImage(theme.add());
-      buttons.add(addButton);
+      withLayoutData(new Label(this, SWT.VERTICAL | SWT.SEPARATOR), new RowData(SWT.DEFAULT, 1));
 
+      boolean customPresetButtonCreated = false;
       for (PerformancePreset preset : settings.ui().getPerformancePresetsList()) {
         if (!preset.getDeviceName().equals(models.devices.getSelectedReplayDevice().getName())) {
           continue;
         }
-        buttons.add(createButton(this, SWT.FLAT, preset.getPresetName(), buttonColor, e -> {
+        createButton(this, SWT.FLAT, preset.getPresetName(), buttonColor, e -> {
           visibleMetrics = Sets.newHashSet(preset.getCounterIdsList());
           updateTree(false);
-        }));
+        });
+        customPresetButtonCreated = true;
+      }
+      if (customPresetButtonCreated) {
+        withLayoutData(new Label(this, SWT.VERTICAL | SWT.SEPARATOR), new RowData(SWT.DEFAULT, 1));
       }
 
+
       for (PerformancePreset preset : getRecommendedPresets()) {
-        buttons.add(createButton(this, SWT.FLAT, preset.getPresetName(), buttonColor, e -> {
+        createButton(this, SWT.FLAT, preset.getPresetName(), buttonColor, e -> {
           visibleMetrics = Sets.newHashSet(preset.getCounterIdsList());
           updateTree(false);
-        }));
+        });
       }
     }
 

--- a/gapic/src/main/com/google/gapid/views/PerformanceView.java
+++ b/gapic/src/main/com/google/gapid/views/PerformanceView.java
@@ -474,7 +474,7 @@ public class PerformanceView extends Composite
       }
       for (Service.ProfilingData.GpuCounters.Metric metric: models.profile.getData().
           getGpuPerformance().getMetricsList()) {
-        for (GpuCounterGroup group : metric.getGpuCounterGroupsList()) {
+        for (GpuCounterGroup group : metric.getCounterGroupsList()) {
           groupToMetrics.get(group).add(metric.getId());
         }
       }

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -1137,6 +1137,8 @@ message ProfilingData {
       AggregationOperator op = 5;
       string description = 6;
       bool select_by_default = 7;
+      // GPU counter group type specified by vendors.
+      repeated device.GpuCounterDescriptor.GpuCounterGroup gpu_counter_groups = 8;
     }
 
     // Perf includes a best-guessing performance value and a confidence range.

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -1138,7 +1138,7 @@ message ProfilingData {
       string description = 6;
       bool select_by_default = 7;
       // GPU counter group type specified by vendors.
-      repeated device.GpuCounterDescriptor.GpuCounterGroup gpu_counter_groups = 8;
+      repeated device.GpuCounterDescriptor.GpuCounterGroup counter_groups = 8;
     }
 
     // Perf includes a best-guessing performance value and a confidence range.

--- a/gapis/trace/android/profile/profile.go
+++ b/gapis/trace/android/profile/profile.go
@@ -150,9 +150,11 @@ func setGpuCounterMetrics(ctx context.Context, groupToSlices map[int32][]*servic
 		op := getCounterAggregationMethod(counter)
 		description := ""
 		selectByDefault := false
+		gpuCounterGroups := []device.GpuCounterDescriptor_GpuCounterGroup{}
 		if counter.Spec != nil {
 			description = counter.Spec.Description
 			selectByDefault = counter.Spec.SelectByDefault
+			gpuCounterGroups = counter.Spec.Groups
 		}
 		*metrics = append(*metrics, &service.ProfilingData_GpuCounters_Metric{
 			Id:              metricId,
@@ -162,6 +164,7 @@ func setGpuCounterMetrics(ctx context.Context, groupToSlices map[int32][]*servic
 			Op:              op,
 			Description:     description,
 			SelectByDefault: selectByDefault,
+			GpuCounterGroups: gpuCounterGroups,
 		})
 		if op != service.ProfilingData_GpuCounters_Metric_TimeWeightedAvg {
 			log.E(ctx, "Counter aggregation method not implemented yet. Operation: %v", op)

--- a/gapis/trace/android/profile/profile.go
+++ b/gapis/trace/android/profile/profile.go
@@ -150,11 +150,11 @@ func setGpuCounterMetrics(ctx context.Context, groupToSlices map[int32][]*servic
 		op := getCounterAggregationMethod(counter)
 		description := ""
 		selectByDefault := false
-		gpuCounterGroups := []device.GpuCounterDescriptor_GpuCounterGroup{}
+		counterGroups := []device.GpuCounterDescriptor_GpuCounterGroup{}
 		if counter.Spec != nil {
 			description = counter.Spec.Description
 			selectByDefault = counter.Spec.SelectByDefault
-			gpuCounterGroups = counter.Spec.Groups
+			counterGroups = counter.Spec.Groups
 		}
 		*metrics = append(*metrics, &service.ProfilingData_GpuCounters_Metric{
 			Id:              metricId,
@@ -164,7 +164,7 @@ func setGpuCounterMetrics(ctx context.Context, groupToSlices map[int32][]*servic
 			Op:              op,
 			Description:     description,
 			SelectByDefault: selectByDefault,
-			GpuCounterGroups: gpuCounterGroups,
+			CounterGroups:   counterGroups,
 		})
 		if op != service.ProfilingData_GpuCounters_Metric_TimeWeightedAvg {
 			log.E(ctx, "Counter aggregation method not implemented yet. Operation: %v", op)


### PR DESCRIPTION
- Before, the presets(quick filters) in perftab are only created by users.
This PR add in some extra presets based on vendor's counter type grouping
metadata. In this way, when a user opens perftab for the first time, they
have some basic recommended presets to play with.
- Organize the functional buttons in perftab.Put them in two rows, leaving 
the preset buttons in the second row. Also add separators in preset buttons row.

Bug: b/190540726, b/190542146.