### PR TITLE
Use ANDROID_SDK_ROOT rather than ANDROID_SDK_HOME

### DIFF
--- a/cmd/gapit/export_replay.go
+++ b/cmd/gapit/export_replay.go
@@ -219,10 +219,10 @@ func (verb *exportReplayVerb) Run(ctx context.Context, flags flag.FlagSet) error
 		// find latest build tools
 		sdkPath := verb.SdkPath
 		if sdkPath == "" {
-			sdkPath = os.ExpandEnv("${ANDROID_SDK_HOME}")
+			sdkPath = os.ExpandEnv("${ANDROID_SDK_ROOT}")
 		}
 		if _, err := os.Stat(sdkPath); err != nil {
-			return log.Err(ctx, err, "Cannot find Android SDK. Please set ANDROID_SDK_HOME, or use the -sdkpath flag")
+			return log.Err(ctx, err, "Cannot find Android SDK. Please set ANDROID_SDK_ROOT, or use the -sdkpath flag")
 		}
 		toolsPathParent := path.Join(sdkPath, "build-tools")
 		matches, err := filepath.Glob(path.Join(toolsPathParent, "*"))

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -193,7 +193,7 @@ type (
 		Out            string     `help:"output directory for commands and assets"`
 		Mode           ExportMode `help:"generate special purposed trace"`
 		Apk            string     `help:"(experimental) name of the stand-alone APK created to perform the replay. This name must be <app_package>.apk (e.g. com.example.replay.apk)"`
-		SdkPath        string     `help:"Path to Android SDK directory (default: ANDROID_SDK_HOME environment variable)"`
+		SdkPath        string     `help:"Path to Android SDK directory (default: ANDROID_SDK_ROOT environment variable)"`
 		LoopCount      int        `help:"_The number of times to loop the trace. (experimental)"`
 		CommandFilterFlags
 		CaptureFileFlags

--- a/gapic/src/main/com/google/gapid/models/Settings.java
+++ b/gapic/src/main/com/google/gapid/models/Settings.java
@@ -345,7 +345,7 @@ public class Settings {
       return;
     }
 
-    String[] sdkVars = { "ANDROID_HOME", "ANDROID_SDK_HOME", "ANDROID_ROOT", "ANDROID_SDK_ROOT" };
+    String[] sdkVars = { "ANDROID_HOME", "ANDROID_ROOT", "ANDROID_SDK_ROOT" };
     for (String sdkVar : sdkVars) {
       File adb = findAdbInSdk(System.getenv(sdkVar));
       if (adb != null) {


### PR DESCRIPTION
ANDROID_SDK_ROOT is the recommended environment variable for defining
the path to the SDK, see
https://developer.android.com/studio/command-line/variables

Bug: b/192053630