### PR TITLE
Add support for vkGetDeviceQueue2

### DIFF
--- a/gapii/cc/spy_base.cpp
+++ b/gapii/cc/spy_base.cpp
@@ -24,7 +24,7 @@
 
 // CurrentCaptureVersion is incremented on breaking changes to the capture
 // format. NB: Also update equally named field in gapis/capture/grahics.go
-static const int CurrentCaptureVersion = 3;
+static const int CurrentCaptureVersion = 4;
 
 using core::Interval;
 

--- a/gapis/api/vulkan/api/queue.api
+++ b/gapis/api/vulkan/api/queue.api
@@ -44,6 +44,7 @@
   @unused VkDevice                                               Device
   @unused u32                                                    Family
   @unused u32                                                    Index
+  @unused VkDeviceQueueCreateFlags                               Flags
   @unused VkQueue                                                VulkanHandle
   map!(VkEvent, ref!EventObject)                                 PendingEvents
   map!(VkSemaphore, ref!SemaphoreObject)                         PendingSemaphores
@@ -76,6 +77,30 @@ cmd void vkGetDeviceQueue(
     dev := Devices[device]
     dev.QueueObjects[len(dev.QueueObjects)] = Queues[id]
     _ = PhysicalDevices[dev.PhysicalDevice].QueueFamilyProperties[queueFamilyIndex]
+  }
+  if pQueue == null { vkErrorNullPointer("VkQueue") }
+  pQueue[0] = id
+}
+
+@since("1.1")
+@indirect("VkDevice")
+cmd void vkGetDeviceQueue2(
+    VkDevice                  device,
+    const VkDeviceQueueInfo2* pQueueInfo,
+    VkQueue*                  pQueue) {
+  if !(device in Devices) { vkErrorInvalidDevice(device) }
+  info := pQueueInfo[0]
+  id := ?
+  if !(id in Queues) {
+    Queues[id] = new!QueueObject(
+      Device: device,
+      Family: info.queueFamilyIndex,
+      Index:  info.queueIndex,
+      Flags:  info.flags,
+      VulkanHandle:  id)
+    dev := Devices[device]
+    dev.QueueObjects[len(dev.QueueObjects)] = Queues[id]
+    _ = PhysicalDevices[dev.PhysicalDevice].QueueFamilyProperties[info.queueFamilyIndex]
   }
   if pQueue == null { vkErrorNullPointer("VkQueue") }
   pQueue[0] = id

--- a/gapis/capture/graphics.go
+++ b/gapis/capture/graphics.go
@@ -40,7 +40,7 @@ import (
 const (
 	// CurrentCaptureVersion is incremented on breaking changes to the capture format.
 	// NB: Also update equally named field in gapii/cc/spy_base.cpp
-	CurrentCaptureVersion int32 = 3
+	CurrentCaptureVersion int32 = 4
 )
 
 type ErrUnsupportedVersion struct{ Version int32 }


### PR DESCRIPTION
Add the command in GAPIL, and also use it in state rebuilding.

Bug: b/194480392
Test: capture an ANGLE trace replay doesn't crash anymore