### PR TITLE
Remove the "Wall Time" column from the command tree.

### DIFF
--- a/gapic/src/main/com/google/gapid/views/CommandTree.java
+++ b/gapic/src/main/com/google/gapid/views/CommandTree.java
@@ -280,7 +280,6 @@ public class CommandTree extends Composite
       // The command tree's GPU performances are calculated from client's side.
       setUpStateForColumnAdding();
       addColumn("GPU Time", false);
-      addColumn("Wall Time", true);
     }
 
     private void addColumn(String title, boolean wallTime) {


### PR DESCRIPTION
We don't actually see much/any overlapping slices, so it doesn't show anything interesting.