### PR TITLE
Fixes for tracing to a file on the device

### DIFF
--- a/gapis/perfetto/android/trace.go
+++ b/gapis/perfetto/android/trace.go
@@ -190,6 +190,12 @@ func Start(ctx context.Context, d adb.Device, a *android.ActivityAction, opts *s
 		return nil, cleanup.Invoke(ctx), err
 	}
 
+	// Remove any left over trace files, as, if tracing to a file on the device is
+	// requested, Perfetto would fail if the file already exists.
+	if err := d.RemoveFile(ctx, perfettoTraceFile); err != nil {
+		log.E(ctx, "Failed to delete previous perfetto trace file %v", err)
+	}
+
 	caps := d.Instance().GetConfiguration().GetPerfettoCapability()
 	var mode traceMode
 	if opts.PerfettoConfig.GetWriteIntoFile() {

--- a/gapis/perfetto/client.go
+++ b/gapis/perfetto/client.go
@@ -137,6 +137,9 @@ func (c *Client) Trace(ctx context.Context, cfg *config.TraceConfig, out io.Writ
 	}
 
 	h := client.NewTraceHandler(ctx, func(r *ipc.EnableTracingResponse, err error) {
+		if err == nil && r.GetError() != "" {
+			err = errors.New(r.GetError())
+		}
 		if !s.onResult(ctx, err) {
 			if s.read == nil {
 				s.done(ctx)


### PR DESCRIPTION
- Don't ignore errors communicated by the Perfetto API during trace setup.
- Don't ignore errors or session exits, while waiting for ftrace to come up.
- Clean up left over trace files as that would make Perfetto refuse to trace.

Bug: http://b/194955623