### PR TITLE
Fix screen auto-unlock for some devices

### DIFF
--- a/core/os/android/adb/adb_data_test.go
+++ b/core/os/android/adb/adb_data_test.go
@@ -141,6 +141,13 @@ mShowingDream=false mShowingLockscreen=false mDreamingSleepToken=null
 mStatusBar=Window{5033a83 u0 StatusBar} isStatusBarKeyguard=false
 ...`),
 
+		// The 'wm dismiss-keyguard' command is used to unlock the screen, it
+		// doesn't return anything
+		stub.RespondTo(adbPath.System()+` -s screen_off_locked_device shell wm dismiss-keyguard`, ""),
+		stub.RespondTo(adbPath.System()+` -s screen_off_unlocked_device shell wm dismiss-keyguard`, ""),
+		stub.RespondTo(adbPath.System()+` -s screen_on_locked_device shell wm dismiss-keyguard`, ""),
+		stub.RespondTo(adbPath.System()+` -s screen_on_unlocked_device shell wm dismiss-keyguard`, ""),
+
 		// Pid queries.
 		stub.Regex(`adb -s ok_pgrep_\S*device shell pgrep .* com.google.foo`, stub.Respond("")),
 		stub.Regex(`adb -s ok_pgrep\S*device shell pgrep -n -f com.google.bar`, stub.Respond("2778")),

--- a/core/os/android/adb/screen.go
+++ b/core/os/android/adb/screen.go
@@ -105,18 +105,17 @@ func (b *binding) UnlockScreen(ctx context.Context) (bool, error) {
 		// Devices may do unexpected transitions between screen
 		// states, so this code does not try to be smart about
 		// expected state changes: unless screenOnUnlocked, apply the
-		// wakeup (put screen on) and menu (unlock screen if no
-		// credentials required) key event sequence.
+		// wakeup (put screen on) and dismiss-keyguard (unlock screen
+		// if no credentials required) sequence.
 		if err := b.KeyEvent(ctx, android.KeyCode_Wakeup); err != nil {
 			return false, err
 		}
-		if err := b.KeyEvent(ctx, android.KeyCode_Menu); err != nil {
+		if err := b.Shell("wm", "dismiss-keyguard").Run(ctx); err != nil {
 			return false, err
 		}
-		// A sleep here is necessary to make sure the key events had
-		// enough time to affect the screen state.
+		// A sleep here is necessary to make sure the above commands had enough
+		// time to affect the screen state.
 		time.Sleep(keyEventEffectDelay)
 		return b.isScreenUnlocked(ctx)
 	}
-	return false, log.Err(ctx, ErrScreenState, "")
 }


### PR DESCRIPTION
Some devices do need a pause between the "wakeup" and the "menu" key
events in order to properly unlock their screens.

Also, remove unreachable code at the end of UnlockScreen(): the
previous switch statement has a default case which always reach a
return, hence the return after this switch statement is effectively
unreachable (the code compiles fine without it).

Bug: b/193011219

Test: manual: take a trace on a device which has a locked screen,
using a device where auto-unlocking was failing before this change.