### PR TITLE
Shader UI Polish

### DIFF
--- a/gapic/src/main/com/google/gapid/views/PipelineView.java
+++ b/gapic/src/main/com/google/gapid/views/PipelineView.java
@@ -531,7 +531,8 @@ public class PipelineView extends Composite
           ShaderView.ShaderWidget shaderView = withLayoutData(
               new ShaderView.ShaderWidget(dataComposite, false, models, widgets),
               new GridData(SWT.FILL, SWT.FILL, true, true));
-          shaderView.setShader(null, dataGroup.getShader());
+          Resources.Resource res = models.resources.getResource(dataGroup.getResource());
+          shaderView.setShader((res == null) ? null : res.resource, dataGroup.getShader());
           break;
 
         case DATA_NOT_SET:

--- a/gapic/src/main/com/google/gapid/views/ShaderView.java
+++ b/gapic/src/main/com/google/gapid/views/ShaderView.java
@@ -318,7 +318,7 @@ public class ShaderView extends Composite
       shaderMessage = shader;
 
       pushButton.ifPresent(b -> b.setEnabled(shaderResource != null));
-      shaderGroup.setText(shaderResource != null ? shaderResource.getHandle() : "Shader");
+      shaderGroup.setText(getLabel(resource));
       String spirvSource = shaderMessage.getSpirvSource();
       if (spirvSource.isEmpty()) {
         spirvSource = EMPTY_SHADER;
@@ -340,6 +340,17 @@ public class ShaderView extends Composite
       }
 
       statTable.setInput(shader.getStaticAnalysis());
+    }
+
+    private static String getLabel(Service.Resource resource) {
+      if (resource == null) {
+        return "Shader";
+      }
+      String label = resource.getHandle();
+      if (!resource.getLabel().isEmpty()) {
+        label += " " + resource.getLabel();
+      }
+      return label;
     }
 
     private static boolean isKey(Event e, int stateMask, int keyCode) {

--- a/gapic/src/main/com/google/gapid/views/ShaderView.java
+++ b/gapic/src/main/com/google/gapid/views/ShaderView.java
@@ -15,20 +15,18 @@
  */
 package com.google.gapid.views;
 
-import static com.google.gapid.util.Loadable.MessageType.Error;
 import static com.google.gapid.util.Loadable.MessageType.Info;
 import static com.google.gapid.widgets.Widgets.createBoldLabel;
+import static com.google.gapid.widgets.Widgets.createButton;
 import static com.google.gapid.widgets.Widgets.createComposite;
 import static com.google.gapid.widgets.Widgets.createGroup;
 import static com.google.gapid.widgets.Widgets.createLabel;
-import static com.google.gapid.widgets.Widgets.createLink;
 import static com.google.gapid.widgets.Widgets.createScrolledComposite;
 import static com.google.gapid.widgets.Widgets.createStandardTabFolder;
 import static com.google.gapid.widgets.Widgets.createStandardTabItem;
 import static com.google.gapid.widgets.Widgets.disposeAllChildren;
 import static com.google.gapid.widgets.Widgets.withLayoutData;
 
-import com.google.common.base.Joiner;
 import com.google.gapid.lang.glsl.GlslSourceConfiguration;
 import com.google.gapid.models.Analytics.View;
 import com.google.gapid.models.Capture;
@@ -37,7 +35,6 @@ import com.google.gapid.models.Resources;
 import com.google.gapid.proto.service.Service;
 import com.google.gapid.proto.service.Service.ClientAction;
 import com.google.gapid.proto.service.api.API;
-import com.google.gapid.proto.service.path.Path;
 import com.google.gapid.rpc.Rpc;
 import com.google.gapid.rpc.RpcException;
 import com.google.gapid.rpc.SingleInFlight;
@@ -46,7 +43,6 @@ import com.google.gapid.util.Experimental;
 import com.google.gapid.util.Loadable;
 import com.google.gapid.util.Messages;
 import com.google.gapid.widgets.LoadablePanel;
-import com.google.gapid.widgets.Theme;
 import com.google.gapid.widgets.Widgets;
 
 import org.eclipse.jface.text.ITextOperationTarget;
@@ -69,8 +65,6 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.TabFolder;
 import org.eclipse.swt.widgets.TabItem;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
@@ -81,105 +75,19 @@ import java.util.logging.Logger;
 public class ShaderView extends Composite
     implements Tab, Capture.Listener, Resources.Listener {
   protected static final Logger LOG = Logger.getLogger(ShaderView.class.getName());
-  private static final String EMPTY_SHADER =
-      "// No source attached to this shader at this point in the trace.";
 
-  protected final Models models;
-  protected final Theme theme;
-  private final SingleInFlight rpcController = new SingleInFlight();
-  private final LoadablePanel<Composite> loading;
-  private final TabFolder tabFolder;
-  private final Group spirvGroup;
-  private final Group sourceGroup;
-  private final Group statGroup;
-  private final Label crossCompileLabel;
-  private final GridData crossCompileGridData;
-  private final SourceViewer spirvViewer;
-  private final SourceViewer sourceViewer;
-  private final Optional<Button> pushButton;
-  private TabItem sourceTab;
+  private final Models models;
+  private final ShaderWidget shaderView;
+  private Service.Resource shaderResource = null;
 
-  protected Service.Resource shaderResource = null;
-  protected API.Shader shaderMessage = null;
-  protected boolean pinned = false;
+  private boolean pinned = false;
 
   public ShaderView(Composite parent, Models models, Widgets widgets) {
     super(parent, SWT.NONE);
     this.models = models;
-    this.theme = widgets.theme;
 
     setLayout(new FillLayout());
-
-    loading = LoadablePanel.create(this, widgets,
-        panel -> createComposite(panel, new GridLayout(1, false)));
-
-    tabFolder = createStandardTabFolder(loading.getContents());
-    tabFolder.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-
-    spirvGroup = createGroup(tabFolder, "");
-    spirvViewer =
-        new SourceViewer(spirvGroup, null, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER);
-    spirvViewer.setEditable(false);
-    spirvViewer.configure(new GlslSourceConfiguration(widgets.theme));
-    StyledText spirvTextWidget = spirvViewer.getTextWidget();
-    spirvTextWidget.setFont(widgets.theme.monoSpaceFont());
-    spirvTextWidget.setKeyBinding(ST.SELECT_ALL, ST.SELECT_ALL);
-    spirvTextWidget.addListener(SWT.KeyDown, e -> {
-      if (isKey(e, SWT.MOD1, 'z') && !isKey(e, SWT.MOD1 | SWT.SHIFT, 'z')) {
-        spirvViewer.doOperation(ITextOperationTarget.UNDO);
-      } else if (isKey(e, SWT.MOD1, 'y') || isKey(e, SWT.MOD1 | SWT.SHIFT, 'z')) {
-        spirvViewer.doOperation(ITextOperationTarget.REDO);
-      }
-    });
-    TabItem spirvTab = createStandardTabItem(tabFolder, "SPIR-V");
-    spirvTab.setControl(spirvGroup);
-
-    sourceGroup = createGroup(tabFolder, "", new GridLayout(1, false));
-    crossCompileGridData = new GridData(SWT.LEFT, SWT.TOP, false, false);
-    crossCompileLabel =
-        createBoldLabel(sourceGroup, "Source code was decompiled using SPIRV-Cross");
-    crossCompileLabel.setLayoutData(crossCompileGridData);
-    sourceViewer =
-        new SourceViewer(sourceGroup, null, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER);
-    sourceViewer.setEditable(false);
-    sourceViewer.configure(new GlslSourceConfiguration(widgets.theme));
-    sourceViewer.getControl().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-    StyledText sourceTextWidget = sourceViewer.getTextWidget();
-    sourceTextWidget.setFont(widgets.theme.monoSpaceFont());
-    sourceTextWidget.setKeyBinding(ST.SELECT_ALL, ST.SELECT_ALL);
-    sourceTextWidget.addListener(SWT.KeyDown, e -> {
-      if (isKey(e, SWT.MOD1, 'z') && !isKey(e, SWT.MOD1 | SWT.SHIFT, 'z')) {
-        sourceViewer.doOperation(ITextOperationTarget.UNDO);
-      } else if (isKey(e, SWT.MOD1, 'y') || isKey(e, SWT.MOD1 | SWT.SHIFT, 'z')) {
-        sourceViewer.doOperation(ITextOperationTarget.REDO);
-      }
-    });
-
-    // TODO(b/188434910): Shader editing is disabled as it doesn't work right
-    // now. Enable it once the issue is fixed.
-    if (!Experimental.enableUnstableFeatures(models.settings)) {
-      pushButton = Optional.empty();
-    } else {
-      pushButton = Optional.of(Widgets.createButton(loading.getContents(), "Push Changes", e -> {
-        if (shaderResource != null && shaderMessage != null) {
-          models.analytics.postInteraction(View.ShaderView, ClientAction.Edit);
-          models.resources.updateResource(shaderResource, API.ResourceData.newBuilder()
-              .setShader(shaderMessage.toBuilder().setSource(spirvViewer.getDocument().get()))
-              .build());
-        }
-      }));
-      pushButton.ifPresent(b -> {
-        b.setLayoutData(new GridData(SWT.RIGHT, SWT.BOTTOM, false, false));
-        b.setEnabled(false);
-      });
-      spirvViewer.setEditable(true);
-      sourceViewer.setEditable(true);
-    }
-
-    statGroup = Widgets.createGroup(loading.getContents(), "Static Analysis");
-    statGroup.setFont(theme.subTitleFont());
-    statGroup.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
-    statGroup.setLayout(new GridLayout(1, false));
+    shaderView = new ShaderWidget(this, models, widgets);
 
     models.capture.addListener(this);
     models.resources.addListener(this);
@@ -199,7 +107,7 @@ public class ShaderView extends Composite
     if (!models.capture.isLoaded()) {
       onCaptureLoadingStart(false);
     } else {
-      loadShader(models.resources.getSelectedShader());
+      shaderView.loadShader(models.resources.getSelectedShader());
     }
   }
 
@@ -225,171 +133,278 @@ public class ShaderView extends Composite
 
   @Override
   public void onCaptureLoadingStart(boolean maintainState) {
+    shaderView.clear();
     if (!pinned) {
-      loading.showMessage(Info, Messages.LOADING_CAPTURE);
+      shaderResource = null;
     }
-    clear();
   }
 
   @Override
   public void onCaptureLoaded(Loadable.Message error) {
-    if (!pinned && error != null) {
-      loading.showMessage(Error, Messages.CAPTURE_LOAD_FAILURE);
+    shaderView.clear();
+    if (!pinned) {
+      shaderResource = null;
     }
-    clear();
+
   }
 
   @Override
   public void onResourcesLoaded() {
+    shaderView.clear();
     if (!pinned) {
-      loading.showMessage(Info, Messages.SELECT_SHADER);
-      clear();
+      shaderResource = null;
     }
   }
 
   @Override
   public void onShaderSelected(Service.Resource shader) {
     if (!pinned) {
-      loadShader(shader);
+      shaderResource = shader;
+      shaderView.loadShader(shader);
     }
   }
 
-  public void setShader(API.Shader shader) {
-    loading.stopLoading();
-    shaderMessage = shader;
-    pushButton.ifPresent(b -> b.setEnabled(true));
-    String label = shaderResource != null ? shaderResource.getHandle() : "Shader";
-    spirvGroup.setText(label);
-    String spirvSource = shaderMessage.getSpirvSource();
-    if (spirvSource.isEmpty()) {
-      spirvSource = EMPTY_SHADER;
-    }
-    spirvViewer.setDocument(GlslSourceConfiguration.createDocument(spirvSource));
-    String source = shaderMessage.getSource();
-    if (!source.isEmpty()) {
-      sourceViewer.setDocument(GlslSourceConfiguration.createDocument(source));
-      crossCompileLabel.setVisible(shaderMessage.getCrossCompiled());
-      crossCompileGridData.exclude = !shaderMessage.getCrossCompiled();
-      if (sourceTab != null) {
-        sourceTab.setText(shaderMessage.getSourceLanguage());
+  public static class ShaderWidget extends Composite {
+    private static final String EMPTY_SHADER =
+        "// No source attached to this shader at this point in the trace.";
+
+    private final SingleInFlight rpcController = new SingleInFlight();
+    private final Models models;
+    private final LoadablePanel<Composite> loading;
+    private final TabFolder tabFolder;
+    private final Group spirvGroup;
+    private final Group sourceGroup;
+    private final Group statGroup;
+    private final Label crossCompileLabel;
+    private final GridData crossCompileGridData;
+    private final SourceViewer spirvViewer;
+    private final SourceViewer sourceViewer;
+    private final Optional<Button> pushButton;
+    private TabItem sourceTab;
+    private Service.Resource shaderResource = null;
+    private API.Shader shaderMessage = null;
+
+
+    public ShaderWidget(Composite parent, Models models, Widgets widgets) {
+      super(parent, SWT.NONE);
+      this.models = models;
+
+      setLayout(new FillLayout());
+
+      loading = LoadablePanel.create(this, widgets,
+          panel -> createComposite(panel, new GridLayout(1, false)));
+
+      tabFolder = createStandardTabFolder(loading.getContents());
+      tabFolder.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+      spirvGroup = createGroup(tabFolder, "");
+      spirvViewer =
+          new SourceViewer(spirvGroup, null, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER);
+      spirvViewer.setEditable(false);
+      spirvViewer.configure(new GlslSourceConfiguration(widgets.theme));
+      StyledText spirvTextWidget = spirvViewer.getTextWidget();
+      spirvTextWidget.setFont(widgets.theme.monoSpaceFont());
+      spirvTextWidget.setKeyBinding(ST.SELECT_ALL, ST.SELECT_ALL);
+      spirvTextWidget.addListener(SWT.KeyDown, e -> {
+        if (isKey(e, SWT.MOD1, 'z') && !isKey(e, SWT.MOD1 | SWT.SHIFT, 'z')) {
+          spirvViewer.doOperation(ITextOperationTarget.UNDO);
+        } else if (isKey(e, SWT.MOD1, 'y') || isKey(e, SWT.MOD1 | SWT.SHIFT, 'z')) {
+          spirvViewer.doOperation(ITextOperationTarget.REDO);
+        }
+      });
+      TabItem spirvTab = createStandardTabItem(tabFolder, "SPIR-V");
+      spirvTab.setControl(spirvGroup);
+
+      sourceGroup = createGroup(tabFolder, "", new GridLayout(1, false));
+      crossCompileGridData = new GridData(SWT.LEFT, SWT.TOP, false, false);
+      crossCompileLabel =
+          createBoldLabel(sourceGroup, "Source code was decompiled using SPIRV-Cross");
+      crossCompileLabel.setLayoutData(crossCompileGridData);
+      sourceViewer =
+          new SourceViewer(sourceGroup, null, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER);
+      sourceViewer.setEditable(false);
+      sourceViewer.configure(new GlslSourceConfiguration(widgets.theme));
+      sourceViewer.getControl().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+      StyledText sourceTextWidget = sourceViewer.getTextWidget();
+      sourceTextWidget.setFont(widgets.theme.monoSpaceFont());
+      sourceTextWidget.setKeyBinding(ST.SELECT_ALL, ST.SELECT_ALL);
+      sourceTextWidget.addListener(SWT.KeyDown, e -> {
+        if (isKey(e, SWT.MOD1, 'z') && !isKey(e, SWT.MOD1 | SWT.SHIFT, 'z')) {
+          sourceViewer.doOperation(ITextOperationTarget.UNDO);
+        } else if (isKey(e, SWT.MOD1, 'y') || isKey(e, SWT.MOD1 | SWT.SHIFT, 'z')) {
+          sourceViewer.doOperation(ITextOperationTarget.REDO);
+        }
+      });
+
+      // TODO(b/188434910): Shader editing is disabled as it doesn't work right
+      // now. Enable it once the issue is fixed.
+      if (!Experimental.enableUnstableFeatures(models.settings)) {
+        pushButton = Optional.empty();
       } else {
-        sourceTab = createStandardTabItem(tabFolder, shaderMessage.getSourceLanguage());
-        sourceTab.setControl(sourceGroup);
+        pushButton = Optional.of(createButton(loading.getContents(), "Push Changes", e -> {
+          if (shaderResource != null && shaderMessage != null) {
+            models.analytics.postInteraction(View.ShaderView, ClientAction.Edit);
+            models.resources.updateResource(shaderResource, API.ResourceData.newBuilder()
+                .setShader(shaderMessage.toBuilder().setSource(spirvViewer.getDocument().get()))
+                .build());
+          }
+        }));
+        pushButton.ifPresent(b -> {
+          b.setLayoutData(new GridData(SWT.RIGHT, SWT.BOTTOM, false, false));
+          b.setEnabled(false);
+        });
+        spirvViewer.setEditable(true);
+        sourceViewer.setEditable(true);
       }
-      sourceGroup.layout();
-    } else {
-      if (sourceTab != null) {
-        sourceTab.dispose();
-        sourceTab = null;
-      }
+
+      statGroup = createGroup(loading.getContents(), "Static Analysis");
+      statGroup.setFont(widgets.theme.subTitleFont());
+      statGroup.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+      statGroup.setLayout(new GridLayout(1, false));
     }
 
-    disposeAllChildren(statGroup);
-    createStaticAnalysisGroup(statGroup, shaderMessage.getStaticAnalysis());
-    statGroup.requestLayout();
-  }
-
-  private void clear() {
-    shaderResource = null;
-    if (!pinned) {
+    public void clear() {
+      shaderResource = null;
       shaderMessage = null;
-    }
-    pushButton.ifPresent(b -> b.setEnabled(false));
-  }
-
-  private void loadShader(Service.Resource shader) {
-    clear();
-    if (shader == null) {
+      pushButton.ifPresent(b -> b.setEnabled(false));
       loading.showMessage(Info, Messages.SELECT_SHADER);
-      return;
     }
 
-    loading.startLoading();
-    shaderResource = shader;
-    rpcController.start().listen(models.resources.loadResource(shaderResource),
-        new UiCallback<API.ResourceData, API.Shader>(this, LOG) {
-      @Override
-      protected API.Shader onRpcThread(Rpc.Result<API.ResourceData> result)
-          throws RpcException, ExecutionException {
-        return result.get().getShader();
+    public void loadShader(Service.Resource shader) {
+      if (shader == null) {
+        clear();
+        return;
       }
 
-      @Override
-      protected void onUiThread(API.Shader result) {
-        setShader(result);
+      loading.startLoading();
+      rpcController.start().listen(models.resources.loadResource(shader),
+          new UiCallback<API.ResourceData, API.Shader>(this, LOG) {
+        @Override
+        protected API.Shader onRpcThread(Rpc.Result<API.ResourceData> result)
+            throws RpcException, ExecutionException {
+          return result.get().getShader();
+        }
+
+        @Override
+        protected void onUiThread(API.Shader result) {
+          setShader(shader, result);
+        }
+      });
+    }
+
+    public void setShader(Service.Resource resource, API.Shader shader) {
+      loading.stopLoading();
+
+      shaderResource = resource;
+      shaderMessage = shader;
+
+      pushButton.ifPresent(b -> b.setEnabled(true));
+      String label = shaderResource != null ? shaderResource.getHandle() : "Shader";
+      spirvGroup.setText(label);
+      String spirvSource = shaderMessage.getSpirvSource();
+      if (spirvSource.isEmpty()) {
+        spirvSource = EMPTY_SHADER;
       }
-    });
-  }
-
-  private static boolean isKey(Event e, int stateMask, int keyCode) {
-    return (e.stateMask & stateMask) == stateMask && e.keyCode == keyCode;
-  }
-
-  private void createStaticAnalysisStat(Composite parent, String statText, int statData) {
-    GridLayout statsLayout = new GridLayout(1, false);
-    statsLayout.marginHeight = 5;
-    statsLayout.marginWidth = 5;
-
-    Composite keyComposite = withLayoutData(createComposite(parent, statsLayout, SWT.BORDER),
-        new GridData(SWT.FILL, SWT.TOP, false, false));
-
-    Label keyLabel = withLayoutData( createBoldLabel(keyComposite, statText),
-        new GridData(SWT.RIGHT, SWT.CENTER, true, true));
-
-    Composite valueComposite = withLayoutData(createComposite(parent, statsLayout, SWT.BORDER),
-        new GridData(SWT.FILL, SWT.TOP, false, false));
-    Label valueLabel = withLayoutData(createLabel(valueComposite, Integer.toString(statData)),
-        new GridData(SWT.LEFT, SWT.CENTER, true, true));
-  }
-
-  private void createStaticAnalysisGroup(Group dataGroupComposite, API.Shader.StaticAnalysis staticAnalysis) {
-    ScrolledComposite scrollComposite = withLayoutData(createScrolledComposite(dataGroupComposite,
-        new FillLayout(), SWT.V_SCROLL | SWT.H_SCROLL),
-        new GridData(SWT.FILL, SWT.FILL, true, true));
-
-    GridLayout gridLayout = new GridLayout(2, false);
-    gridLayout.marginWidth = 5;
-    gridLayout.marginHeight = 5;
-    gridLayout.horizontalSpacing = -1;
-    gridLayout.verticalSpacing = -1;
-    Composite contentComposite = createComposite(scrollComposite, gridLayout);
-
-    createStaticAnalysisStat(contentComposite, "ALU Instructions:", staticAnalysis.getAluInstructions());
-    createStaticAnalysisStat(contentComposite, "Texture Instructions:", staticAnalysis.getTextureInstructions());
-    createStaticAnalysisStat(contentComposite, "Branch Instructions:", staticAnalysis.getBranchInstructions());
-    createStaticAnalysisStat(contentComposite, "Peak Temporary Register Pressure:", staticAnalysis.getTempRegisters());
-
-    scrollComposite.setContent(contentComposite);
-    scrollComposite.setExpandVertical(true);
-    scrollComposite.setExpandHorizontal(true);
-    scrollComposite.addListener(SWT.Resize, event -> {
-      Rectangle scrollArea = scrollComposite.getClientArea();
-
-      int currentNumColumns = gridLayout.numColumns;
-      int numChildren = contentComposite.getChildren().length;
-      Point tableSize = contentComposite.computeSize(SWT.DEFAULT, SWT.DEFAULT, true);
-
-      if (tableSize.x < scrollArea.width) {
-        while (tableSize.x < scrollArea.width && gridLayout.numColumns < numChildren) {
-          gridLayout.numColumns += 2;
-          tableSize = contentComposite.computeSize(SWT.DEFAULT, SWT.DEFAULT, true);
+      spirvViewer.setDocument(GlslSourceConfiguration.createDocument(spirvSource));
+      String source = shaderMessage.getSource();
+      if (!source.isEmpty()) {
+        sourceViewer.setDocument(GlslSourceConfiguration.createDocument(source));
+        crossCompileLabel.setVisible(shaderMessage.getCrossCompiled());
+        crossCompileGridData.exclude = !shaderMessage.getCrossCompiled();
+        if (sourceTab != null) {
+          sourceTab.setText(shaderMessage.getSourceLanguage());
+        } else {
+          sourceTab = createStandardTabItem(tabFolder, shaderMessage.getSourceLanguage());
+          sourceTab.setControl(sourceGroup);
         }
-
-        if (tableSize.x > scrollArea.width) {
-          gridLayout.numColumns -= 2;
-        }
+        sourceGroup.layout();
       } else {
-        while (tableSize.x > scrollArea.width && gridLayout.numColumns >= 4) {
-          gridLayout.numColumns -= 2;
-          tableSize = contentComposite.computeSize(SWT.DEFAULT, SWT.DEFAULT, true);
+        if (sourceTab != null) {
+          sourceTab.dispose();
+          sourceTab = null;
         }
       }
 
-      if (gridLayout.numColumns != currentNumColumns) {
-        scrollComposite.layout();
-      }
+      disposeAllChildren(statGroup);
+      createStaticAnalysisGroup(statGroup, shaderMessage.getStaticAnalysis());
+      statGroup.requestLayout();
+    }
 
-      scrollComposite.setMinHeight(contentComposite.computeSize(scrollArea.width, SWT.DEFAULT).y);
-    });
+    private static void createStaticAnalysisGroup(
+        Group dataGroupComposite, API.Shader.StaticAnalysis staticAnalysis) {
+      ScrolledComposite scrollComposite = withLayoutData(createScrolledComposite(dataGroupComposite,
+          new FillLayout(), SWT.V_SCROLL | SWT.H_SCROLL),
+          new GridData(SWT.FILL, SWT.FILL, true, true));
+
+      GridLayout gridLayout = new GridLayout(2, false);
+      gridLayout.marginWidth = 5;
+      gridLayout.marginHeight = 5;
+      gridLayout.horizontalSpacing = -1;
+      gridLayout.verticalSpacing = -1;
+      Composite contentComposite = createComposite(scrollComposite, gridLayout);
+
+      createStaticAnalysisStat(
+          contentComposite, "ALU Instructions:", staticAnalysis.getAluInstructions());
+      createStaticAnalysisStat(
+          contentComposite, "Texture Instructions:", staticAnalysis.getTextureInstructions());
+      createStaticAnalysisStat(
+          contentComposite, "Branch Instructions:", staticAnalysis.getBranchInstructions());
+      createStaticAnalysisStat(
+          contentComposite, "Peak Temporary Register Pressure:", staticAnalysis.getTempRegisters());
+
+      scrollComposite.setContent(contentComposite);
+      scrollComposite.setExpandVertical(true);
+      scrollComposite.setExpandHorizontal(true);
+      scrollComposite.addListener(SWT.Resize, event -> {
+        Rectangle scrollArea = scrollComposite.getClientArea();
+
+        int currentNumColumns = gridLayout.numColumns;
+        int numChildren = contentComposite.getChildren().length;
+        Point tableSize = contentComposite.computeSize(SWT.DEFAULT, SWT.DEFAULT, true);
+
+        if (tableSize.x < scrollArea.width) {
+          while (tableSize.x < scrollArea.width && gridLayout.numColumns < numChildren) {
+            gridLayout.numColumns += 2;
+            tableSize = contentComposite.computeSize(SWT.DEFAULT, SWT.DEFAULT, true);
+          }
+
+          if (tableSize.x > scrollArea.width) {
+            gridLayout.numColumns -= 2;
+          }
+        } else {
+          while (tableSize.x > scrollArea.width && gridLayout.numColumns >= 4) {
+            gridLayout.numColumns -= 2;
+            tableSize = contentComposite.computeSize(SWT.DEFAULT, SWT.DEFAULT, true);
+          }
+        }
+
+        if (gridLayout.numColumns != currentNumColumns) {
+          scrollComposite.layout();
+        }
+
+        scrollComposite.setMinHeight(contentComposite.computeSize(scrollArea.width, SWT.DEFAULT).y);
+      });
+    }
+
+    private static void createStaticAnalysisStat(Composite parent, String statText, int statData) {
+      GridLayout statsLayout = new GridLayout(1, false);
+      statsLayout.marginHeight = 5;
+      statsLayout.marginWidth = 5;
+
+      Composite keyComposite = withLayoutData(createComposite(parent, statsLayout, SWT.BORDER),
+          new GridData(SWT.FILL, SWT.TOP, false, false));
+
+      withLayoutData( createBoldLabel(keyComposite, statText),
+          new GridData(SWT.RIGHT, SWT.CENTER, true, true));
+
+      Composite valueComposite = withLayoutData(createComposite(parent, statsLayout, SWT.BORDER),
+          new GridData(SWT.FILL, SWT.TOP, false, false));
+      withLayoutData(createLabel(valueComposite, Integer.toString(statData)),
+          new GridData(SWT.LEFT, SWT.CENTER, true, true));
+    }
+
+    private static boolean isKey(Event e, int stateMask, int keyCode) {
+      return (e.stateMask & stateMask) == stateMask && e.keyCode == keyCode;
+    }
   }
 }

--- a/gapic/src/main/com/google/gapid/views/ShaderView.java
+++ b/gapic/src/main/com/google/gapid/views/ShaderView.java
@@ -86,7 +86,7 @@ public class ShaderView extends Composite
     this.models = models;
 
     setLayout(new FillLayout());
-    shaderView = new ShaderWidget(this, models, widgets);
+    shaderView = new ShaderWidget(this, true, models, widgets);
 
     models.capture.addListener(this);
     models.resources.addListener(this);
@@ -183,7 +183,7 @@ public class ShaderView extends Composite
     private Service.Resource shaderResource = null;
     private API.Shader shaderMessage = null;
 
-    public ShaderWidget(Composite parent, Models models, Widgets widgets) {
+    public ShaderWidget(Composite parent, boolean allowEditing, Models models, Widgets widgets) {
       super(parent, SWT.NONE);
       this.models = models;
 
@@ -238,7 +238,7 @@ public class ShaderView extends Composite
 
       // TODO(b/188434910): Shader editing is disabled as it doesn't work right
       // now. Enable it once the issue is fixed.
-      if (!Experimental.enableUnstableFeatures(models.settings)) {
+      if (!allowEditing || !Experimental.enableUnstableFeatures(models.settings)) {
         pushButton = Optional.empty();
       } else {
         pushButton = Optional.of(createButton(shaderGroup, "Push Changes", e -> {
@@ -317,7 +317,7 @@ public class ShaderView extends Composite
       shaderResource = resource;
       shaderMessage = shader;
 
-      pushButton.ifPresent(b -> b.setEnabled(true));
+      pushButton.ifPresent(b -> b.setEnabled(shaderResource != null));
       shaderGroup.setText(shaderResource != null ? shaderResource.getHandle() : "Shader");
       String spirvSource = shaderMessage.getSpirvSource();
       if (spirvSource.isEmpty()) {

--- a/gapis/api/service.proto
+++ b/gapis/api/service.proto
@@ -263,6 +263,8 @@ message DataGroup {
     Table table = 3;
     Shader shader = 4;
   }
+  // If data is a Shader, this is the path to the shader's data.
+  path.ResourceData resource = 5;
 }
 
 message DataValue {

--- a/gapis/api/vulkan/resources.go
+++ b/gapis/api/vulkan/resources.go
@@ -1308,6 +1308,7 @@ func commonShaderDataGroups(ctx context.Context,
 				&api.DataGroup{
 					GroupName: "Shader Code",
 					Data:      &api.DataGroup_Shader{shader},
+					Resource:  cmd.ResourceAfter(path.NewID(resources[module.ResourceHandle()])),
 				},
 
 				&api.DataGroup{


### PR DESCRIPTION
Polishes a bunch of shader related UI:
- Use the same widget to show a shader in the pipeline view as the shader view.
- Show the static analysis data in an actual table.
- Clean up the layout of the shader code views, so they don't bounce around when switching between SPIRV and source.
- Make the debug labels show up in the pipeline, shader, and shader list views.
- Other minor UI layout polish.

Bug: http://b/200556859