### PR TITLE
Display pipeline and mesh data for GLES draw calls

### DIFF
--- a/gapis/resolve/command_tree.go
+++ b/gapis/resolve/command_tree.go
@@ -579,7 +579,7 @@ func getOpenGLAliasRepresentation(indices []uint64, item *api.CmdIDGroup, cmdTre
 		parentIndices := indices[:len(indices)-1]
 		pItem, _ := cmdTree.index(parentIndices)
 		parentItem := pItem.(api.CmdIDGroup)
-		aliasRepId = parentItem.Range.Last()
+		aliasRepId = parentItem.Range.Last() - 1
 	} else if strings.HasPrefix(item.Name, "glDraw") || strings.HasPrefix(item.Name, "glMultiDraw") || strings.HasPrefix(item.Name, "glClear(") {
 		pindices := indices[:len(indices)-1]
 		pItem, _ := cmdTree.index(pindices)
@@ -588,7 +588,7 @@ func getOpenGLAliasRepresentation(indices []uint64, item *api.CmdIDGroup, cmdTre
 				grandparentIndices := indices[:len(indices)-2]
 				gpItem, _ := cmdTree.index(grandparentIndices)
 				if gparentItem, ok := gpItem.(api.CmdIDGroup); ok {
-					aliasRepId = gparentItem.Range.Last()
+					aliasRepId = gparentItem.Range.Last() - 1
 				}
 			}
 		}

--- a/gapis/resolve/mesh.go
+++ b/gapis/resolve/mesh.go
@@ -51,6 +51,12 @@ func meshFor(ctx context.Context, o interface{}, p *path.Mesh, r *path.ResolveCo
 			return nil, err
 		}
 
+		representation := o.Representation.Indices
+		p := o.Commands.Capture.Command(representation[0], representation[1:]...).Mesh(p.Options)
+		if mesh, err := meshFor(ctx, cmds[representation[0]], p, r); err != api.ErrMeshNotAvailable {
+			return mesh, err
+		}
+
 		if len(o.Commands.From) != len(o.Commands.To) {
 			return nil, log.Errf(ctx, nil, "Subcommand indices must be the same length")
 		}

--- a/gapis/resolve/pipeline.go
+++ b/gapis/resolve/pipeline.go
@@ -65,6 +65,12 @@ func pipelinesFor(ctx context.Context, o interface{}, p *path.Pipelines, r *path
 			return nil, err
 		}
 
+		representation := o.Representation.Indices
+		p := o.Commands.Capture.Command(representation[0], representation[1:]...).Pipelines()
+		if pl, err := pipelinesFor(ctx, cmds[representation[0]], p, r); err != api.ErrPipelineNotAvailable {
+			return pl, err
+		}
+
 		if len(o.Commands.From) != len(o.Commands.To) {
 			return nil, log.Errf(ctx, nil, "Subcommand indices must be the same length")
 		}


### PR DESCRIPTION
Build on #752 to use the GL representation for displaying pipeline and mesh information.

Modify `getOpenGLAliasRepresentation` to return the second-to-last command of the outer command group as the last command will be `vkCmdEndDebugUtilsLabelEXT`

Fixes #811