### PR TITLE
Remove obsolete @reserved_flags GAPIL annotation

### DIFF
--- a/gapis/api/vulkan/android/vulkan_android.api
+++ b/gapis/api/vulkan/android/vulkan_android.api
@@ -29,7 +29,6 @@ class ANativeWindow {}
 type void* buffer_handle_t
 
 @extension("VK_KHR_android_surface")
-@reserved_flags
 type VkFlags VkAndroidSurfaceCreateFlagsKHR
 
 @platform("VK_USE_PLATFORM_ANDROID_KHR")

--- a/gapis/api/vulkan/api/bitfields.api
+++ b/gapis/api/vulkan/api/bitfields.api
@@ -36,7 +36,6 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 
-@reserved_flags
 type VkFlags VkInstanceCreateFlags
 
 /// Format capability flags
@@ -163,7 +162,6 @@ bitfield VkMemoryHeapFlagBits {
 }
 type VkFlags VkMemoryHeapFlags
 
-@reserved_flags
 type VkFlags VkDeviceCreateFlags
 
 @unused
@@ -194,7 +192,6 @@ bitfield VkPipelineStageFlagBits {
 }
 type VkFlags VkPipelineStageFlags
 
-@reserved_flags
 type VkFlags VkMemoryMapFlags
 
 bitfield VkImageAspectFlagBits {
@@ -232,13 +229,10 @@ bitfield VkFenceCreateFlagBits {
 }
 type VkFlags VkFenceCreateFlags
 
-@reserved_flags
 type VkFlags VkSemaphoreCreateFlags
 
-@reserved_flags
 type VkFlags VkEventCreateFlags
 
-@reserved_flags
 type VkFlags VkQueryPoolCreateFlags
 
 @unused
@@ -290,16 +284,12 @@ bitfield VkBufferUsageFlagBits {
 }
 type VkFlags VkBufferUsageFlags
 
-@reserved_flags
 type VkFlags VkBufferViewCreateFlags
 
-@reserved_flags
 type VkFlags VkImageViewCreateFlags
 
-@reserved_flags
 type VkFlags VkShaderModuleCreateFlags
 
-@reserved_flags
 type VkFlags VkPipelineCacheCreateFlags
 
 @unused
@@ -313,7 +303,6 @@ bitfield VkPipelineCreateFlagBits {
 }
 type VkFlags VkPipelineCreateFlags
 
-@reserved_flags
 type VkFlags VkPipelineShaderStageCreateFlags
 
 
@@ -329,19 +318,14 @@ bitfield VkShaderStageFlagBits {
 }
 type VkFlags VkShaderStageFlags
 
-@reserved_flags
 type VkFlags VkPipelineVertexInputStateCreateFlags
 
-@reserved_flags
 type VkFlags VkPipelineInputAssemblyStateCreateFlags
 
-@reserved_flags
 type VkFlags VkPipelineTessellationStateCreateFlags
 
-@reserved_flags
 type VkFlags VkPipelineViewportStateCreateFlags
 
-@reserved_flags
 type VkFlags VkPipelineRasterizationStateCreateFlags
 
 @unused
@@ -353,11 +337,8 @@ bitfield VkCullModeFlagBits {
 }
 type VkFlags VkCullModeFlags
 
-@reserved_flags
 type VkFlags VkPipelineMultisampleStateCreateFlags
-@reserved_flags
 type VkFlags VkPipelineDepthStencilStateCreateFlags
-@reserved_flags
 type VkFlags VkPipelineColorBlendStateCreateFlags
 
 @unused
@@ -369,16 +350,12 @@ bitfield VkColorComponentFlagBits {
 }
 type VkFlags VkColorComponentFlags
 
-@reserved_flags
 type VkFlags VkPipelineDynamicStateCreateFlags
 
-@reserved_flags
 type VkFlags VkPipelineLayoutCreateFlags
 
-@reserved_flags
 type VkFlags VkSamplerCreateFlags
 
-@reserved_flags
 type VkFlags VkDescriptorSetLayoutCreateFlags
 
 @unused
@@ -387,13 +364,10 @@ bitfield VkDescriptorPoolCreateFlagBits {
 }
 type VkFlags VkDescriptorPoolCreateFlags
 
-@reserved_flags
 type VkFlags VkDescriptorPoolResetFlags
 
-@reserved_flags
 type VkFlags VkFramebufferCreateFlags
 
-@reserved_flags
 type VkFlags VkRenderPassCreateFlags
 
 @unused
@@ -402,7 +376,6 @@ bitfield VkAttachmentDescriptionFlagBits {
 }
 type VkFlags VkAttachmentDescriptionFlags
 
-@reserved_flags
 type VkFlags VkSubpassDescriptionFlags
 
 @unused
@@ -578,10 +551,8 @@ bitfield VkSubgroupFeatureFlagBits {
 }
 type VkFlags VkSubgroupFeatureFlags
 
-@reserved_flags
 type VkFlags VkCommandPoolTrimFlags // reserved for future use
 
-@reserved_flags
 type VkFlags VkDescriptorUpdateTemplateCreateFlags // reserved for future use
 
 @unused

--- a/gapis/api/vulkan/extensions/ext_debug_utils.api
+++ b/gapis/api/vulkan/extensions/ext_debug_utils.api
@@ -55,11 +55,9 @@
 ///////////
 
 @extension("VK_EXT_debug_utils")
-@reserved_flags
 type VkFlags VkDebugUtilsMessengerCallbackDataFlagsEXT
 
 @extension("VK_EXT_debug_utils")
-@reserved_flags
 type VkFlags VkDebugUtilsMessengerCreateFlagsEXT
 
 @extension("VK_EXT_debug_utils")
@@ -72,7 +70,6 @@ enum VkDebugUtilsMessageSeverityFlagBitsEXT: u32 {
 }
 
 @extension("VK_EXT_debug_utils")
-@reserved_flags
 type VkFlags VkDebugUtilsMessageSeverityFlagsEXT
 
 @extension("VK_EXT_debug_utils")
@@ -84,7 +81,6 @@ enum VkDebugUtilsMessageTypeFlagBitsEXT: u32 {
 }
 
 @extension("VK_EXT_debug_utils")
-@reserved_flags
 type VkFlags VkDebugUtilsMessageTypeFlagsEXT
 
 /////////////

--- a/gapis/api/vulkan/extensions/ext_pipeline_creation_feedback.api
+++ b/gapis/api/vulkan/extensions/ext_pipeline_creation_feedback.api
@@ -48,7 +48,6 @@ enum VkPipelineCreationFeedbackFlagBitsEXT: u32 {
     VK_PIPELINE_CREATION_FEEDBACK_FLAG_BITS_MAX_ENUM_EXT = 0x7FFFFFFF
 }
 
-@reserved_flags
 type VkFlags VkPipelineCreationFeedbackFlagsEXT
 
 @extension("VK_EXT_pipeline_creation_feedback")

--- a/gapis/api/vulkan/extensions/khr_display.api
+++ b/gapis/api/vulkan/extensions/khr_display.api
@@ -65,11 +65,9 @@ bitfield VkDisplayPlaneAlphaFlagBitsKHR {
 type VkFlags VkDisplayPlaneAlphaFlagsKHR
 
 @extension("VK_KHR_display")
-@reserved_flags
 type VkFlags VkDisplayModeCreateFlagsKHR
 
 @extension("VK_KHR_display")
-@reserved_flags
 type VkFlags VkDisplaySurfaceCreateFlagsKHR
 
 /////////////

--- a/gapis/api/vulkan/extensions/khr_swapchain.api
+++ b/gapis/api/vulkan/extensions/khr_swapchain.api
@@ -61,7 +61,6 @@ bitfield VkSwapchainCreateFlagBitsKHR {
 }
 
 @extension("VK_KHR_swapchain")
-@reserved_flags
 type VkFlags VkSwapchainCreateFlagsKHR
 
 /////////////

--- a/gapis/api/vulkan/linux/vulkan_linux.api
+++ b/gapis/api/vulkan/linux/vulkan_linux.api
@@ -28,7 +28,6 @@
 // ----------------------------------------------------------------------------
 
 @extension("VK_KHR_xlib_surface")
-@reserved_flags
 type VkFlags VkXlibSurfaceCreateFlagsKHR
 
 @extension("VK_KHR_xlib_surface") @forwarddecl class Display {}
@@ -88,7 +87,6 @@ cmd VkBool32 vkGetPhysicalDeviceXlibPresentationSupportKHR(
 // ----------------------------------------------------------------------------
 
 @extension("VK_KHR_xcb_surface")
-@reserved_flags
 type VkFlags VkXcbSurfaceCreateFlagsKHR
 
 @extension("VK_KHR_xcb_surface") @forwarddecl class xcb_connection_t {}
@@ -148,7 +146,6 @@ cmd VkBool32 vkGetPhysicalDeviceXcbPresentationSupportKHR(
 // ----------------------------------------------------------------------------
 
 @extension("VK_KHR_wayland_surface")
-@reserved_flags
 type VkFlags VkWaylandSurfaceCreateFlagsKHR
 
 @extension("VK_KHR_wayland_surface") @forwarddecl class wl_display {}

--- a/gapis/api/vulkan/mac/vulkan_mac.api
+++ b/gapis/api/vulkan/mac/vulkan_mac.api
@@ -22,7 +22,6 @@
 // ----------------------------------------------------------------------------
 
 @extension("VK_MVK_macos_surface")
-@reserved_flags
 type VkFlags VkMacOSSurfaceCreateFlagsMVK
 
 @platform("VK_USE_PLATFORM_MACOS_MVK")

--- a/gapis/api/vulkan/windows/vulkan_windows.api
+++ b/gapis/api/vulkan/windows/vulkan_windows.api
@@ -24,7 +24,6 @@
 @internal type size HWND
 
 @extension("VK_KHR_win32_surface")
-@reserved_flags
 type VkFlags VkWin32SurfaceCreateFlagsKHR
 
 @platform("VK_USE_PLATFORM_WIN32_KHR")


### PR DESCRIPTION
This annotation doesn't seem to be used anywhere in AGI codebase.

```
~/agi$ git grep -in reserved_flags
gapis/api/vulkan/android/vulkan_android.api:32:@reserved_flags
gapis/api/vulkan/api/bitfields.api:39:@reserved_flags
... etc ...

~/agi$ git grep -in reserved_flags | grep -v '@reserved_flags'
 # no output
```

I believe this annotation might be a leftover from when GAPID's vulkan
GAPIL files were used in the Android codebase (in
`frameworks/native/vulkan/api/vulkan.api`), in any case the Android
codebase does not use GAPIL files anymore.

Bug: b/160856238
Test: AGI compiles and works fine without this annotation.