### PR TITLE
Fix VK_EXT_line_rasterization support

### DIFF
--- a/gapis/api/vulkan/api/draw_commands.api
+++ b/gapis/api/vulkan/api/draw_commands.api
@@ -520,8 +520,8 @@ sub void readDrawState() {
     _ = dyn.LineStippleFactor
     _ = dyn.LineStipplePattern
   } else {
-    _ = pipeline.RasterizationState.LineStippleFactor
-    _ = pipeline.RasterizationState.LineStipplePattern
+    _ = pipeline.RasterizationState.PipelineRasterizationLineStateCreateInfoEXT.LineStippleFactor
+    _ = pipeline.RasterizationState.PipelineRasterizationLineStateCreateInfoEXT.LineStipplePattern
   }
 
   // read depth bias

--- a/gapis/api/vulkan/api/draw_commands.api
+++ b/gapis/api/vulkan/api/draw_commands.api
@@ -519,7 +519,7 @@ sub void readDrawState() {
   if hasDynamicState(pipeline, VK_DYNAMIC_STATE_LINE_STIPPLE_EXT) {
     _ = dyn.LineStippleFactor
     _ = dyn.LineStipplePattern
-  } else {
+  } else if pipeline.RasterizationState.PipelineRasterizationLineStateCreateInfoEXT != null {
     _ = pipeline.RasterizationState.PipelineRasterizationLineStateCreateInfoEXT.LineStippleFactor
     _ = pipeline.RasterizationState.PipelineRasterizationLineStateCreateInfoEXT.LineStipplePattern
   }

--- a/gapis/api/vulkan/api/pipeline.api
+++ b/gapis/api/vulkan/api/pipeline.api
@@ -146,10 +146,7 @@ cmd void vkDestroyPipelineLayout(
   @unused f32             LineWidth
 
   // @extension("VK_EXT_line_rasterization")
-  @unused VkLineRasterizationModeEXT LineRasterizationMode
-  @unused VkBool32                   StippledLineEnable
-  @unused u32                        LineStippleFactor
-  @unused u16                        LineStipplePattern
+  @unsued ref!PipelineRasterizationLineStateCreateInfoEXT PipelineRasterizationLineStateCreateInfoEXT
 
   // @extension("VK_EXT_provoking_vertex")
   @unused ref!PipelineRasterizationProvokingVertexStateCreateInfoEXT PipelineRasterizationProvokingVertexStateCreateInfoEXT
@@ -511,10 +508,12 @@ cmd VkResult vkCreateGraphicsPipelines(
         switch (sType) {
           case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_LINE_STATE_CREATE_INFO_EXT: {
             ext := as!VkPipelineRasterizationLineStateCreateInfoEXT*(next.Ptr)[0]
-            obj.RasterizationState.LineRasterizationMode = ext.lineRasterizationMode
-            obj.RasterizationState.StippledLineEnable = ext.stippledLineEnable
-            obj.RasterizationState.LineStippleFactor = ext.lineStippleFactor
-            obj.RasterizationState.LineStipplePattern = ext.lineStipplePattern
+            obj.RasterizationState.PipelineRasterizationLineStateCreateInfoEXT = new!PipelineRasterizationLineStateCreateInfoEXT(
+              LineRasterizationMode: ext.lineRasterizationMode,
+              StippledLineEnable: ext.stippledLineEnable,
+              LineStippleFactor: ext.lineStippleFactor,
+              LineStipplePattern: ext.lineStipplePattern,
+            )
           }
           case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_PROVOKING_VERTEX_STATE_CREATE_INFO_EXT: {
             ext := as!VkPipelineRasterizationProvokingVertexStateCreateInfoEXT*(next.Ptr)[0]

--- a/gapis/api/vulkan/extensions/ext_line_rasterization.api
+++ b/gapis/api/vulkan/extensions/ext_line_rasterization.api
@@ -105,6 +105,14 @@ class VkPipelineRasterizationLineStateCreateInfoEXT {
   u16                        lineStipplePattern
 }
 
+@internal
+class PipelineRasterizationLineStateCreateInfoEXT {
+  VkLineRasterizationModeEXT LineRasterizationMode
+  VkBool32                   StippledLineEnable
+  u32                        LineStippleFactor
+  u16                        LineStipplePattern
+}
+
 //////////////
 // Commands //
 //////////////

--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -2659,6 +2659,18 @@ func (sb *stateBuilder) createGraphicsPipeline(gp GraphicsPipelineObjectʳ) {
 				),
 			).Ptr())
 		}
+		if !gp.RasterizationState().PipelineRasterizationLineStateCreateInfoEXT().IsNil() {
+			pNext = NewVoidᶜᵖ(sb.MustAllocReadData(
+				NewVkPipelineRasterizationLineStateCreateInfoEXT(
+					VkStructureType_VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_LINE_STATE_CREATE_INFO_EXT,
+					pNext,
+					gp.RasterizationState().PipelineRasterizationLineStateCreateInfoEXT().LineRasterizationMode(),
+					gp.RasterizationState().PipelineRasterizationLineStateCreateInfoEXT().StippledLineEnable(),
+					gp.RasterizationState().PipelineRasterizationLineStateCreateInfoEXT().LineStippleFactor(),
+					gp.RasterizationState().PipelineRasterizationLineStateCreateInfoEXT().LineStipplePattern(),
+				),
+			).Ptr())
+		}
 		rasterizationState = NewVkPipelineRasterizationStateCreateInfoᶜᵖ(sb.MustAllocReadData(
 			NewVkPipelineRasterizationStateCreateInfo(
 				VkStructureType_VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO, // sType


### PR DESCRIPTION
This change makes sure to add the relevant VK_EXT_line_rasterization
info when re-creating graphics pipelines in the state rebuilder. Also,
the info related to this extension is now stored in a separate
PipelineRasterizationLineStateCreateInfoEXT class, which is used as a
member in the graphics pipeline's RasterizationState (whereas before,
all VK_EXT_line_rasterization-related filed were direct members of
RasterizationState).

Bug: b/194180484