### PR TITLE
Add a --size flag for `gapit screenshot`.

### DIFF
--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -380,7 +380,8 @@ type (
 		Max           struct {
 			Overdraw int `help:"the amount of overdraw to map to white in the output"`
 		}
-		DisplayToSurface bool `help:"display the frames rendered in the replay back to the surface"`
+		Size             string `help:"requested framebuffer size (scales output). Either a single integer used as width and height, or <w>x<h>"`
+		DisplayToSurface bool   `help:"display the frames rendered in the replay back to the surface"`
 		CommandFilterFlags
 		CaptureFileFlags
 	}


### PR DESCRIPTION
The size flag can be used to provide the requested width and height in the replay request.