### PR TITLE
Add state rebuilder part for VK_EXT_line_rasterization

### DIFF
--- a/gapis/api/vulkan/extensions/ext_line_rasterization.api
+++ b/gapis/api/vulkan/extensions/ext_line_rasterization.api
@@ -64,7 +64,7 @@ enum VkLineRasterizationModeEXT: u32 {
 @extension("VK_EXT_line_rasterization")
 class VkPhysicalDeviceLineRasterizationFeaturesEXT {
   VkStructureType sType
-  const void*     pNext
+  void*           pNext
   VkBool32        rectangularLines
   VkBool32        bresenhamLines
   VkBool32        smoothLines

--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -865,6 +865,20 @@ func (sb *stateBuilder) createDevice(d DeviceObjectʳ) {
 			),
 		).Ptr())
 	}
+	if !d.PhysicalDeviceLineRasterizationFeaturesEXT().IsNil() {
+		pNext = NewVoidᵖ(sb.MustAllocReadData(
+			NewVkPhysicalDeviceLineRasterizationFeaturesEXT(
+				VkStructureType_VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT,
+				pNext,
+				d.PhysicalDeviceLineRasterizationFeaturesEXT().RectangularLines(),
+				d.PhysicalDeviceLineRasterizationFeaturesEXT().BresenhamLines(),
+				d.PhysicalDeviceLineRasterizationFeaturesEXT().SmoothLines(),
+				d.PhysicalDeviceLineRasterizationFeaturesEXT().StippledRectangularLines(),
+				d.PhysicalDeviceLineRasterizationFeaturesEXT().StippledBresenhamLines(),
+				d.PhysicalDeviceLineRasterizationFeaturesEXT().StippledSmoothLines(),
+			),
+		).Ptr())
+	}
 
 	sb.write(sb.cb.VkCreateDevice(
 		d.PhysicalDevice(),


### PR DESCRIPTION
Add missing part for support of VK_EXT_line_rasterization: make sure
to request this extension's features when creating devices as part of
the state rebuilder.

Also need to declare pNext as `void*` (and not `const void*`) at the
GAPIL level such that the Golang code passes type checking. This is
consistent with other vulkan structs in GAPIL that always use `void*`
as a type for their `pNext` field.

Bug: b/192662962