### PR TITLE
Update Mali counters for both JM and CSF

### DIFF
--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -80,11 +80,11 @@ type androidTracer struct {
 }
 
 func newValidator(dev bind.Device) validate.Validator {
-	gpu := dev.Instance().GetConfiguration().GetHardware().GetGPU()
-	if strings.Contains(gpu.GetName(), "Adreno") {
+	gpuName := dev.Instance().GetConfiguration().GetHardware().GetGPU().GetName()
+	if strings.Contains(gpuName, "Adreno") {
 		return &adreno.AdrenoValidator{}
-	} else if strings.Contains(gpu.GetName(), "Mali") {
-		return &mali.MaliValidator{}
+	} else if strings.Contains(gpuName, "Mali") {
+		return mali.NewMaliValidator(gpuName)
 	}
 	return nil
 }


### PR DESCRIPTION
There is a notable change in Mali GPUs introducing CSF, which replace
the previous JM based Mali GPUs.

But CSF GPUs have different hardware counters so they do not have exact
match with previous JM GPUs.

So GPU profiling devices validation fails on Mali CSF GPUs as follows.
```
  $ ./gapit validate_gpu_profiling
        ...
  Failed to validate device
     Cause: Internal error: Check failed for counter: {6 GPU active cycles 0x101df60}
```
This patch updates Mali counters into two set of counters, one for JM
and other other for CSF.

Then the device is distinguished based on the product name. The list of
JM GPUs are Mali-G31, Mali-G51, Mali-G52, Mali-G71, Mali-G72, Mali-G76,
Mali-G57, Mali-G68, Mali-G77, Mali-G78, and Mali-G78AE.

Future Mali GPUs are expected to be CSF based.