### PR TITLE
Fix retired swapchain image deletion

### DIFF
--- a/gapis/api/vulkan/extensions/khr_swapchain.api
+++ b/gapis/api/vulkan/extensions/khr_swapchain.api
@@ -119,6 +119,18 @@ cmd VkResult vkCreateSwapchainKHR(
   if pCreateInfo == null { vkErrorNullPointer("VkSwapchainCreateInfoKHR") }
   create_info := pCreateInfo[0]
 
+  if create_info.oldSwapchain in Swapchains {
+    old := Swapchains[create_info.oldSwapchain]
+    old.Retired = true
+    // Delete images from the oldSwapchain that is being retired, unless these
+    // images are acquired, in which case they may still be used and presented.
+    for _, i, img in old.SwapchainImages {
+      if !(old.ImagesAcquired[i]) {
+        delete(Images, img.VulkanHandle)
+      }
+    }
+  }
+
   queueFamilyIndices := create_info.pQueueFamilyIndices[0:create_info.queueFamilyIndexCount]
 
   swapchainObject := new!SwapchainObject(Device: device,
@@ -193,7 +205,7 @@ sub bool imageUsedByAnotherSwapchain(
     for _, _, s in Swapchains {
       if (s != null) && (s != swapchainObject) {
         for _, _, i in s.SwapchainImages {
-          if i == imageObject {
+          if i.VulkanHandle == imageObject.VulkanHandle {
             found.b = true
           }
         }
@@ -212,12 +224,28 @@ cmd void vkDestroySwapchainKHR(
   if !(device in Devices) { vkErrorInvalidDevice(device) }
   if !(swapchain in Swapchains) { vkErrorInvalidSwapchain(swapchain) }
   swapObject := Swapchains[swapchain]
-  for _ , _ , v in swapObject.SwapchainImages {
-    // Some images may be reused between swapchains via the oldSwapchain
-    // argument of vkCreateSwapchainKHR
-    if !imageUsedByAnotherSwapchain(v, swapObject) {
-      delete(Images, v.VulkanHandle)
-    }
+  for _, _, img in swapObject.SwapchainImages {
+     if !(swapObject.Retired) {
+       // This swapchain has not been retired, so we are sure none of its images
+       // handle may have been reused: we can safely remove them from Images.
+       delete(Images, img.VulkanHandle)
+     } else {
+       // This is a retired swapchain: its images handle may have been reused
+       // for either another swapchain's image, or a regular image created by
+       // vkCreateImage. If the handle has been reused for a fresh image
+       // obtained with vkCreateImage, then Images[handle] will refer to a
+       // different object than img, so we must make sure to retrieve the image
+       // object from Images again.
+       activeImg := Images[img.VulkanHandle]
+       // If this image is not a swapchain image, it means the handle was reused
+       // for a fresh image obtained via vkCreateImage, so we must not remove
+       // it from Images. If this image is a swapchain image, only remove it
+       // from Images if it is not used by another swapchain (which would have
+       // been created by retiring the swapchain that is being destroyed).
+       if activeImg.IsSwapchainImage && !imageUsedByAnotherSwapchain(activeImg, swapObject) {
+         delete(Images, activeImg.VulkanHandle)
+       }
+     }
   }
   delete(Swapchains, swapchain)
 }
@@ -406,6 +434,11 @@ cmd VkResult vkQueuePresentKHR(
     _ = swapchain.ImagesAcquired[imageIndices[i]]
     swapchain.ImagesAcquired[imageIndices[i]] = false
     recordPresentSwapchainImage(swapchains[i], imageIndices[i])
+    if swapchain.Retired {
+      // This image was acquired at the time its swapchain was retired, so it
+      // was not removed from Images, do it now.
+      delete(Images, image.VulkanHandle)
+    }
   }
   fence
   if (info.pResults != null) {
@@ -440,6 +473,7 @@ cmd VkResult vkQueuePresentKHR(
   @unused ref!VulkanDebugMarkerInfo     DebugInfo
   @unused ref!ExtHDRMetadata            HDRMetadata
   VkSwapchainCreateFlagsKHR             Flags
+  bool                                  Retired
 }
 
 extern void recordAcquireNextImage(VkSwapchainKHR swapchain, u32 imageIndex)


### PR DESCRIPTION
The deletion of retired swapchain images could actually remove a
non-swapchain image from the global Images map that tracks Vulkan
images as part of the Vulkan state.

Consider these commands, and how our code was working before this
change:

```
vkCreateSwapchainKHR(oldSwapchain:0x123) # retires swapchain 0x123
                                         # which has img 0x456
					 # that is not acquired

vkCreateImage() # Returns a fresh new image with handle 0x456

vkDestroySwapchainKHR(0x123) # This removes img handle 0x456 from
                             # Images, and that is incorrect
```

This change fixes how retired swapchain images are handled, and
properly deletes them from Images only when it is relevant. See
code comments for details.

Bug: b/190829522
Test: manual, on an app that systematically triggered an error.