### PR TITLE
Increase timeout waiting for FTrace ready

### DIFF
--- a/gapis/perfetto/android/trace.go
+++ b/gapis/perfetto/android/trace.go
@@ -315,8 +315,8 @@ func (p *Process) captureWithClientApi(ctx context.Context, start task.Signal, s
 				}
 				cnt += 1
 
-				// Give up after 1000 tries
-				if cnt == 1000 {
+				// Give up after 5000 tries
+				if cnt == 5000 {
 					timeout = true
 					sessionReadyFunc(ctx)
 					break


### PR DESCRIPTION
Content Analysis are seeing some timeouts waiting for FTrace to be ready
when making perfetto system profiles. This increases the timeout to see
if timeout duration is the issue. If the problem persists I will investigate
what else might be going on here and reevaluate rolling the timeout back.