### PR TITLE
In perftab, apply a unified unit to each metric column.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/Unit.java
+++ b/gapic/src/main/com/google/gapid/perfetto/Unit.java
@@ -192,7 +192,8 @@ public class Unit {
   private static interface Formatter {
     public String format(long value);
     public String format(double value);
-    // Conversion interface for units that can convert between different offsets. e.g. Time, Memory.
+    // Conversion interface for units that can convert between different offsets/scales.
+    // e.g. Time can be converted among {ns, us, ms, s, m, h}, Memory among {B, KB, MB, GB}, etc.
     public default boolean convertible() { return false; }
     public default int findOptimalOffset(double value) { return -1; }
     public default String convertTo(double value, int offset) { return "Conversion not supported"; }

--- a/gapic/src/main/com/google/gapid/perfetto/Unit.java
+++ b/gapic/src/main/com/google/gapid/perfetto/Unit.java
@@ -111,15 +111,16 @@ public class Unit {
 
       @Override
       public Formatter withFixedScale(double representativeValue) {
+        Unit fixed = numer.withFixedScale(representativeValue);
         return new Formatter() {
           @Override
           public String format(long value) {
-            return numer.withFixedScale(representativeValue).format(value) + "/" + denom.name;
+            return fixed.format(value) + "/" + denom.name;
           }
 
           @Override
           public String format(double value) {
-            return numer.withFixedScale(representativeValue).format(value) + "/" + denom.name;
+            return fixed.format(value) + "/" + denom.name;
           }
         };
       }

--- a/gapic/src/main/com/google/gapid/views/PerformanceView.java
+++ b/gapic/src/main/com/google/gapid/views/PerformanceView.java
@@ -318,8 +318,7 @@ public class PerformanceView extends Composite
   }
 
   private void addColumnForMetric(Service.ProfilingData.GpuCounters.Metric metric) {
-    Unit unit = CounterInfo.unitFromString(metric.getUnit());
-    int optimalOffset = unit.findOptimalOffset(metric.getAverage());
+    Unit unit = CounterInfo.unitFromString(metric.getUnit()).withFixedScale(metric.getAverage());
     TreeViewerColumn column = createTreeColumn(tree, metric.getName() + "(" + unit.name + ")", e -> {
       Profile.PerfNode node = (Profile.PerfNode)e;
       if (node == null || node.getPerfs() == null) {
@@ -329,23 +328,15 @@ public class PerformanceView extends Composite
       } else {
         Service.ProfilingData.GpuCounters.Perf perf = node.getPerfs().get(metric.getId());
         if (showEstimate) {
-          return perf.getEstimate() < 0 ? "" : format(perf.getEstimate(), unit, optimalOffset);
+          return perf.getEstimate() < 0 ? "" : unit.format(perf.getEstimate());
         } else {
-          String minStr = perf.getMin() < 0 ? "?" : format(perf.getMin(), unit, optimalOffset);
-          String maxStr = perf.getMax() < 0 ? "?" : format(perf.getMax(), unit, optimalOffset);
+          String minStr = perf.getMin() < 0 ? "?" : unit.format(perf.getMin());
+          String maxStr = perf.getMax() < 0 ? "?" : unit.format(perf.getMax());
           return minStr + " ~ " + maxStr;
         }
       }
     });
     column.getColumn().setAlignment(SWT.RIGHT);
-  }
-
-  private String format(double value, Unit unit, int optimalOffset) {
-    if (unit.convertible() && optimalOffset >= 0) {
-      return unit.convertTo(value, optimalOffset);
-    } else {
-      return unit.format(value);
-    }
   }
 
   private void toggleEstimateOrRange() {

--- a/gapic/src/main/com/google/gapid/views/PerformanceView.java
+++ b/gapic/src/main/com/google/gapid/views/PerformanceView.java
@@ -319,6 +319,7 @@ public class PerformanceView extends Composite
 
   private void addColumnForMetric(Service.ProfilingData.GpuCounters.Metric metric) {
     Unit unit = CounterInfo.unitFromString(metric.getUnit());
+    int optimalOffset = unit.findOptimalOffset(metric.getAverage());
     TreeViewerColumn column = createTreeColumn(tree, metric.getName() + "(" + unit.name + ")", e -> {
       Profile.PerfNode node = (Profile.PerfNode)e;
       if (node == null || node.getPerfs() == null) {
@@ -328,15 +329,23 @@ public class PerformanceView extends Composite
       } else {
         Service.ProfilingData.GpuCounters.Perf perf = node.getPerfs().get(metric.getId());
         if (showEstimate) {
-          return perf.getEstimate() < 0 ? "" : unit.format(perf.getEstimate());
+          return perf.getEstimate() < 0 ? "" : format(perf.getEstimate(), unit, optimalOffset);
         } else {
-          String minStr = perf.getMin() < 0 ? "?" : unit.format(perf.getMin());
-          String maxStr = perf.getMax() < 0 ? "?" : unit.format(perf.getMax());
+          String minStr = perf.getMin() < 0 ? "?" : format(perf.getMin(), unit, optimalOffset);
+          String maxStr = perf.getMax() < 0 ? "?" : format(perf.getMax(), unit, optimalOffset);
           return minStr + " ~ " + maxStr;
         }
       }
     });
     column.getColumn().setAlignment(SWT.RIGHT);
+  }
+
+  private String format(double value, Unit unit, int optimalOffset) {
+    if (unit.convertible() || optimalOffset >= 0) {
+      return unit.convertTo(value, optimalOffset);
+    } else {
+      return unit.format(value);
+    }
   }
 
   private void toggleEstimateOrRange() {

--- a/gapic/src/main/com/google/gapid/views/PerformanceView.java
+++ b/gapic/src/main/com/google/gapid/views/PerformanceView.java
@@ -341,7 +341,7 @@ public class PerformanceView extends Composite
   }
 
   private String format(double value, Unit unit, int optimalOffset) {
-    if (unit.convertible() || optimalOffset >= 0) {
+    if (unit.convertible() && optimalOffset >= 0) {
       return unit.convertTo(value, optimalOffset);
     } else {
       return unit.format(value);

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -1139,6 +1139,7 @@ message ProfilingData {
       bool select_by_default = 7;
       // GPU counter group type specified by vendors.
       repeated device.GpuCounterDescriptor.GpuCounterGroup counter_groups = 8;
+      double average = 9;
     }
 
     // Perf includes a best-guessing performance value and a confidence range.


### PR DESCRIPTION
Before this PR, for some units that have different level of offset,
e.g. Time(ns, us, ms, s), Memory Size(B, KB, MB, GB), perftab will
allow cells in a metric column to have different offset, like 1.172ms
and 698us appearing together. That may make it difficult to compare
values in each column. This PR trys to unify unit's offset level for
each metric and solve the problem, the optimal offset level is picked
based on the average performance number.

Bug: b/190541223.
Test: Changes could be observed in Performance tab, on GPU Time metric
or Memory bandwidth related metrics.