### PR TITLE
Fix display of representations for glClear commands (#828)

### DIFF
--- a/gapis/resolve/command_tree.go
+++ b/gapis/resolve/command_tree.go
@@ -580,7 +580,7 @@ func getOpenGLAliasRepresentation(indices []uint64, item *api.CmdIDGroup, cmdTre
 		pItem, _ := cmdTree.index(parentIndices)
 		parentItem := pItem.(api.CmdIDGroup)
 		aliasRepId = parentItem.Range.Last()
-	} else if strings.HasPrefix(item.Name, "glDraw") || strings.HasPrefix(item.Name, "glMultiDraw") {
+	} else if strings.HasPrefix(item.Name, "glDraw") || strings.HasPrefix(item.Name, "glMultiDraw") || strings.HasPrefix(item.Name, "glClear(") {
 		pindices := indices[:len(indices)-1]
 		pItem, _ := cmdTree.index(pindices)
 		if parentItem, ok := pItem.(api.CmdIDGroup); ok {


### PR DESCRIPTION
In an ANGLE AGI trace, the thumbnail/resources of the containing OpenGL group and the OpenGL glClear displayed incorrect info.
Created aliased representations for them to the correct thumbnail/resource data.

Test: Manual

Fixes #828.