### PR TITLE
cmd/gofuse update for Windows.

### DIFF
--- a/DEVDOC.md
+++ b/DEVDOC.md
@@ -36,7 +36,10 @@ With the above setup, you can run presubmit tests locally with:
 This project contains Go code, but it does not have the file hierarchy of
 regular Go projects (this is due to the use of Bazel as a build system).
 The `cmd/gofuse` utility enables to re-create the file hierarchy expected by Go
-tools:
+tools. Note, however, `cmd/gofuse` is not supported on Windows, but it is not
+required to build/develop AGI either. The steps described here are optional and
+are only intended to facilitate working on the AGI codebase using an IDE or
+other Go tooling.
 
 ```sh
 # Make sure to build to have all compile-time generated files
@@ -63,11 +66,6 @@ bazel build pkg
 export GOPATH="${GOPATH:+${GOPATH}:}<path-to-agi-gofuse>"
 # On other configurations, please search online how to add/edit environment variables.
 ```
-
-If you encounter a symlink error on Windows like 'a required privilege is not held by the client',
-you have to use a command prompt with administrator privileges or enable
-[Developer Mode](https://docs.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development)
-as described [here](https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/).
 
 After adding the gofuse directory to your GOPATH, Go tools should work as
 expected. You can edit files under the newly populated gofuse directory. You

--- a/DEVDOC.md
+++ b/DEVDOC.md
@@ -31,10 +31,10 @@ With the above setup, you can run presubmit tests locally with:
 ./kokoro/presubmit/presubmit.sh
 ```
 
-## Setup Golang development
+## Setup Go development
 
-This project contains Golang code, but it does not have the file hierarchy of
-regular Golang projects (this is due to the use of Bazel as a build system).
+This project contains Go code, but it does not have the file hierarchy of
+regular Go projects (this is due to the use of Bazel as a build system).
 The `cmd/gofuse` utility enables to re-create the file hierarchy expected by Go
 tools:
 
@@ -85,9 +85,9 @@ With the GOPATH setup to gofuse and opening the `<path-to-agi-gofuse>` directory
 as the root of your workspace, you should get some jump-to-definition and autocomplete
 features working. Make sure to edit the files through their link found under the gofuse directory.
 
-## How to debug / breakpoint in Golang code
+## How to debug / breakpoint in Go code
 
-The recommended Golang debugger is
+The recommended Go debugger is
 [delve](https://github.com/go-delve/delve). You can start a **debug** build of
 gapis or a client under this debugger. To build in debug mode, use the `-c dbg`
 Bazel flag, e.g.:
@@ -192,13 +192,13 @@ See the workaround for VSCode below, any help to fix it for other IDEs is very w
 
 Follow these steps to use the delve debugger for Go with VSCode to debug `gapis`.
 
-1. Make sure to complete the Golang setup above for AGI.
+1. Make sure to complete the Go setup above for AGI.
 
 2. Settings file: There are two settings file(`settings.json`) that can be written.
-	- Global one that applies to all projects that can be opened with `Ctrl + Shift + P` and `Preferences: Open Settings (JSON)`. 
+	- Global one that applies to all projects that can be opened with `Ctrl + Shift + P` and `Preferences: Open Settings (JSON)`.
 	Add this line to ensure that you have a stable tools directory:
 	`"go.toolsGopath": "<path-to-go-plugin-tools-folder>",`
-	
+
 	- Local one is under `.vscode` folder in your project folder. Create one if it does not already exist and add this line to your local settings to be able to search source code in AGI:
 	`"go.gopath": "<path-to-agi-gofuse>"`,
 
@@ -254,7 +254,7 @@ This allows you to put breakpoint at any line in AGI Go source code regardless i
 
 You can use the built-in logging functions to place debug prints.
 
-In Golang:
+In Go:
 
 ```go
 import (
@@ -380,7 +380,7 @@ bazel test tests
 bazel test //core/log:go_default_test
 ```
 
-### Golang
+### Go
 
 Following the [regular Go test](https://golang.org/doc/code.html#Testing) setup,
 tests are written as `func TestXXX(t *testing.T)` functions in `*_test.go`

--- a/cmd/gofuse/main.go
+++ b/cmd/gofuse/main.go
@@ -62,6 +62,8 @@ var (
 
 	bazelOutDirectory = flag.String("bazelout", "",
 		"The bazel-out/X directory name from which to include .go files. E.g. k8-fastbuild, darwin-fastbuild, k8-dbg, etc.")
+
+	runOnWindows = flag.Bool("force-run-on-windows", false, "Don't fail to run on Windows, even though it's unsupported.")
 )
 
 func main() {
@@ -74,6 +76,9 @@ func main() {
 }
 
 func run() error {
+	if runtime.GOOS == "windows" && !*runOnWindows {
+		return fmt.Errorf("cmd/gofuse is not supported on Windows")
+	}
 
 	if len(*bazelOutDirectory) == 0 {
 		switch runtime.GOOS {


### PR DESCRIPTION
 - Refuse to run on Windows, unless specifically instructed via a flag.
 - Don't advice people to run bazel as an administrator on Windows.
 - Point out that cmd/gofuse is not required for development.