### PR TITLE
Temporarily disable ImageComponent's scroll bar to avoid a freeze bug on macOS.

### DIFF
--- a/gapic/src/main/com/google/gapid/widgets/ImagePanel.java
+++ b/gapic/src/main/com/google/gapid/widgets/ImagePanel.java
@@ -696,7 +696,6 @@ public class ImagePanel extends Composite implements Loadable {
     private final Consumer<AlphaWarning> showAlphaWarning;
     private final boolean naturallyFlipped;
 
-    private final ScrollBar scrollbars[];
     private final ScenePanel<SceneData> canvas;
     protected final SceneData data;
     private Image[] images = {};
@@ -720,14 +719,12 @@ public class ImagePanel extends Composite implements Loadable {
 
     public ImageComponent(Composite parent, Theme theme, Consumer<AlphaWarning> showAlphaWarning,
         boolean naturallyFlipped) {
-      super(parent, SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL | SWT.NO_BACKGROUND);
+      // TODO: b/189382432 Enable scroll bars when compatibility issue between SWT & macOS resolves.
+      super(parent, SWT.NO_BACKGROUND);
       setLayout(new FillLayout(SWT.VERTICAL));
-      disableAutoHideScrollbars(this);
 
       this.showAlphaWarning = showAlphaWarning;
       this.naturallyFlipped = naturallyFlipped;
-
-      scrollbars = new ScrollBar[] { getHorizontalBar(), getVerticalBar() };
 
       data = new SceneData();
       data.flipped = naturallyFlipped;
@@ -763,8 +760,6 @@ public class ImagePanel extends Composite implements Loadable {
       canvas = new ScenePanel<SceneData>(this, new ImageScene());
       canvas.setSceneData(data.copy());
 
-      getHorizontalBar().addListener(SWT.Selection, e -> onScroll());
-      getVerticalBar().addListener(SWT.Selection, e -> onScroll());
       canvas.addListener(SWT.Resize, e -> onResize());
 
       // Prevent the mouse wheel from scrolling the view.
@@ -853,7 +848,6 @@ public class ImagePanel extends Composite implements Loadable {
       viewOffset = viewOffset
           .add(dx / scaleGridToView, dy / scaleGridToView, 0)
           .clamp(viewOffsetMin, viewOffsetMax);
-      updateScrollbars();
       refresh();
     }
 
@@ -922,7 +916,6 @@ public class ImagePanel extends Composite implements Loadable {
           /* do nothing */
           break;
       }
-      updateScrollbars();
       refresh();
     }
 
@@ -941,7 +934,6 @@ public class ImagePanel extends Composite implements Loadable {
       } else {
         setScale(scale);
       }
-      updateScrollbars();
       refresh();
     }
 
@@ -1041,43 +1033,6 @@ public class ImagePanel extends Composite implements Loadable {
       // The smallest zoom factor to see the whole image or that causes the larger dimension to be
       // no less than MIN_ZOOM_WIDTH pixels.
       scaleGridToViewMin = Math.min(MIN_ZOOM_SIZE.safeDivide(gridSize).minXY(), scaleGridToViewFit);
-    }
-
-    private void updateScrollbars() {
-      for (int i = 0; i < scrollbars.length; i++) {
-        ScrollBar scrollbar = scrollbars[i];
-        int val = (int)(viewOffset.get(i) * scaleGridToView); // offset in view pixels
-        int min = (int)(viewOffsetMin.get(i) * scaleGridToView); // min movement in view pixels
-        int max = (int)(viewOffsetMax.get(i) * scaleGridToView); // max movement in view pixels
-        int rng = max - min;
-        if (rng == 0) {
-          scrollbar.setEnabled(false);
-          scrollbar.setValues(0, 0, 1, 1, 1, 1);
-        } else {
-          int size = (int)this.viewSize.get(i);
-          scrollbar.setEnabled(true);
-          scrollbar.setValues(
-              val - min,        // selection
-              0,                // min
-              size + rng,       // max
-              size,             // thumb
-              (rng + 99) / 100, // increment
-              (rng + 9) / 10    // page increment
-          );
-        }
-      }
-    }
-
-    private void onScroll() {
-      for (int i = 0; i < scrollbars.length; i++) {
-        ScrollBar scrollbar = scrollbars[i];
-        if (scrollbar.getEnabled()) {
-          int min = (int)(viewOffsetMin.get(i) * scaleGridToView); // min movement in view pixels
-          int val = min + scrollbar.getSelection();
-          viewOffset = viewOffset.set(i, val / scaleGridToView);
-        }
-      }
-      refresh();
     }
   }
 


### PR DESCRIPTION
- Affected Panels: FrameBuffer and Texture(singular).
- Disabled Function: the scroll bar was originally used to quickly jump
to another part of the image, if the image got zoomed too big. After this
function gets disabled, users could still drag to navigate around the image,
and scroll to zoom in/out of the image.
- The original bug only happens on macOS platform, it's likely that there's
some compatibility issue between SWT and macOS Big Sur that causes it. More info
in PR #843.
- Weighing between the small impact of the disabled fuction, and the big possible
bad freezing experience for AGI mac users, this PR decides to hide the scroll bar
temporarily for the coming AGI frame profiler launch.

Bug: b/189382432.
Test: Manual test with AGI on macOS, have the FrameBuffer and Texture view
shown together, try resize the window, AGI client will freeze before this PR.