### PR TITLE
Verify auth token for streaming RPCs

### DIFF
--- a/core/app/auth/auth.go
+++ b/core/app/auth/auth.go
@@ -111,7 +111,7 @@ func UnaryServerInterceptor(token Token) grpc.UnaryServerInterceptor {
 	}
 }
 
-// StreamServerInterceptor returns a grpc.UnaryServerInterceptor that checks
+// StreamServerInterceptor returns a grpc.StreamServerInterceptor that checks
 // incoming RPC calls for the given auth token.
 func StreamServerInterceptor(token Token) grpc.StreamServerInterceptor {
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {

--- a/core/app/auth/auth.go
+++ b/core/app/auth/auth.go
@@ -91,9 +91,9 @@ func GenTokenFile() (path string, token Token) {
 	return path, token
 }
 
-// ServerInterceptor returns a grpc.UnaryServerInterceptor that checks incoming
-// RPC calls for the given auth token.
-func ServerInterceptor(token Token) grpc.UnaryServerInterceptor {
+// UnaryServerInterceptor returns a grpc.UnaryServerInterceptor that checks
+// incoming RPC calls for the given auth token.
+func UnaryServerInterceptor(token Token) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		if token != NoAuth {
 			md, ok := metadata.FromIncomingContext(ctx)
@@ -111,9 +111,29 @@ func ServerInterceptor(token Token) grpc.UnaryServerInterceptor {
 	}
 }
 
-// ClientInterceptor returns a grpc.UnaryClientInterceptor that adds the given
-// auth token to outgoing RPC calls.
-func ClientInterceptor(token Token) grpc.UnaryClientInterceptor {
+// StreamServerInterceptor returns a grpc.UnaryServerInterceptor that checks
+// incoming RPC calls for the given auth token.
+func StreamServerInterceptor(token Token) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if token != NoAuth {
+			md, ok := metadata.FromIncomingContext(ss.Context())
+			if !ok {
+				return ErrInvalidToken
+			}
+
+			got, ok := md[rpcHeader]
+			if !ok || len(got) != 1 || Token(got[0]) != token {
+				return ErrInvalidToken
+			}
+		}
+
+		return handler(srv, ss)
+	}
+}
+
+// UnaryClientInterceptor returns a grpc.UnaryClientInterceptor that adds the
+// given auth token to outgoing RPC calls.
+func UnaryClientInterceptor(token Token) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		if token != NoAuth {
 			if md, ok := metadata.FromOutgoingContext(ctx); ok {
@@ -123,5 +143,20 @@ func ClientInterceptor(token Token) grpc.UnaryClientInterceptor {
 			}
 		}
 		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+// StreamClientInterceptor returns a grpc.StreamClientInterceptor that adds the
+// given auth token to outgoing RPC calls.
+func StreamClientInterceptor(token Token) grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		if token != NoAuth {
+			if md, ok := metadata.FromOutgoingContext(ctx); ok {
+				ctx = metadata.NewOutgoingContext(ctx, metadata.Join(md, metadata.Pairs(rpcHeader, string(token))))
+			} else {
+				ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(rpcHeader, string(token)))
+			}
+		}
+		return streamer(ctx, desc, cc, method, opts...)
 	}
 }

--- a/gapis/client/process.go
+++ b/gapis/client/process.go
@@ -73,7 +73,8 @@ func Connect(ctx context.Context, cfg Config) (Client, error) {
 
 	conn, err := grpcutil.Dial(ctx, target,
 		grpc.WithInsecure(),
-		grpc.WithUnaryInterceptor(auth.ClientInterceptor(cfg.Token)))
+		grpc.WithUnaryInterceptor(auth.UnaryClientInterceptor(cfg.Token)),
+		grpc.WithStreamInterceptor(auth.StreamClientInterceptor(cfg.Token)))
 	if err != nil {
 		return nil, log.Err(ctx, err, "Dialing GAPIS")
 	}

--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -78,7 +78,8 @@ func NewWithListener(ctx context.Context, l net.Listener, cfg Config, srvChan ch
 				crash.Go(func() { s.stopOnInterrupt(ctx, server, stop) })
 			}
 			return nil
-		}, grpc.UnaryInterceptor(auth.ServerInterceptor(cfg.AuthToken)))
+		}, grpc.UnaryInterceptor(auth.UnaryServerInterceptor(cfg.AuthToken)),
+			grpc.StreamInterceptor(auth.StreamServerInterceptor(cfg.AuthToken)))
 	})
 
 	select {

--- a/test/integration/service/service_test.go
+++ b/test/integration/service/service_test.go
@@ -50,7 +50,8 @@ func startServerAndGetGrpcClient(ctx context.Context, config server.Config) (ser
 
 	conn, err := grpcutil.Dial(ctx, "pipe:servicetest",
 		grpc.WithInsecure(),
-		grpc.WithUnaryInterceptor(auth.ClientInterceptor(config.AuthToken)),
+		grpc.WithUnaryInterceptor(auth.UnaryClientInterceptor(config.AuthToken)),
+		grpc.WithStreamInterceptor(auth.StreamClientInterceptor(config.AuthToken)),
 		grpc.WithDialer(grpcutil.GetDialer(ctx)),
 	)
 	if err != nil {
@@ -105,6 +106,7 @@ var (
 			VersionMinor: 456,
 			Features:     []string{"moo", "meow", "meh"},
 		},
+		AuthToken:    "s3Cr3t",
 		StringTables: stringtables,
 	}
 	testCaptureData []byte


### PR DESCRIPTION
Also, use the auth token in the integration test service_test.go.
TestProfile is using a streaming RPCs and fails without adding the
StreamClientInterceptor to the client in the test.

Bug: 191146135