### PR TITLE
Fix size calculation for vertex attrib with stride 0

### DIFF
--- a/gapis/api/vulkan/api/coherent_memory.api
+++ b/gapis/api/vulkan/api/coherent_memory.api
@@ -515,14 +515,18 @@ sub void trackMemoryInCurrentPipelineBoundVertexBuffers(u32 vertexCount, u32 ins
                 }
             }
         }
-        start_offset := bound_vertex_buffer.Offset + as!VkDeviceSize(start_vertex * vertex_binding.stride)
-        num := switch vertexCount == 0xFFFFFFFF {
-          case true:
-            backing_buf.Info.Size - start_offset
-          case false:
-            as!VkDeviceSize(num_vertices * vertex_binding.stride)
+        if num_vertices > 0 {
+          vertex_attrib := ldi.GraphicsPipeline.VertexInputState.AttributeDescriptions[vertex_binding.binding]
+          vertex_attrib_size := getElementAndTexelBlockSize(vertex_attrib.format).ElementSize
+          start_offset := bound_vertex_buffer.Offset + as!VkDeviceSize((start_vertex * vertex_binding.stride) + vertex_attrib.offset)
+          num := switch vertexCount == 0xFFFFFFFF {
+            case true:
+              backing_buf.Info.Size - start_offset
+            case false:
+              as!VkDeviceSize(((num_vertices - 1) * vertex_binding.stride) + vertex_attrib_size)
+          }
+          readMemoryInBuffer(backing_buf, start_offset, num)
         }
-        readMemoryInBuffer(backing_buf, start_offset, num)
       }
     }
   }


### PR DESCRIPTION
Previous calculation used stride as vertex size, resulting in memory
read of size 0 when stride was 0. New calculation uses vertex size,
offset, and stride to determine bounds of vertex data:

offset = (start_vertex * vertex_attrib_stride) + vertex_attrib_offset
size   = ((num_vertices - 1) * vertex_attrib_stride) + vertex_attrib_size

Fixes #814

Manual test with GLES1 game on ANGLE, which uses a vertex color
attribute with stride 0 to implement glColor4f.