### PR TITLE
Add a way to set system properties for swarming tests

### DIFF
--- a/test/swarming/README.md
+++ b/test/swarming/README.md
@@ -78,7 +78,13 @@ script:
   "package": "com.example.myApp",
   "activity": "com.example.myApp.myActivity",
   "startframe": "5",
-  "numframe": "2"
+  "numframe": "2",
+  "setprop": [
+    {
+      "name": "debug.myApp.foobar",
+      "value": "42"
+    }
+  ]
 }
 ```
 

--- a/test/swarming/bot-scripts/botutil.py
+++ b/test/swarming/bot-scripts/botutil.py
@@ -113,7 +113,7 @@ class BotUtil:
         "force_install": true|false, # (Optional): force APK installation,
                                     # even if the package is already found
                                     # on the device
-        "install_flags": ["-g", "-t"], # (Opriotnal) list of flags to pass
+        "install_flags": ["-g", "-t"], # (Optional) list of flags to pass
                                         # to adb install
         ...
         }
@@ -141,3 +141,7 @@ class BotUtil:
             time.sleep(1)
         else:
             log('Skip install of {} because package {} is already installed.'.format(test_params['apk'], test_params['package']))
+        # Set Android properties specific to this APK.
+        if 'setprop' in test_params.keys():
+            for prop in test_params['setprop']:
+                self.adb(['shell',  'setprop', prop['name'], prop['value']])


### PR DESCRIPTION
This is needed by some apps, e.g. for
Filament (https://github.com/google/filament) we need to set
'debug.filament.backend' to '2' to force the Vulkan backend.

Also, fix a typo.

Bug: b/187675797
Test: manual