### PR TITLE
Remove the obsolete @threadSafety annotation

### DIFF
--- a/gapis/api/vulkan/api/buffer.api
+++ b/gapis/api/vulkan/api/buffer.api
@@ -73,7 +73,6 @@
   ref!DeviceGroupBinding             DeviceGroupBinding
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 @override
 cmd VkResult vkCreateBuffer(
@@ -141,7 +140,6 @@ cmd VkResult vkCreateBuffer(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkDestroyBuffer(
     VkDevice                     device,
@@ -179,7 +177,6 @@ cmd void vkDestroyBuffer(
 }
 
 // Buffer view functions
-@threadSafety("system")
 @indirect("VkDevice")
 cmd VkResult vkCreateBufferView(
     VkDevice                      device,
@@ -217,7 +214,6 @@ cmd VkResult vkCreateBufferView(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkDestroyBufferView(
     VkDevice                     device,

--- a/gapis/api/vulkan/api/command_buffer_control.api
+++ b/gapis/api/vulkan/api/command_buffer_control.api
@@ -377,7 +377,6 @@ sub void AddCommand(
   onCommandAdded(commandBuffer)
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 @custom
 cmd VkResult vkAllocateCommandBuffers(
@@ -419,7 +418,6 @@ cmd VkResult vkAllocateCommandBuffers(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 @custom
 cmd void vkFreeCommandBuffers(
@@ -450,7 +448,6 @@ cmd void vkFreeCommandBuffers(
 extern void recordBeginCommandBuffer(VkCommandBuffer commandBuffer)
 extern void recordEndCommandBuffer(VkCommandBuffer commandBuffer)
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 cmd VkResult vkBeginCommandBuffer(
     VkCommandBuffer                 commandBuffer,
@@ -513,7 +510,6 @@ cmd VkResult vkBeginCommandBuffer(
   return ?
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 cmd VkResult vkEndCommandBuffer(
     VkCommandBuffer commandBuffer) {
@@ -530,7 +526,6 @@ cmd VkResult vkEndCommandBuffer(
   return ?
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 cmd VkResult vkResetCommandBuffer(
     VkCommandBuffer           commandBuffer,

--- a/gapis/api/vulkan/api/copy_clear_commands.api
+++ b/gapis/api/vulkan/api/copy_clear_commands.api
@@ -177,7 +177,6 @@ sub void copyBufferToBuffer(ref!BufferObject dstBuf, VkDeviceSize dstOffset, ref
         }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdCopyBuffer(
@@ -358,7 +357,6 @@ sub void dovkCmdCopyImage(ref!vkCmdCopyImageArgs args) {
   trackVkCmdCopyImage(args)
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdCopyImage(
@@ -529,7 +527,6 @@ sub void dovkCmdBlitImage(ref!vkCmdBlitImageArgs args) {
   trackVkCmdBlitImage(args)
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdBlitImage(
@@ -735,7 +732,6 @@ sub void dovkCmdCopyBufferToImage(ref!vkCmdCopyBufferToImageArgs args) {
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdCopyBufferToImage(
@@ -788,7 +784,6 @@ sub void dovkCmdCopyImageToBuffer(ref!vkCmdCopyImageToBufferArgs args) {
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdCopyImageToBuffer(
@@ -849,7 +844,6 @@ sub void dovkCmdUpdateBuffer(ref!vkCmdUpdateBufferArgs args) {
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdUpdateBuffer(
@@ -901,7 +895,6 @@ sub void dovkCmdFillBuffer(ref!vkCmdFillBufferArgs args) {
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdFillBuffer(
@@ -950,7 +943,6 @@ sub void dovkCmdClearColorImage(ref!vkCmdClearColorImageArgs args) {
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdClearColorImage(
@@ -1007,7 +999,6 @@ sub void dovkCmdClearDepthStencilImage(ref!vkCmdClearDepthStencilImageArgs args)
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdClearDepthStencilImage(
@@ -1058,7 +1049,6 @@ sub void dovkCmdClearAttachments(ref!vkCmdClearAttachmentsArgs args) {
   useRenderPass()
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdClearAttachments(
@@ -1125,7 +1115,6 @@ sub void dovkCmdResolveImage(ref!vkCmdResolveImageArgs args) {
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdResolveImage(

--- a/gapis/api/vulkan/api/descriptor.api
+++ b/gapis/api/vulkan/api/descriptor.api
@@ -56,7 +56,6 @@
   @unused ref!VulkanDebugMarkerInfo     DebugInfo
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd VkResult vkCreateDescriptorSetLayout(
     VkDevice                               device,
@@ -113,7 +112,6 @@ cmd VkResult vkCreateDescriptorSetLayout(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkDestroyDescriptorSetLayout(
     VkDevice                     device,
@@ -137,7 +135,6 @@ cmd void vkDestroyDescriptorSetLayout(
   @unused ref!VulkanDebugMarkerInfo                      DebugInfo
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd VkResult vkCreateDescriptorPool(
     VkDevice                          device,
@@ -177,7 +174,6 @@ cmd VkResult vkCreateDescriptorPool(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkDestroyDescriptorPool(
     VkDevice                     device,
@@ -194,7 +190,6 @@ cmd void vkDestroyDescriptorPool(
   }
 }
 
-@threadSafety("app")
 @indirect("VkDevice")
 cmd VkResult vkResetDescriptorPool(
     VkDevice                   device,
@@ -252,7 +247,6 @@ cmd VkResult vkResetDescriptorPool(
   map!(VkCommandBuffer, bool)           CommandBufferUsers
 }
 
-@threadSafety("app")
 @indirect("VkDevice")
 cmd VkResult vkAllocateDescriptorSets(
     VkDevice                           device,
@@ -836,7 +830,6 @@ sub void dovkCmdBindDescriptorSets(ref!vkCmdBindDescriptorSetsArgs args) {
   updateDescriptorBufferBindingOffsets(args)
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdBindDescriptorSets(

--- a/gapis/api/vulkan/api/device.api
+++ b/gapis/api/vulkan/api/device.api
@@ -85,7 +85,6 @@ cmd PFN_vkVoidFunction vkGetDeviceProcAddr(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkPhysicalDevice", "VkInstance")
 @override
 @custom
@@ -112,7 +111,6 @@ cmd VkResult vkCreateDevice(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 @override
 @custom
@@ -139,7 +137,6 @@ cmd void vkDestroyDevice(
   delete(Devices, device)
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 @threadsafe
 @alive

--- a/gapis/api/vulkan/api/draw_commands.api
+++ b/gapis/api/vulkan/api/draw_commands.api
@@ -63,7 +63,6 @@ sub void dovkCmdBindIndexBuffer(ref!vkCmdBindIndexBufferArgs buffer) {
 }
 
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdBindIndexBuffer(
@@ -118,7 +117,6 @@ sub void dovkCmdBindVertexBuffers(ref!vkCmdBindVertexBuffersArgs bind) {
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdBindVertexBuffers(
@@ -167,7 +165,6 @@ sub void dovkCmdDraw(ref!vkCmdDrawArgs draw) {
   ldi.CommandParameters.Draw = draw
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @executed_draw
 @threadsafe
@@ -238,7 +235,6 @@ sub void dovkCmdDrawIndexed(ref!vkCmdDrawIndexedArgs draw) {
   ldi.CommandParameters.DrawIndexed = draw
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @executed_draw
 @threadsafe
@@ -299,7 +295,6 @@ sub void dovkCmdDrawIndirect(ref!vkCmdDrawIndirectArgs draw) {
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @executed_draw
 @threadsafe
@@ -361,7 +356,6 @@ sub void dovkCmdDrawIndexedIndirect(ref!vkCmdDrawIndexedIndirectArgs draw) {
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @executed_draw
 @threadsafe
@@ -400,7 +394,6 @@ sub void dovkCmdDispatch(ref!vkCmdDispatchArgs args) {
   lci.CommandParameters.Dispatch = args
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @executed_dispatch
 @threadsafe
@@ -444,7 +437,6 @@ sub void dovkCmdDispatchIndirect(ref!vkCmdDispatchIndirectArgs dispatch) {
   lci.CommandParameters.DispatchIndirect = dispatch
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @executed_dispatch
 @threadsafe

--- a/gapis/api/vulkan/api/image.api
+++ b/gapis/api/vulkan/api/image.api
@@ -162,7 +162,6 @@
   map!(u32, ref!VkSubresourceLayout) LevelLayouts
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 @override
 cmd VkResult vkCreateImage(
@@ -310,7 +309,6 @@ cmd VkResult vkCreateImage(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkDestroyImage(
     VkDevice            device,
@@ -453,7 +451,6 @@ cmd VkResult vkBindImageMemory(
   @unused ref!SamplerYcbcrConversionObject YcbcrConversion
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd VkResult vkCreateImageView(
     VkDevice                     device,
@@ -528,7 +525,6 @@ cmd VkResult vkCreateImageView(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkDestroyImageView(
     VkDevice            device,
@@ -623,7 +619,6 @@ cmd void vkDestroyImageView(
   @unused ref!SamplerYcbcrConversionObject YcbcrConversion
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd VkResult vkCreateSampler(
     VkDevice                   device,
@@ -677,7 +672,6 @@ cmd VkResult vkCreateSampler(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkDestroySampler(
     VkDevice            device,
@@ -956,7 +950,6 @@ sub void CreateSamplerYcbcrConversion(
 }
 
 @since("1.1")
-@threadSafety("system")
 @indirect("VkDevice")
 cmd VkResult vkCreateSamplerYcbcrConversion(
     VkDevice                                    device,
@@ -979,7 +972,6 @@ sub void DestroySamplerYcbcrConversion(
 }
 
 @since("1.1")
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkDestroySamplerYcbcrConversion(
     VkDevice                                    device,

--- a/gapis/api/vulkan/api/instance.api
+++ b/gapis/api/vulkan/api/instance.api
@@ -54,7 +54,6 @@
 }
 
 @custom
-@threadSafety("system")
 @override
 cmd VkResult vkCreateInstance(
     const VkInstanceCreateInfo*  pCreateInfo,
@@ -72,7 +71,6 @@ cmd VkResult vkCreateInstance(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkInstance")
 @override
 @custom

--- a/gapis/api/vulkan/api/memory.api
+++ b/gapis/api/vulkan/api/memory.api
@@ -71,7 +71,6 @@
   VkBuffer Buffer
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 @override
 cmd VkResult vkAllocateMemory(
@@ -144,7 +143,6 @@ cmd VkResult vkAllocateMemory(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkFreeMemory(
     VkDevice                     device,
@@ -162,7 +160,6 @@ cmd void vkFreeMemory(
   }
 }
 
-@threadSafety("app")
 @indirect("VkDevice")
 cmd VkResult vkMapMemory(
     VkDevice         device,
@@ -196,7 +193,6 @@ cmd VkResult vkMapMemory(
   return ?
 }
 
-@threadSafety("app")
 @indirect("VkDevice")
 cmd void vkUnmapMemory(
     VkDevice       device,

--- a/gapis/api/vulkan/api/physical_device.api
+++ b/gapis/api/vulkan/api/physical_device.api
@@ -78,7 +78,6 @@
   map!(VkPhysicalDevice, map!(VkFormat, VkFormatProperties)) PhyDevToFormatProperties
 }
 
-@threadSafety("system")
 @indirect("VkInstance")
 cmd VkResult vkEnumeratePhysicalDevices(
     VkInstance        instance,

--- a/gapis/api/vulkan/api/pipeline.api
+++ b/gapis/api/vulkan/api/pipeline.api
@@ -48,7 +48,6 @@
   @unused ref!VulkanDebugMarkerInfo                DebugInfo
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 @threadsafe
 cmd VkResult vkCreatePipelineLayout(
@@ -81,7 +80,6 @@ cmd VkResult vkCreatePipelineLayout(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkDestroyPipelineLayout(
     VkDevice                     device,
@@ -781,7 +779,6 @@ cmd VkResult vkCreateComputePipelines(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkDestroyPipeline(
     VkDevice                     device,
@@ -967,7 +964,6 @@ sub void dovkCmdBindPipeline(ref!vkCmdBindPipelineArgs args) {
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdBindPipeline(
@@ -998,7 +994,6 @@ sub void dovkCmdSetViewport(ref!vkCmdSetViewportArgs args) {
       }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdSetViewport(
@@ -1036,7 +1031,6 @@ sub void dovkCmdSetScissor(ref!vkCmdSetScissorArgs args) {
       }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdSetScissor(
@@ -1070,7 +1064,6 @@ sub void dovkCmdSetLineWidth(ref!vkCmdSetLineWidthArgs args) {
   ldps.LineWidth = args.LineWidth
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdSetLineWidth(
@@ -1099,7 +1092,6 @@ sub void dovkCmdSetDepthBias(ref!vkCmdSetDepthBiasArgs args) {
   dyn.DepthBiasSlopeFactor = args.DepthBiasSlopeFactor
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdSetDepthBias(
@@ -1136,7 +1128,6 @@ sub void dovkCmdSetBlendConstants(ref!vkCmdSetBlendConstantsArgs args) {
   dyn.BlendConstants[3] = args.A
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdSetBlendConstants(
@@ -1167,7 +1158,6 @@ sub void dovkCmdSetDepthBounds(ref!vkCmdSetDepthBoundsArgs args) {
   dyn.MaxDepthBounds = args.MaxDepthBounds
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdSetDepthBounds(
@@ -1201,7 +1191,6 @@ sub void dovkCmdSetStencilCompareMask(ref!vkCmdSetStencilCompareMaskArgs args) {
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdSetStencilCompareMask(
@@ -1236,7 +1225,6 @@ sub void dovkCmdSetStencilWriteMask(ref!vkCmdSetStencilWriteMaskArgs args) {
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdSetStencilWriteMask(
@@ -1271,7 +1259,6 @@ sub void dovkCmdSetStencilReference(ref!vkCmdSetStencilReferenceArgs args) {
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdSetStencilReference(

--- a/gapis/api/vulkan/api/properties_features_requirements.api
+++ b/gapis/api/vulkan/api/properties_features_requirements.api
@@ -318,7 +318,6 @@ cmd void vkGetImageSparseMemoryRequirements(
 //////////////
 
 @since("1.1")
-@threadSafety("system")
 cmd VkResult vkEnumerateInstanceVersion(
     u32* pApiVersion) {
   pApiVersion[0] = ?
@@ -457,7 +456,6 @@ sub void GetPhysicalDeviceFeatures2(
 }
 
 @since("1.1")
-@threadSafety("system")
 @indirect("VkPhysicalDevice", "VkInstance")
 cmd void vkGetPhysicalDeviceFeatures2(
     VkPhysicalDevice           physicalDevice,
@@ -482,7 +480,6 @@ sub void GetPhysicalDeviceFormatProperties2(
 }
 
 @since("1.1")
-@threadSafety("system")
 @indirect("VkPhysicalDevice", "VkInstance")
 cmd void vkGetPhysicalDeviceFormatProperties2(
     VkPhysicalDevice     physicalDevice,
@@ -551,7 +548,6 @@ sub void GetPhysicalDeviceImageFormatProperties2(
 }
 
 @since("1.1")
-@threadSafety("system")
 @indirect("VkPhysicalDevice", "VkInstance")
 cmd VkResult vkGetPhysicalDeviceImageFormatProperties2(
     VkPhysicalDevice                        physicalDevice,
@@ -737,7 +733,6 @@ sub void GetPhysicalDeviceProperties2(
 }
 
 @since("1.1")
-@threadSafety("system")
 @indirect("VkPhysicalDevice", "VkInstance")
 cmd void vkGetPhysicalDeviceProperties2(
     VkPhysicalDevice             physicalDevice,
@@ -764,7 +759,6 @@ sub void GetPhysicalDeviceMemoryProperties2(
 }
 
 @since("1.1")
-@threadSafety("system")
 @indirect("VkPhysicalDevice", "VkInstance")
 cmd void vkGetPhysicalDeviceMemoryProperties2(
     VkPhysicalDevice                   physicalDevice,
@@ -810,7 +804,6 @@ sub void GetPhysicalDeviceSparseImageFormatProperties2(
 }
 
 @since("1.1")
-@threadSafety("system")
 @indirect("VkPhysicalDevice", "VkInstance")
 cmd void vkGetPhysicalDeviceSparseImageFormatProperties2(
     VkPhysicalDevice                              physicalDevice,
@@ -849,7 +842,6 @@ sub void GetPhysicalDeviceQueueFamilyProperties2(
 }
 
 @since("1.1")
-@threadSafety("system")
 @indirect("VkPhysicalDevice", "VkInstance")
 cmd void vkGetPhysicalDeviceQueueFamilyProperties2(
     VkPhysicalDevice          physicalDevice,
@@ -900,7 +892,6 @@ sub void GetPhysicalDeviceExternalBufferProperties(
 }
 
 @since("1.1")
-@threadSafety("system")
 @indirect("VkPhysicalDevice", "VkInstance")
 cmd void vkGetPhysicalDeviceExternalBufferProperties(
     VkPhysicalDevice                            physicalDevice,
@@ -951,7 +942,6 @@ sub void GetPhysicalDeviceExternalSemaphoreProperties(
 }
 
 @since("1.1")
-@threadSafety("system")
 @indirect("VkPhysicalDevice", "VkInstance")
 cmd void vkGetPhysicalDeviceExternalSemaphoreProperties(
     VkPhysicalDevice                                physicalDevice,
@@ -1002,7 +992,6 @@ sub void GetPhysicalDeviceExternalFenceProperties(
 }
 
 @since("1.1")
-@threadSafety("system")
 @indirect("VkPhysicalDevice", "VkInstance")
 cmd void vkGetPhysicalDeviceExternalFenceProperties(
     VkPhysicalDevice                            physicalDevice,
@@ -1068,7 +1057,6 @@ sub void GetBufferMemoryRequirements2(
 }
 
 @since("1.1")
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkGetBufferMemoryRequirements2(
     VkDevice                               device,
@@ -1146,7 +1134,6 @@ sub void GetImageMemoryRequirements2(
 }
 
 @since("1.1")
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkGetImageMemoryRequirements2(
     VkDevice                              device,
@@ -1197,7 +1184,6 @@ sub void GetImageSparseMemoryRequirements2(
 }
 
 @since("1.1")
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkGetImageSparseMemoryRequirements2(
     VkDevice                                    device,

--- a/gapis/api/vulkan/api/query_pool.api
+++ b/gapis/api/vulkan/api/query_pool.api
@@ -58,7 +58,6 @@ enum QueryStatus {
   @untracked @unused ref!QueueObject    LastBoundQueue
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd VkResult vkCreateQueryPool(
     VkDevice                     device,
@@ -98,7 +97,6 @@ cmd VkResult vkCreateQueryPool(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkDestroyQueryPool(
     VkDevice                     device,
@@ -108,7 +106,6 @@ cmd void vkDestroyQueryPool(
   delete(QueryPools, queryPool)
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 @threadsafe
 cmd VkResult vkGetQueryPoolResults(
@@ -171,7 +168,6 @@ sub void dovkCmdBeginQuery(ref!vkCmdBeginQueryArgs args) {
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 cmd void vkCmdBeginQuery(
     VkCommandBuffer     commandBuffer,
@@ -213,7 +209,6 @@ sub void dovkCmdEndQuery(ref!vkCmdEndQueryArgs args) {
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 cmd void vkCmdEndQuery(
     VkCommandBuffer commandBuffer,
@@ -255,7 +250,6 @@ sub void dovkCmdResetQueryPool(ref!vkCmdResetQueryPoolArgs args) {
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 cmd void vkCmdResetQueryPool(
     VkCommandBuffer commandBuffer,
@@ -298,7 +292,6 @@ sub void dovkCmdWriteTimestamp(ref!vkCmdWriteTimestampArgs args) {
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 cmd void vkCmdWriteTimestamp(
     VkCommandBuffer         commandBuffer,
@@ -363,7 +356,6 @@ sub void dovkCmdCopyQueryPoolResults(ref!vkCmdCopyQueryPoolResultsArgs args) {
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 cmd void vkCmdCopyQueryPoolResults(
     VkCommandBuffer    commandBuffer,

--- a/gapis/api/vulkan/api/queue.api
+++ b/gapis/api/vulkan/api/queue.api
@@ -59,7 +59,6 @@
   ref!QueuedSparseBinds  SparseBinds
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkGetDeviceQueue(
     VkDevice device,
@@ -82,7 +81,6 @@ cmd void vkGetDeviceQueue(
   pQueue[0] = id
 }
 
-@threadSafety("app")
 @indirect("VkQueue", "VkDevice")
 @submission
 cmd VkResult vkQueueSubmit(
@@ -192,7 +190,6 @@ cmd VkResult vkQueueSubmit(
 }
 
 
-@threadSafety("system")
 @indirect("VkQueue", "VkDevice")
 @threadsafe
 @alive

--- a/gapis/api/vulkan/api/renderpass_framebuffer.api
+++ b/gapis/api/vulkan/api/renderpass_framebuffer.api
@@ -60,7 +60,6 @@ sub void registerFramebufferUser(ref!ImageViewObject view, VkFramebuffer vkFb, u
   view.FramebufferUsers[vkFb][attachment] = true
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd VkResult vkCreateFramebuffer(
     VkDevice                       device,
@@ -109,7 +108,6 @@ cmd VkResult vkCreateFramebuffer(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkDestroyFramebuffer(
     VkDevice                     device,
@@ -144,7 +142,6 @@ cmd void vkDestroyFramebuffer(
   @unused ref!InputAttachmentAspectInfo      InputAttachmentAspectInfo
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd VkResult vkCreateRenderPass(
     VkDevice                      device,
@@ -237,7 +234,6 @@ cmd VkResult vkCreateRenderPass(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkDestroyRenderPass(
     VkDevice                     device,
@@ -320,7 +316,6 @@ sub void RecordSubpassBegin(ref!CommandBufferObject cb, u32 subpass) {
 }
 
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 cmd void vkCmdBeginRenderPass(
     VkCommandBuffer              commandBuffer,
@@ -452,7 +447,6 @@ sub void dovkCmdEndRenderPass(ref!vkCmdEndRenderPassArgs unused) {
   ldi.InRenderPass = false
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 cmd void vkCmdEndRenderPass(
     VkCommandBuffer commandBuffer) {

--- a/gapis/api/vulkan/api/synchronization.api
+++ b/gapis/api/vulkan/api/synchronization.api
@@ -47,7 +47,6 @@
   @unused ref!VulkanDebugMarkerInfo DebugInfo
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd VkResult vkCreateFence(
     VkDevice                     device,
@@ -85,7 +84,6 @@ cmd VkResult vkCreateFence(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkDestroyFence(
     VkDevice                     device,
@@ -95,7 +93,6 @@ cmd void vkDestroyFence(
   delete(Fences, fence)
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd VkResult vkResetFences(
     VkDevice       device,
@@ -112,7 +109,6 @@ cmd VkResult vkResetFences(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 @custom
 cmd VkResult vkGetFenceStatus(
@@ -133,7 +129,6 @@ cmd VkResult vkGetFenceStatus(
   return res
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 @threadsafe
 @alive
@@ -176,7 +171,6 @@ cmd VkResult vkWaitForFences(
   @unused VkExternalSemaphoreHandleTypeFlags ExternalHandleTypeFlags
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd VkResult vkCreateSemaphore(
     VkDevice                     device,
@@ -213,7 +207,6 @@ cmd VkResult vkCreateSemaphore(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkDestroySemaphore(
     VkDevice                     device,
@@ -225,7 +218,6 @@ cmd void vkDestroySemaphore(
 
 // Partial implementation
 @since("1.2")
-@threadSafety("system")
 @indirect("VkDevice")
 cmd VkResult vkSignalSemaphore(
     VkDevice                                    device,
@@ -235,7 +227,6 @@ cmd VkResult vkSignalSemaphore(
 
 // Partial implementation
 @since("1.2")
-@threadSafety("system")
 @indirect("VkDevice")
 cmd VkResult vkWaitSemaphores(
     VkDevice                                    device,
@@ -246,7 +237,6 @@ cmd VkResult vkWaitSemaphores(
 
 // Partial implementation
 @since("1.2")
-@threadSafety("system")
 @indirect("VkDevice")
 cmd VkResult vkGetSemaphoreCounterValue(
     VkDevice                                    device,
@@ -267,7 +257,6 @@ cmd VkResult vkGetSemaphoreCounterValue(
   @unused ref!VulkanDebugMarkerInfo DebugInfo
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd VkResult vkCreateEvent(
     VkDevice                     device,
@@ -301,7 +290,6 @@ cmd VkResult vkCreateEvent(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd void vkDestroyEvent(
     VkDevice                     device,
@@ -310,7 +298,6 @@ cmd void vkDestroyEvent(
   delete(Events, event)
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 @custom
 cmd VkResult vkGetEventStatus(
@@ -321,7 +308,6 @@ cmd VkResult vkGetEventStatus(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd VkResult vkSetEvent(
     VkDevice device,
@@ -342,7 +328,6 @@ cmd VkResult vkSetEvent(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkDevice")
 cmd VkResult vkResetEvent(
     VkDevice device,
@@ -368,7 +353,6 @@ sub void dovkCmdSetEvent(ref!vkCmdSetEventArgs event) {
   evt.SubmitQueue = LastBoundQueue.VulkanHandle
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 cmd void vkCmdSetEvent(
     VkCommandBuffer      commandBuffer,
@@ -402,7 +386,6 @@ sub void dovkCmdResetEvent(ref!vkCmdResetEventArgs event) {
   evt.SubmitQueue = LastBoundQueue.VulkanHandle
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 cmd void vkCmdResetEvent(
     VkCommandBuffer      commandBuffer,
@@ -452,7 +435,6 @@ sub void dovkCmdWaitEvents(ref!vkCmdWaitEventsArgs args) {
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 cmd void vkCmdWaitEvents(
     VkCommandBuffer              commandBuffer,
@@ -582,7 +564,6 @@ sub void handleImageMemoryBarriersPNext(const VkImageMemoryBarrier* pBarriers, u
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 cmd void vkCmdPipelineBarrier(
     VkCommandBuffer              commandBuffer,

--- a/gapis/api/vulkan/extensions/amd_buffer_marker.api
+++ b/gapis/api/vulkan/extensions/amd_buffer_marker.api
@@ -48,7 +48,6 @@
 // Commands //
 //////////////
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @extension("VK_AMD_buffer_marker")
 @override

--- a/gapis/api/vulkan/extensions/amd_draw_indirect_count.api
+++ b/gapis/api/vulkan/extensions/amd_draw_indirect_count.api
@@ -44,7 +44,6 @@ sub void dovkCmdDrawIndexedIndirectCountAMD(ref!vkCmdDrawIndexedIndirectCountAMD
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @executed_draw
 @threadsafe
@@ -88,7 +87,6 @@ cmd void vkCmdDrawIndirectCountAMD(
   u32          Stride
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @executed_draw
 @threadsafe

--- a/gapis/api/vulkan/extensions/android_external_memory_android_hardware_buffer.api
+++ b/gapis/api/vulkan/extensions/android_external_memory_android_hardware_buffer.api
@@ -107,7 +107,6 @@ class VkImportAndroidHardwareBufferInfoANDROID {
 
 @platform("VK_USE_PLATFORM_ANDROID_KHR")
 @extension("VK_ANDROID_external_memory_android_hardware_buffer")
-@threadSafety("system")
 @indirect("VkDevice")
 @no_replay
 cmd VkResult vkGetAndroidHardwareBufferPropertiesANDROID(
@@ -156,7 +155,6 @@ cmd VkResult vkGetAndroidHardwareBufferPropertiesANDROID(
 
 @platform("VK_USE_PLATFORM_ANDROID_KHR")
 @extension("VK_ANDROID_external_memory_android_hardware_buffer")
-@threadSafety("system")
 @indirect("VkDevice")
 @no_replay
 cmd VkResult vkGetMemoryAndroidHardwareBufferANDROID(

--- a/gapis/api/vulkan/extensions/ext_debug_marker.api
+++ b/gapis/api/vulkan/extensions/ext_debug_marker.api
@@ -79,7 +79,6 @@ class VkDebugMarkerMarkerInfoEXT {
 // Commands //
 //////////////
 
-@threadSafety("app")
 @extension("VK_EXT_debug_marker")
 @extension("VK_EXT_debug_report")
 @indirect("VkDevice")
@@ -94,7 +93,6 @@ cmd VkResult vkDebugMarkerSetObjectTagEXT(
   return ?
 }
 
-@threadSafety("app")
 @extension("VK_EXT_debug_marker")
 @extension("VK_EXT_debug_report")
 @indirect("VkDevice")
@@ -118,7 +116,6 @@ vkCmdDebugMarkerBeginEXTArgs {
 sub void dovkCmdDebugMarkerBeginEXT(ref!vkCmdDebugMarkerBeginEXTArgs args) {
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @extension("VK_EXT_debug_marker")
 @extension("VK_EXT_debug_report")
@@ -153,7 +150,6 @@ vkCmdDebugMarkerEndEXTArgs {}
 sub void dovkCmdDebugMarkerEndEXT(ref!vkCmdDebugMarkerEndEXTArgs draw) {
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @extension("VK_EXT_debug_marker")
 @extension("VK_EXT_debug_report")
@@ -183,7 +179,6 @@ vkCmdDebugMarkerInsertEXTArgs {
 sub void dovkCmdDebugMarkerInsertEXT(ref!vkCmdDebugMarkerInsertEXTArgs draw) {
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @extension("VK_EXT_debug_marker")
 @extension("VK_EXT_debug_report")

--- a/gapis/api/vulkan/extensions/ext_debug_utils.api
+++ b/gapis/api/vulkan/extensions/ext_debug_utils.api
@@ -149,7 +149,6 @@ class VkDebugUtilsMessengerCallbackDataEXT {
 // Commands //
 //////////////
 
-@threadSafety("app")
 @extension("VK_EXT_debug_utils")
 @indirect("VkDevice")
 @override
@@ -163,7 +162,6 @@ cmd VkResult vkSetDebugUtilsObjectNameEXT(
   return ?
 }
 
-@threadSafety("app")
 @extension("VK_EXT_debug_utils")
 @indirect("VkDevice")
 @override
@@ -186,7 +184,6 @@ vkCmdBeginDebugUtilsLabelEXTArgs {
 sub void dovkCmdBeginDebugUtilsLabelEXT(ref!vkCmdBeginDebugUtilsLabelEXTArgs args) {
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @extension("VK_EXT_debug_utils")
 @override
@@ -218,7 +215,6 @@ vkCmdEndDebugUtilsLabelEXTArgs {}
 sub void dovkCmdEndDebugUtilsLabelEXT(ref!vkCmdEndDebugUtilsLabelEXTArgs args) {
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @extension("VK_EXT_debug_utils")
 @override
@@ -245,7 +241,6 @@ vkCmdInsertDebugUtilsLabelEXTArgs {
 sub void dovkCmdInsertDebugUtilsLabelEXT(ref!vkCmdInsertDebugUtilsLabelEXTArgs args) {
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @extension("VK_EXT_debug_utils")
 @override
@@ -270,7 +265,6 @@ cmd void vkCmdInsertDebugUtilsLabelEXT(
   AddCommand(commandBuffer, cmd_vkCmdInsertDebugUtilsLabelEXT, mapPos)
 }
 
-@threadSafety("app")
 @indirect("VkQueue", "VkDevice")
 @extension("VK_EXT_debug_utils")
 @override
@@ -281,7 +275,6 @@ cmd void vkQueueBeginDebugUtilsLabelEXT(
 {
 }
 
-@threadSafety("app")
 @indirect("VkQueue", "VkDevice")
 @extension("VK_EXT_debug_utils")
 @override
@@ -291,7 +284,6 @@ cmd void vkQueueEndDebugUtilsLabelEXT(
 {
 }
 
-@threadSafety("app")
 @indirect("VkQueue", "VkDevice")
 @extension("VK_EXT_debug_utils")
 @override
@@ -302,7 +294,6 @@ cmd void vkQueueInsertDebugUtilsLabelEXT(
 {
 }
 
-@threadSafety("app")
 @indirect("VkInstance")
 @extension("VK_EXT_debug_utils")
 @override
@@ -316,7 +307,6 @@ cmd VkResult vkCreateDebugUtilsMessengerEXT(
   return ?
 }
 
-@threadSafety("app")
 @indirect("VkInstance")
 @extension("VK_EXT_debug_utils")
 @override
@@ -328,7 +318,6 @@ cmd void vkDestroyDebugUtilsMessengerEXT(
 {
 }
 
-@threadSafety("app")
 @indirect("VkInstance")
 @extension("VK_EXT_debug_utils")
 @override

--- a/gapis/api/vulkan/extensions/ext_line_rasterization.api
+++ b/gapis/api/vulkan/extensions/ext_line_rasterization.api
@@ -124,7 +124,6 @@ sub void dovkCmdSetLineStippleEXT(ref!vkCmdSetLineStippleEXTArgs args) {
 }
 
 @extension("VK_EXT_line_rasterization")
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdSetLineStippleEXT(

--- a/gapis/api/vulkan/extensions/khr_device_group.api
+++ b/gapis/api/vulkan/extensions/khr_device_group.api
@@ -143,7 +143,6 @@ sub void dovkCmdSetDeviceMaskKHR(ref!vkCmdSetDeviceMaskKHRArgs args) {
 }
 
 @extension("VK_KHR_device_group")
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdSetDeviceMaskKHR(
@@ -173,7 +172,6 @@ sub void dovkCmdSetDeviceMask(ref!vkCmdSetDeviceMaskArgs args) {
 }
 
 // Vulkan 1.1
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
 cmd void vkCmdSetDeviceMask(
@@ -208,7 +206,6 @@ sub void dovkCmdDispatchBaseKHR(ref!vkCmdDispatchBaseKHRArgs args) {
 }
 
 @extension("VK_KHR_device_group")
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @executed_dispatch
 @threadsafe
@@ -257,7 +254,6 @@ sub void dovkCmdDispatchBase(ref!vkCmdDispatchBaseArgs args) {
 }
 
 // Vulkan 1.1
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @executed_dispatch
 @threadsafe

--- a/gapis/api/vulkan/extensions/khr_draw_indirect_count.api
+++ b/gapis/api/vulkan/extensions/khr_draw_indirect_count.api
@@ -83,7 +83,6 @@ sub void dovkCmdDrawIndexedIndirectCountKHR(ref!vkCmdDrawIndexedIndirectCountKHR
   }
 }
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @executed_draw
 @threadsafe
@@ -118,7 +117,6 @@ cmd void vkCmdDrawIndirectCountKHR(
 }
 
 
-@threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @executed_draw
 @threadsafe

--- a/gapis/api/vulkan/extensions/khr_external_semaphore_fd.api
+++ b/gapis/api/vulkan/extensions/khr_external_semaphore_fd.api
@@ -69,7 +69,6 @@ class VkSemaphoreGetFdInfoKHR {
 //////////////
 
 @extension("VK_KHR_external_semaphore_fd")
-@threadSafety("system")
 @indirect("VkDevice")
 @no_replay
 cmd VkResult vkImportSemaphoreFdKHR(
@@ -84,7 +83,6 @@ cmd VkResult vkImportSemaphoreFdKHR(
 }
 
 @extension("VK_KHR_external_semaphore_fd")
-@threadSafety("system")
 @indirect("VkDevice")
 @no_replay
 cmd VkResult vkGetSemaphoreFdKHR(

--- a/gapis/api/vulkan/extensions/khr_get_physical_device_properties2.api
+++ b/gapis/api/vulkan/extensions/khr_get_physical_device_properties2.api
@@ -115,7 +115,6 @@ class VkPhysicalDeviceSparseImageFormatInfo2KHR {
 // Commands //
 //////////////
 
-@threadSafety("system")
 @indirect("VkPhysicalDevice", "VkInstance")
 @extension("VK_KHR_get_physical_device_properties2")
 cmd void vkGetPhysicalDeviceFeatures2KHR(
@@ -125,7 +124,6 @@ cmd void vkGetPhysicalDeviceFeatures2KHR(
     as!VkPhysicalDeviceFeatures2*(pFeatures))
 }
 
-@threadSafety("system")
 @indirect("VkPhysicalDevice", "VkInstance")
 @extension("VK_KHR_get_physical_device_properties2")
 cmd void vkGetPhysicalDeviceProperties2KHR(
@@ -135,7 +133,6 @@ cmd void vkGetPhysicalDeviceProperties2KHR(
     as!VkPhysicalDeviceProperties2*(pProperties))
 }
 
-@threadSafety("system")
 @indirect("VkPhysicalDevice", "VkInstance")
 @extension("VK_KHR_get_physical_device_properties2")
 cmd void vkGetPhysicalDeviceFormatProperties2KHR(
@@ -146,7 +143,6 @@ cmd void vkGetPhysicalDeviceFormatProperties2KHR(
     as!VkFormatProperties2*(pFormatProperties))
 }
 
-@threadSafety("system")
 @indirect("VkPhysicalDevice", "VkInstance")
 @extension("VK_KHR_get_physical_device_properties2")
 cmd VkResult vkGetPhysicalDeviceImageFormatProperties2KHR(
@@ -159,7 +155,6 @@ cmd VkResult vkGetPhysicalDeviceImageFormatProperties2KHR(
   return ?
 }
 
-@threadSafety("system")
 @indirect("VkPhysicalDevice", "VkInstance")
 @extension("VK_KHR_get_physical_device_properties2")
 cmd void vkGetPhysicalDeviceQueueFamilyProperties2KHR(
@@ -171,7 +166,6 @@ cmd void vkGetPhysicalDeviceQueueFamilyProperties2KHR(
     as!VkQueueFamilyProperties2*(pQueueFamilyProperties))
 }
 
-@threadSafety("system")
 @indirect("VkPhysicalDevice", "VkInstance")
 @extension("VK_KHR_get_physical_device_properties2")
 cmd void vkGetPhysicalDeviceMemoryProperties2KHR(
@@ -181,7 +175,6 @@ cmd void vkGetPhysicalDeviceMemoryProperties2KHR(
     as!VkPhysicalDeviceMemoryProperties2*(pMemoryProperties))
 }
 
-@threadSafety("system")
 @indirect("VkPhysicalDevice", "VkInstance")
 @extension("VK_KHR_get_physical_device_properties2")
 cmd void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(

--- a/gapis/api/vulkan/extensions/khr_get_surface_capabilities2.api
+++ b/gapis/api/vulkan/extensions/khr_get_surface_capabilities2.api
@@ -65,7 +65,6 @@ class VkSurfaceFormat2KHR {
 // Commands //
 //////////////
 
-@threadSafety("system")
 @indirect("VkPhysicalDevice", "VkInstance")
 @extension("VK_KHR_get_surface_capabilities2")
 cmd VkResult vkGetPhysicalDeviceSurfaceCapabilities2KHR(
@@ -95,7 +94,6 @@ cmd VkResult vkGetPhysicalDeviceSurfaceCapabilities2KHR(
 
 }
 
-@threadSafety("system")
 @indirect("VkPhysicalDevice", "VkInstance")
 @extension("VK_KHR_get_surface_capabilities2")
 cmd VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(


### PR DESCRIPTION
This annotation doesn't appear to be used anywhere in the codebase.

The only match of 'threadSafety' is the annotation's occurences, there
is no other code matching this identifier:

```
~/agi$ git grep -i threadsafety
gapis/api/vulkan/api/buffer.api:76:@threadSafety("system")
gapis/api/vulkan/api/buffer.api:144:@threadSafety("system")
... etc ...

~/agi$ git grep -i threadsafety | grep -v '@threadSafety'
 # no results
```

I believe this annotation may have been relevant years ago in the
GAPIL vulkan definition that was used in the Android source tree
(`frameworks/native/vulkan/api/vulkan.api`), but nowadays this file is
not even present in the Android source tree.

Bug: b/160856238

Test: AGI compiles and works well without this annotation.