### PR TITLE
ABI by name lookup fixes.

### DIFF
--- a/core/os/android/adb/device.go
+++ b/core/os/android/adb/device.go
@@ -223,7 +223,7 @@ func newDevice(ctx context.Context, serial string, status bind.Status) (*binding
 			if seen[abi] {
 				continue
 			}
-			d.To.Configuration.ABIs = append(d.To.Configuration.ABIs, device.ABIByName(abi))
+			d.To.Configuration.ABIs = append(d.To.Configuration.ABIs, device.AndroidABIByName(abi))
 			seen[abi] = true
 		}
 	}

--- a/core/os/android/adb/installed_package.go
+++ b/core/os/android/adb/installed_package.go
@@ -177,7 +177,7 @@ func (b *binding) parsePackages(str string) (android.InstalledPackages, error) {
 					if splits[1] == "null" {
 						break // This means the package manager will select the platform ABI
 					}
-					ip.ABI = device.ABIByName(splits[1])
+					ip.ABI = device.AndroidABIByName(splits[1])
 				}
 			}
 		}

--- a/core/os/android/apk/apk.go
+++ b/core/os/android/apk/apk.go
@@ -85,7 +85,7 @@ func GatherABIs(files []*zip.File) []*device.ABI {
 		if len(parts) >= 2 && parts[0] == "lib" {
 			abiName := parts[1]
 			if _, existing := seen[abiName]; !existing {
-				abis = append(abis, device.ABIByName(abiName))
+				abis = append(abis, device.AndroidABIByName(abiName))
 				seen[abiName] = struct{}{}
 			}
 		}

--- a/core/os/device/abi.go
+++ b/core/os/device/abi.go
@@ -34,8 +34,10 @@ var (
 	WindowsX86_64 = abi("windows_x64", Windows, X86_64, Little64)
 )
 
-var abiByName = map[string]*ABI{}
+var androidAbiByName = map[string]*ABI{}
 
+// abi is the private helper constructor used by the constants above. It also
+// registers the Android ABIs in a map for AndroidABIByName.
 func abi(name string, os OSKind, arch Architecture, ml *MemoryLayout) *ABI {
 	abi := &ABI{
 		Name:         name,
@@ -43,15 +45,21 @@ func abi(name string, os OSKind, arch Architecture, ml *MemoryLayout) *ABI {
 		Architecture: arch,
 		MemoryLayout: ml,
 	}
-	abiByName[name] = abi
+
+	if os == Android {
+		if _, ok := androidAbiByName[name]; ok {
+			panic("Duplicate Android ABI name: " + name)
+		}
+		androidAbiByName[name] = abi
+	}
 	return abi
 }
 
-// ABIByName returns the ABI that matches the provided human name.
+// AndroidABIByName returns the Android ABI that matches the provided human name.
 // If there is no standard ABI that matches the name, then the returned ABI will have an UnknownOS and
 // UnknownArchitecture.
-func ABIByName(name string) *ABI {
-	abi, ok := abiByName[name]
+func AndroidABIByName(name string) *ABI {
+	abi, ok := androidAbiByName[name]
 	if !ok {
 		abi = &ABI{
 			Name:         name,

--- a/core/os/device/abi_test.go
+++ b/core/os/device/abi_test.go
@@ -21,9 +21,9 @@ import (
 	"github.com/google/gapid/core/os/device"
 )
 
-func TestABIByName(t *testing.T) {
+func TestAndroidABIByName(t *testing.T) {
 	assert := assert.To(t)
-	abi := device.ABIByName("invalid")
+	abi := device.AndroidABIByName("invalid")
 	assert.For("ABI.Name").That(abi.Name).Equals("invalid")
 	assert.For("ABI.Architecture").That(abi.Architecture).Equals(device.UnknownArchitecture)
 	assert.For("ABI.OS").That(abi.OS).Equals(device.UnknownOS)

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -607,7 +607,7 @@ func (t *androidTracer) SetupTrace(ctx context.Context, o *service.TraceOptions)
 	match := re.FindStringSubmatch(o.GetUri())
 
 	if len(match) == 3 {
-		process, err := gapii.Connect(ctx, t.b, device.ABIByName(match[2]), match[1], tracer.GapiiOptions(o))
+		process, err := gapii.Connect(ctx, t.b, device.AndroidABIByName(match[2]), match[1], tracer.GapiiOptions(o))
 		if err != nil {
 			return ret, cleanup.Invoke(ctx), err
 		}


### PR DESCRIPTION
Currently the ABIs' names need to be unique, because we lookup ABIs by name. However, this lookup is only done in the Android parsing code, so we can loosen this restriction to only require unique names for the Android ABIs. This change also adds an init check to ensure the Android ABI names are unique. This check would fail at build time, as we use this during the codegen step.