### PR TITLE
Refresh swarming doc, add debug.py script

### DIFF
--- a/test/swarming/README.md
+++ b/test/swarming/README.md
@@ -1,22 +1,25 @@
-# Swarming: capture-replay tests on real Android devices
+# Swarming: integration tests on real Android devices
 
 This is a collection of scripts to run AGI tests on real Android devices.
 
 We can access devices through Swarming, which is part of
 [LUCI](https://chromium.googlesource.com/infra/infra/+/master/doc/users/services/about_luci.md),
-hence the name "swarming tests".
+hence the name "Swarming tests".
 
-A swarming test typically consists in installing an APK using Vulkan, and
-running some `gapit` commands to capture-replay this APK. As we don't want to
-include APKs in this repo, we store them on x20.
+A Swarming test typically consists in installing the APK containing some GPU
+workloads (e.g. a Vulkan demo), and running some `gapit` commands to test AGI
+features on this workload. As we don't want to include APKs in this repo, we
+store them on x20.
+
+Googlers: see also [go/agi-doc-swarming](https://go/agi-doc-swarming).
 
 ## Scripts running order
 
 The scripts are primarly designed to run as part of Kokoro Linux builds. The
 running order is:
 
-1. The Kokoro build script `kokoro/linux/build.sh` uses `test/swarming/trigger.py` to
-   schedule Swarming tests.
+1. The Kokoro build script `kokoro/linux/build.sh` uses
+   `test/swarming/trigger.py` to schedule Swarming tests.
 
 2. The Swarming bot runs `test/swarming/bot-harness.py`, which wraps one of the
    scripts unders `test/swarming/bot-scripts/` and makes sure to **always** turn
@@ -41,9 +44,10 @@ and `${LUCI_ROOT}/isolate whoami` to check your local credentials.
 
 You can trigger a Swarming test manually with:
 
-1. Grab tests from x20:
-   `x20/teams/android-graphics-tools/agi/kokoro/swarming`. Copy the `tests`
-   folder under `test/swarming/`.
+1. Grab tests from x20: `x20/teams/android-graphics-tools/agi/kokoro/swarming`.
+   Copy the `tests` folder under `test/swarming/`. For instance, a "foobar" test
+   folder (typically containing an APK and a `params.json` file) should be under
+   `test/swarming/tests/foobar`.
 
 2. Use `./manual-run.sh tests/foobar` to trigger the foobar test in Swarming and
    collect its results.
@@ -68,12 +72,12 @@ the name of the script to use, this script being found under
 `test/swarming/bot-scripts`. Moreover, this JSON typically defines additional
 parameters used by the test script.
 
-As an example, this is a possible params.json file to use the `test/swarming/bot-scripts/benchmark.py`
-script:
+As an example, this is a possible `params.json` file to use the
+`test/swarming/bot-scripts/video.py` script:
 
 ```
 {
-  "script": "benchmark.py",
+  "script": "video.py",
   "apk": "com.example.myApp.apk",
   "package": "com.example.myApp",
   "activity": "com.example.myApp.myActivity",
@@ -110,9 +114,9 @@ code. Some noteworthy parameters:
 ## Nightly results
 
 Nightly results are accumulated over nightly runs. To achieve this, the results
-file is receieved as a build input from the latest build on x20, new results are
-added to it, and the new results are produced as an artifact of the nightly
-build.
+are stored on x20, and used as both input and output of a given nightly run: a
+nightly run receives the exiting results as an input, adds their own results to
+it, and returns this as a result artifact that is stored on x20 again.
 
-The results are stored in the `results.json` file. The precise format of this
-JSON is defined in `test/swarming/collect.py`.
+Results are stored in a `results.json` file. The precise format of this JSON is
+defined in `test/swarming/collect.py`.

--- a/test/swarming/bot-scripts/botutil.py
+++ b/test/swarming/bot-scripts/botutil.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This is a  library of utilies for Swarming bot scripts
+# This is a library of utilies for Swarming bot scripts
 
 import json
 import os
@@ -72,7 +72,7 @@ class BotUtil:
         self.gapit_path = ''
 
     def adb(self, args, timeout=1):
-        '''Log and run an ADB command, r_patheturning a subprocess.CompletedProcess with output captured'''
+        '''Log and run an ADB command, returning a subprocess.CompletedProcess with output captured'''
         cmd = [self.adb_path] + args
         print('ADB command: ' + ' '.join(cmd), flush=True)
         return subprocess.run(cmd, timeout=timeout, check=True, capture_output=True, text=True)

--- a/test/swarming/bot-scripts/debug.py
+++ b/test/swarming/bot-scripts/debug.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This Swarming bot test script is a basis to run short debug tasks.
+
+import argparse
+import botutil
+import json
+import os
+import subprocess
+import sys
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('adb_path', help='Path to adb command')
+    parser.add_argument('agi_dir', help='Path to AGI build')
+    parser.add_argument('out_dir', help='Path to output directory')
+    args = parser.parse_args()
+
+    #### Early checks and sanitization
+    assert os.path.isfile(args.adb_path)
+    adb_path = os.path.abspath(args.adb_path)
+    assert os.path.isdir(args.agi_dir)
+    agi_dir = os.path.abspath(args.agi_dir)
+    assert os.path.isdir(args.out_dir)
+    out_dir = os.path.abspath(args.out_dir)
+    gapit_path = os.path.join(agi_dir, 'gapit')
+
+    #### Create BotUtil with relevant adb and gapit paths
+    bu = botutil.BotUtil(adb_path)
+    bu.set_gapit_path(gapit_path)
+
+    #### Test parameters
+    test_params = {}
+    botutil.load_params(test_params)
+
+    #### Here add your debug experiments
+    # For instance, list packages installed on the device:
+    botutil.runcmd(['adb', 'shell', 'pm', 'list', 'packages'])
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/test/swarming/bot-scripts/video.py
+++ b/test/swarming/bot-scripts/video.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This Swarming bot test script uses gapit to perform a capture-replay test,
-# checking whether the replay output matches the app frames.
+# This Swarming bot test script uses gapit to perform various tests on a given
+# workload.
 
 import argparse
 import botutil
@@ -96,6 +96,13 @@ def main():
         return p.returncode
 
     #### Screenshot test to retrieve mid-frame resources
+    # This is meant to test the command buffer splitter, which is invoked to be
+    # able to retrieve the framebuffer in the middle of a render pass. We ask
+    # for the framebuffer at the 5th draw call, this number was choosen because:
+    # it is low enough to be present in most frames (i.e. we expect frames to
+    # have at least 5 draw calls), and it hopefully falls in the middle of a
+    # renderpass. Also, we don't want to have a random number here, as we want
+    # to keep the tests as reproducible as feasible.
     screenshotfile = os.path.join(out_dir, test_params['package'] + '.png')
     gapit_args = [
         '-executeddraws', '5',


### PR DESCRIPTION
The new debug.py script is meant to be used as a basis when running
one-off swarming tasks to diagnose failures.

Bug: n/a
Test: manual runs of debub.py on Swarming bots