### PR TITLE
Workaround for a race condition with perfetto slices on arm mali

### DIFF
--- a/core/os/android/adb/perfetto.go
+++ b/core/os/android/adb/perfetto.go
@@ -47,7 +47,7 @@ func (b *binding) StartPerfettoTrace(ctx context.Context, config *perfetto_pb.Tr
 	reader, stdout := io.Pipe()
 	logRing := ring.New(10)
 	// TODO(apbodnar) Find a way to reliably know when Perfetto/producers are ready (b/147388497)
-	readyOnce := task.Once(task.Delay(ready, 250*time.Millisecond))
+	readyOnce := task.Once(task.Delay(ready, 1000*time.Millisecond))
 	data, err := proto.Marshal(config)
 	if err != nil {
 		return err

--- a/gapis/api/vulkan/wait_for_perfetto.go
+++ b/gapis/api/vulkan/wait_for_perfetto.go
@@ -19,6 +19,7 @@ package vulkan
 import (
 	"bytes"
 	"context"
+	"time"
 
 	"github.com/google/gapid/core/event/task"
 	"github.com/google/gapid/core/log"
@@ -64,6 +65,10 @@ func getPerfettoLoopCallbacks(traceOptions *service.TraceOptions, signalHandler 
 
 	postLoop := func(ctx context.Context, request *gapir.FenceReadyRequest) {
 		if !signalHandler.StopSignal.Fired() {
+			// Bugs b/188440357 and b/190170108 appear to be caused by a race condition with perfetto not
+			// starting and ending correctly as signaled. This wait matches a wait on startup and works
+			// around the race conditions for now.
+			time.Sleep(1000 * time.Millisecond)
 			signalHandler.StopFunc(ctx)
 		}
 	}


### PR DESCRIPTION
There is a problem with the AGI/Perfetto integration for ARM where the
mali driver does not appear to respect the perfetto producer ready
signal. Previously a sleep was added to the code to work around this
race condition. This CL enlarges the wait time for devices that appear
to have slower drivers and adds a second wait at termination because I
am starting to suspect there is a dual of the first race condition on
exiting, where we may be processing the data before it has all been read
back. This is a temporary workaround until we get something to address
the real issue.

Bugs:
b/188440357
b/190170108