### PR TITLE
Remove unused GAPIL annotation: @lastUnused

### DIFF
--- a/gapis/api/vulkan/api/enums.api
+++ b/gapis/api/vulkan/api/enums.api
@@ -41,7 +41,6 @@ enum VkPipelineCacheHeaderVersion : u32 {
   VK_PIPELINE_CACHE_HEADER_VERSION_ONE = 1,
 }
 
-@lastUnused(-11)
 /// Error and return codes
 enum VkResult : u32 {
   // Return codes for successful operation execution (positive values)


### PR DESCRIPTION
There doesn't appear to be any usage of this annotation in the whole
codebase:

```
~/work/agi$ git grep -ni lastunused
gapis/api/vulkan/api/enums.api:44:@lastUnused(-11)
```

Also, given its name, this annotation was probably meant to indicate
the last unused value of an enum, in which case the value `-11` is
incorrect.

Bug: b/160856238

Test: AGI compiles and works well without this annotation.