### PR TITLE
Remove irrelevant and flaky test WithoutSpinLockGuardedWrapper

### DIFF
--- a/core/memory_tracker/cc/memory_tracker_test.cpp
+++ b/core/memory_tracker/cc/memory_tracker_test.cpp
@@ -331,31 +331,6 @@ TEST_F(SignalBlockerTest, BlockerRecursiveSafe) {
 
 using WrapperTest = TestFixture;
 
-// Call the member function: DoTask() without spin lock guard.
-TEST_F(WrapperTest, WithoutSpinLockGuardedWrapper) {
-  Init();
-  uint32_t counter = 0u;
-  RunInTwoThreads(
-      // Initiated first
-      [this, &counter]() {
-        DoTask([this, &counter]() {
-          m_.unlock();
-          usleep(5000);
-          counter++;
-          EXPECT_EQ(2u, counter);
-        });
-      },
-      // Initiated secondly
-      [this, &counter]() {
-        DoTask([this, &counter]() {
-          m_.lock();
-          counter++;
-          EXPECT_EQ(1u, counter);
-        });
-      });
-  EXPECT_EQ(2u, counter);
-}
-
 // Call the member function: DoTask() with spin lock guarded.
 TEST_F(WrapperTest, WithSpinLockGuardedWrapper) {
   Init();


### PR DESCRIPTION
This change removes the WrapperTest.WithoutSpinLockGuardedWrapper test
that was part of the memory tracker tests.

The first issue with this test is that it only use test framework
primitives, and thus doesn't test anything related to the memory
tracker.

The second issue is that the test expectations are incorrect, and this
leads to flaky failures on CI-linux-test. This test starts two
threads, each of them increments a shared counter. The first thread
sleeps on 5000us before incrementing the counter. The test seems to
assume that this sleep (and maybe the lock/unlock operations on m_)
are enough to guarantee that the second thread is the first to
increment the counter and is thus guaranteed to see the counter at
value 1 after that; while the first thread will always see the counter
at value 2 (thus assuming the second thread already had incremented it
before).

This is incorrect, it is possible that the first thread completes
before the second thread is scheduled at all. This is confirmed by
flakes on this test where the expectations are violated:

```
[ RUN      ] WrapperTest.WithoutSpinLockGuardedWrapper
core/memory_tracker/cc/memory_tracker_test.cpp:345: Failure
Expected equality of these values:
  2u
    Which is: 2
  counter
    Which is: 1
core/memory_tracker/cc/memory_tracker_test.cpp:353: Failure
Expected equality of these values:
  1u
    Which is: 1
  counter
    Which is: 2
[  FAILED  ] WrapperTest.WithoutSpinLockGuardedWrapper (9 ms)
```

Bug: b/163547280