### PR TITLE
Use the Perfetto API even when tracing to a file.

### DIFF
--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -371,6 +371,7 @@ func (b *binding) QueryPerfettoServiceState(ctx context.Context) (*device.Perfet
 		// SurfaceFlinger frame lifecycle perfetto producer is mandated by Android 11 CTS, hence it will
 		// always exist.
 		result.HasFrameLifecycle = true
+		result.CanProvideTraceFilePath = true
 
 		// This has anecdotally not worked well in Q, but appears to be fine in R.
 		result.CanDownloadWhileTracing = true

--- a/core/os/device/device.proto
+++ b/core/os/device/device.proto
@@ -188,6 +188,9 @@ message PerfettoCapability {
   bool has_frame_lifecycle = 4;
   bool has_power_rail = 5;
   bool can_download_while_tracing = 6;
+  // Whether the Perfetto tracing API supports tracing to a file on the device
+  // given a path, rather than a file descriptor.
+  bool can_provide_trace_file_path = 7;
 }
 
 message GPUProfiling {


### PR DESCRIPTION
If the device supports it, use Perfetto's API to trace, when tracing to a file is requested, via the API's "OutputPath" capability.