### PR TITLE
Avoid clearing screen when selecting a different draw call

### DIFF
--- a/gapic/src/main/com/google/gapid/views/FramebufferView.java
+++ b/gapic/src/main/com/google/gapid/views/FramebufferView.java
@@ -354,6 +354,10 @@ public class FramebufferView extends Composite
         image.dispose();
       }
     }
+
+    public boolean isImageReady() {
+      return (image != null && image.hasFinished());
+    }
   }
 
   private static class AttachmentPicker extends Composite implements LoadingIndicator.Repaintable {
@@ -511,8 +515,11 @@ public class FramebufferView extends Composite
 
         image.setImage(attachment.getImage(widgets, this, this));
         label.setText(attachment.label);
-        image.requestLayout();
         label.requestLayout();
+        // Skip 'loading' image layout changes until attachment selection image is available
+        if (attachment.isImageReady()) {
+          image.requestLayout();
+        }
       }
     }
 


### PR DESCRIPTION
When selecting a new draw call in AGI, the framebuffer view panel clears and the image is replaced by a 'loading' image, and is eventually replaced with the image created by the newly-selected draw call.  This PR will, for framebuffer views only, skip the clear and loading image, so that the new image is rendered directly on top of the old one and making it easer to see what has changed.

The second commit skips the layout changes for the attachment selection control until the image has loaded. This prevents the framebuffer image from jumping around within the panel, again facilitating the ability to discern draw call results.

Fixes #900
Internal bug b/195041011