### PR TITLE
Fixes missing device id in Perfetto data.

### DIFF
--- a/gapis/trace/android/adreno/profiling_data.go
+++ b/gapis/trace/android/adreno/profiling_data.go
@@ -98,7 +98,7 @@ func fixContextIds(contextIDs []int64) {
 	// device id, where there is only one device id.
 
 	zeroIndices := make([]int, 0)
-	deviceID := int64(0)
+	contextID := int64(0)
 
 	for i, v := range contextIDs {
 		if v == 0 {
@@ -106,12 +106,12 @@ func fixContextIds(contextIDs []int64) {
 			continue
 		}
 
-		if deviceID == 0 {
-			deviceID = v
+		if contextID == 0 {
+			contextID = v
 			continue
 		}
 
-		if deviceID != v {
+		if contextID != v {
 			// There are multiple devices
 			// We cannot know which one to fill
 			return
@@ -121,7 +121,7 @@ func fixContextIds(contextIDs []int64) {
 	for _, v := range zeroIndices {
 		// If there is only one device in entire trace
 		// We can assume that we possibly have only one device
-		contextIDs[v] = deviceID
+		contextIDs[v] = contextID
 	}
 }
 

--- a/gapis/trace/android/adreno/profiling_data.go
+++ b/gapis/trace/android/adreno/profiling_data.go
@@ -91,13 +91,15 @@ func extractTraceHandles(ctx context.Context, replayHandles *[]int64, replayHand
 }
 
 func fixContextIds(contextIDs []int64) []int64 {
-	// This is a temporary work to workaround a QC bug
+	// This is a workaround a QC bug(b/192546534)
 	// that causes first deviceID to be zero after a
 	// renderpass change in the same queue submit.
+	// So, we fill the zero devices with the existing
+	// device id, where there is only one device id.
 
 	zeroIndices := make([]int, 0)
 	deviceID := int64(0)
-	multipleDevice := false
+	multipleDevices := false
 
 	for i, v := range contextIDs {
 		if v == 0 {
@@ -109,13 +111,12 @@ func fixContextIds(contextIDs []int64) []int64 {
 			if deviceID == 0 {
 				deviceID = v
 				continue
-			} else {
-				multipleDevice = true
 			}
+			multipleDevices = true
 		}
 	}
 
-	if multipleDevice {
+	if multipleDevices {
 		// We cannot know which deviceID we should fill
 		return contextIDs
 	}


### PR DESCRIPTION
Sometimes Perfetto returns deviceID 0 for the QC devices which leads
to missing data.

There is no guaranteed way to fix this but for the Android we can assume
that, if there is only one device id is used for the entire trace,
it's very likely that missing deviceID is the same one rather than a
different device. If there are multiple devices then it does not do anything.