### PR TITLE
Revert "Properly implement VK_KHR_shader_float_controls."

### DIFF
--- a/gapis/api/vulkan/api/device.api
+++ b/gapis/api/vulkan/api/device.api
@@ -67,8 +67,6 @@
   @unused ref!PhysicalDeviceShaderClockFeaturesKHR PhysicalDeviceShaderClockFeaturesKHR
   @unused ref!PhysicalDeviceVulkanMemoryModelFeaturesKHR PhysicalDeviceVulkanMemoryModelFeaturesKHR
   @unused ref!PhysicalDeviceShaderFloat16Int8FeaturesKHR PhysicalDeviceShaderFloat16Int8FeaturesKHR
-  @unused ref!PhysicalDeviceFloatControlsPropertiesKHR PhysicalDeviceFloatControlsPropertiesKHR
-
   // @extension("VK_EXT_line_rasterization")
   @unused ref!PhysicalDeviceLineRasterizationFeaturesEXT PhysicalDeviceLineRasterizationFeaturesEXT
 
@@ -244,28 +242,6 @@ sub ref!DeviceObject createDeviceObject(const VkDeviceCreateInfo* data) {
             VulkanMemoryModel: ext.vulkanMemoryModel,
             VulkanMemoryModelDeviceScope: ext.vulkanMemoryModelDeviceScope,
             VulkanMemoryModelAvailabilityVisibilityChains: ext.vulkanMemoryModelAvailabilityVisibilityChains,
-          )
-        }
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES_KHR :{
-          ext := as!VkPhysicalDeviceFloatControlsPropertiesKHR*(next.Ptr)[0]
-          object.PhysicalDeviceFloatControlsPropertiesKHR = new!PhysicalDeviceFloatControlsPropertiesKHR(
-            DenormBehaviorIndependence: ext.denormBehaviorIndependence,
-            RoundingModeIndependence: ext.roundingModeIndependence,
-            ShaderSignedZeroInfNanPreserveFloat16: ext.shaderSignedZeroInfNanPreserveFloat16,
-            ShaderSignedZeroInfNanPreserveFloat32: ext.shaderSignedZeroInfNanPreserveFloat32,
-            ShaderSignedZeroInfNanPreserveFloat64: ext.shaderSignedZeroInfNanPreserveFloat64,
-            ShaderDenormPreserveFloat16: ext.shaderDenormPreserveFloat16,
-            ShaderDenormPreserveFloat32: ext.shaderDenormPreserveFloat32,
-            ShaderDenormPreserveFloat64: ext.shaderDenormPreserveFloat64,
-            ShaderDenormFlushToZeroFloat16: ext.shaderDenormFlushToZeroFloat16,
-            ShaderDenormFlushToZeroFloat32: ext.shaderDenormFlushToZeroFloat32,
-            ShaderDenormFlushToZeroFloat64: ext.shaderDenormFlushToZeroFloat64,
-            ShaderRoundingModeRTEFloat16: ext.shaderRoundingModeRTEFloat16,
-            ShaderRoundingModeRTEFloat32: ext.shaderRoundingModeRTEFloat32,
-            ShaderRoundingModeRTEFloat64: ext.shaderRoundingModeRTEFloat64,
-            ShaderRoundingModeRTZFloat16: ext.shaderRoundingModeRTZFloat16,
-            ShaderRoundingModeRTZFloat32: ext.shaderRoundingModeRTZFloat32,
-            ShaderRoundingModeRTZFloat64: ext.shaderRoundingModeRTZFloat64,
           )
         }
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES_KHR: {

--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -839,31 +839,6 @@ func (sb *stateBuilder) createDevice(d DeviceObjectʳ) {
 			),
 		).Ptr())
 	}
-	if !d.PhysicalDeviceFloatControlsPropertiesKHR().IsNil() {
-		pNext = NewVoidᵖ(sb.MustAllocReadData(
-			NewVkPhysicalDeviceFloatControlsPropertiesKHR(
-				VkStructureType_VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES_KHR, // sType
-				pNext, // pNext
-				d.PhysicalDeviceFloatControlsPropertiesKHR().DenormBehaviorIndependence(),            // denormBehaviorIndependence
-				d.PhysicalDeviceFloatControlsPropertiesKHR().RoundingModeIndependence(),              // roundingModeIndependence
-				d.PhysicalDeviceFloatControlsPropertiesKHR().ShaderSignedZeroInfNanPreserveFloat16(), // shaderSignedZeroInfNanPreserveFloat16
-				d.PhysicalDeviceFloatControlsPropertiesKHR().ShaderSignedZeroInfNanPreserveFloat32(), // shaderSignedZeroInfNanPreserveFloat32
-				d.PhysicalDeviceFloatControlsPropertiesKHR().ShaderSignedZeroInfNanPreserveFloat64(), // shaderSignedZeroInfNanPreserveFloat64
-				d.PhysicalDeviceFloatControlsPropertiesKHR().ShaderDenormPreserveFloat16(),           // shaderDenormPreserveFloat16
-				d.PhysicalDeviceFloatControlsPropertiesKHR().ShaderDenormPreserveFloat32(),           // shaderDenormPreserveFloat32
-				d.PhysicalDeviceFloatControlsPropertiesKHR().ShaderDenormPreserveFloat64(),           // shaderDenormPreserveFloat64
-				d.PhysicalDeviceFloatControlsPropertiesKHR().ShaderDenormFlushToZeroFloat16(),        // shaderDenormFlushToZeroFloat16
-				d.PhysicalDeviceFloatControlsPropertiesKHR().ShaderDenormFlushToZeroFloat32(),        // shaderDenormFlushToZeroFloat32
-				d.PhysicalDeviceFloatControlsPropertiesKHR().ShaderDenormFlushToZeroFloat64(),        // shaderDenormFlushToZeroFloat64
-				d.PhysicalDeviceFloatControlsPropertiesKHR().ShaderRoundingModeRTEFloat16(),          // shaderRoundingModeRTEFloat16
-				d.PhysicalDeviceFloatControlsPropertiesKHR().ShaderRoundingModeRTEFloat32(),          // shaderRoundingModeRTEFloat32
-				d.PhysicalDeviceFloatControlsPropertiesKHR().ShaderRoundingModeRTEFloat64(),          // shaderRoundingModeRTEFloat64
-				d.PhysicalDeviceFloatControlsPropertiesKHR().ShaderRoundingModeRTZFloat16(),          // shaderRoundingModeRTZFloat16
-				d.PhysicalDeviceFloatControlsPropertiesKHR().ShaderRoundingModeRTZFloat32(),          // shaderRoundingModeRTZFloat32
-				d.PhysicalDeviceFloatControlsPropertiesKHR().ShaderRoundingModeRTZFloat64(),          // shaderRoundingModeRTZFloat64
-			),
-		).Ptr())
-	}
 	if !d.PhysicalDeviceVertexAttributeDivisorFeaturesEXT().IsNil() {
 		pNext = NewVoidᵖ(sb.MustAllocReadData(
 			NewVkPhysicalDeviceVertexAttributeDivisorFeaturesEXT(


### PR DESCRIPTION
This reverts commit 201f4d7bf879db76f6e665f16b263bb8b5dc6b97.

VkPhysicalDeviceFloatControlsPropertiesKHR does not exists in VkCreateDevice's valid pNext structure list.

This is the case for any Properties(KHR/EXT) structure. I believe this is not true.

https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceCreateInfo.html