### PR TITLE
Invert the trace type / device selection order.

### DIFF
--- a/cmd/gapit/trace.go
+++ b/cmd/gapit/trace.go
@@ -62,7 +62,7 @@ func (verb *traceVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		app.Usage(ctx, "The API is required.")
 		return nil
 	}
-	api, err := verb.apiAndType()
+	api, err := verb.traceType()
 	if err != nil {
 		return err
 	}
@@ -228,7 +228,6 @@ func (verb *traceVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 
 	options := &service.TraceOptions{
 		Type:                         api.traceType,
-		Apis:                         api.apis,
 		AdditionalCommandLineArgs:    verb.AdditionalArgs,
 		Cwd:                          verb.WorkingDir,
 		Environment:                  verb.Env,
@@ -323,33 +322,29 @@ func (verb *traceVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	})
 }
 
-type apiAndType struct {
+type traceType struct {
 	traceType service.TraceType
-	apis      []string
 	traceExt  string
 }
 
-func (verb *traceVerb) apiAndType() (apiAndType, error) {
+func (verb *traceVerb) traceType() (traceType, error) {
 	switch verb.API {
 	case "angle":
-		return apiAndType{
-			service.TraceType_Graphics,
-			[]string{"OpenGL on ANGLE"},
+		return traceType{
+			service.TraceType_ANGLE,
 			".gfxtrace",
 		}, nil
 	case "vulkan":
-		return apiAndType{
+		return traceType{
 			service.TraceType_Graphics,
-			[]string{"Vulkan"},
 			".gfxtrace",
 		}, nil
 	case "perfetto":
-		return apiAndType{
+		return traceType{
 			service.TraceType_Perfetto,
-			[]string{},
 			".perfetto",
 		}, nil
 	default:
-		return apiAndType{}, fmt.Errorf("Unknown API '%s'", verb.API)
+		return traceType{}, fmt.Errorf("Unknown API '%s'", verb.API)
 	}
 }

--- a/gapic/src/main/com/google/gapid/models/Devices.java
+++ b/gapic/src/main/com/google/gapid/models/Devices.java
@@ -284,7 +284,7 @@ public class Devices {
 
   public List<DeviceCaptureInfo> getCaptureDevices() {
     return (devices == null) ? null :
-      devices.stream().filter(info -> !info.config.getApisList().isEmpty()).collect(toList());
+      devices.stream().filter(info -> !info.config.getTypesList().isEmpty()).collect(toList());
   }
 
   public void addListener(Listener listener) {

--- a/gapic/src/main/com/google/gapid/models/Devices.java
+++ b/gapic/src/main/com/google/gapid/models/Devices.java
@@ -410,6 +410,19 @@ public class Devices {
     public boolean isAndroid() {
       return device.getConfiguration().getOS().getKind() == Device.OSKind.Android;
     }
+
+    /**
+     * Returns this device's tracing capabilities for the given type. Returns {@code null} if the
+     * given type is not supported by this device.
+     */
+    public final Service.TraceTypeCapabilities getTypeCapabilities(Service.TraceType type) {
+      for (Service.TraceTypeCapabilities cap : config.getTypesList()) {
+        if (cap.getType() == type) {
+          return cap;
+        }
+      }
+      return null;
+    }
   }
 
   public static class DeviceValidationResult {

--- a/gapic/src/main/com/google/gapid/models/Devices.java
+++ b/gapic/src/main/com/google/gapid/models/Devices.java
@@ -105,14 +105,6 @@ public class Devices {
     incompatibleReplayDevices = null;
   }
 
-  public static String GetDriverVersion(Device.Instance device) {
-    Device.VulkanDriver vkDriver = device.getConfiguration().getDrivers().getVulkan();
-    if (vkDriver.getPhysicalDevicesCount() <= 0) {
-      return "no physical device found";
-    }
-    return Integer.toUnsignedString(vkDriver.getPhysicalDevices(0).getDriverVersion());
-  }
-
   public void loadReplayDevices(Path.Capture capturePath) {
     rpcController.start().listen(MoreFutures.transformAsync(client.getDevicesForReplay(capturePath),
           devs -> {
@@ -293,6 +285,14 @@ public class Devices {
 
   public void removeListener(Listener listener) {
     listeners.removeListener(listener);
+  }
+
+  public static String getDriverVersion(Device.Instance device) {
+    Device.VulkanDriver vkDriver = device.getConfiguration().getDrivers().getVulkan();
+    if (vkDriver.getPhysicalDevicesCount() <= 0) {
+      return "no physical device found";
+    }
+    return Integer.toUnsignedString(vkDriver.getPhysicalDevices(0).getDriverVersion());
   }
 
   public static String getVulkanDriverVersions(Device.Instance dev) {

--- a/gapic/src/main/com/google/gapid/models/Settings.java
+++ b/gapic/src/main/com/google/gapid/models/Settings.java
@@ -59,7 +59,7 @@ public class Settings {
 
   private static final String SETTINGS_FILE = ".agic";
   private static final int MAX_RECENT_FILES = 16;
-  private static final int CURRENT_VERSION = 2;
+  private static final int CURRENT_VERSION = 3;
 
   // Only set values for fields where the proto zero/false/empty default doesn't make sense.
   private static SettingsProto.Settings DEFAULT_SETTINGS = SettingsProto.Settings.newBuilder()
@@ -120,6 +120,7 @@ public class Settings {
     this.proto = fixup(proto);
   }
 
+  @SuppressWarnings("deprecation")
   private static SettingsProto.Settings.Builder fixup(SettingsProto.Settings.Builder proto) {
     tryFindAdb(proto.getPreferencesBuilder());
     switch (proto.getVersion()) {
@@ -140,6 +141,14 @@ public class Settings {
             proto.getDeviceValidationBuilder().getValidationEntriesBuilderList()) {
           entry.setLastSeen(System.currentTimeMillis());
         }
+        //$FALL-THROUGH$
+      case 2:
+        // Version 3 removed the Trace.api field and expanded the Trace.Type field.
+        if ("Graphics".equals(proto.getTrace().getType()) &&
+            "OpenGL on ANGLE".equals(proto.getTrace().getApi())) {
+          proto.getTraceBuilder().setType("ANGLE");
+        }
+        proto.getTraceBuilder().clearApi();
     }
     return proto.setVersion(CURRENT_VERSION);
   }

--- a/gapic/src/main/com/google/gapid/settings.proto
+++ b/gapic/src/main/com/google/gapid/settings.proto
@@ -104,7 +104,7 @@ message Trace {
   string device_serial = 1;
   string device_name = 2;
   string type = 3;
-  string api = 4;
+  string api = 4 [deprecated = true];  // Kept for de-serialization.
   string uri = 5;
   string arguments = 6;
   string cwd = 7;

--- a/gapic/src/main/com/google/gapid/util/CenteringStackLayout.java
+++ b/gapic/src/main/com/google/gapid/util/CenteringStackLayout.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.util;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StackLayout;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+
+/**
+ * A {@link StackLayout} that vertically centers the control currently being displayed.
+ */
+public class CenteringStackLayout extends StackLayout {
+  @Override
+  protected void layout(Composite composite, boolean flushCache) {
+    Rectangle rect = composite.getClientArea();
+    rect.x += marginWidth;
+    rect.y += marginHeight;
+    rect.width -= 2 * marginWidth;
+    rect.height -= 2 * marginHeight;
+    for (Control element : composite.getChildren()) {
+      Point size = element.computeSize(rect.width, SWT.DEFAULT);
+      Rectangle bounds = rect;
+      if (size.y < rect.height) {
+        bounds = new Rectangle(rect.x, rect.y + (rect.height - size.y) / 2, rect.width, size.y);
+      }
+      element.setBounds(bounds);
+      element.setVisible(element == topControl);
+    }
+  }
+}

--- a/gapic/src/main/com/google/gapid/views/DeviceDialog.java
+++ b/gapic/src/main/com/google/gapid/views/DeviceDialog.java
@@ -207,7 +207,7 @@ public class DeviceDialog implements Devices.Listener, Capture.Listener {
       Widgets.createTableColumn(compatibleDeviceTable,
           "GPU", dev -> ((Device.Instance)dev).getConfiguration().getHardware().getGPU().getName());
       Widgets.createTableColumn(compatibleDeviceTable,
-          "Driver version", dev -> Devices.GetDriverVersion((Device.Instance)dev));
+          "Driver version", dev -> Devices.getDriverVersion((Device.Instance)dev));
       Widgets.packColumns(compatibleDeviceTable.getTable());
 
       compatibleDeviceTable.getTable().addListener(SWT.Selection, e -> {
@@ -243,7 +243,7 @@ public class DeviceDialog implements Devices.Listener, Capture.Listener {
       Widgets.createTableColumn(incompatibleDeviceTable, "Name", dev -> ((ReplayDeviceInfo)dev).instance.getName());
       Widgets.createTableColumn(incompatibleDeviceTable, "Serial", dev -> ((ReplayDeviceInfo)dev).instance.getSerial());
       Widgets.createTableColumn(incompatibleDeviceTable, "GPU", dev -> ((ReplayDeviceInfo)dev).instance.getConfiguration().getHardware().getGPU().getName());
-      Widgets.createTableColumn(incompatibleDeviceTable, "Driver version", dev -> Devices.GetDriverVersion(((ReplayDeviceInfo)dev).instance));
+      Widgets.createTableColumn(incompatibleDeviceTable, "Driver version", dev -> Devices.getDriverVersion(((ReplayDeviceInfo)dev).instance));
       Widgets.createTableColumn(incompatibleDeviceTable, "Incompatibility", dev -> Strings.getMessage(((ReplayDeviceInfo)dev).reason));
       Widgets.packColumns(incompatibleDeviceTable.getTable());
       incompatibleDeviceTable.getTable().setBackground(theme.invalidDeviceBackground());

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -33,6 +33,7 @@ import static com.google.gapid.widgets.Widgets.createTextbox;
 import static com.google.gapid.widgets.Widgets.withIndents;
 import static com.google.gapid.widgets.Widgets.withLayoutData;
 import static com.google.gapid.widgets.Widgets.withMargin;
+import static com.google.gapid.widgets.Widgets.withMarginOnly;
 import static com.google.gapid.widgets.Widgets.withSpans;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -393,14 +394,21 @@ public class TracerDialog {
           logFailure(LOG, Scheduler.EXECUTOR.schedule(refreshDevices, 300, TimeUnit.MILLISECONDS));
         });
 
-        validationStatusLoader = widgets.loading.createWidgetWithImage(mainGroup, widgets.theme.check(), widgets.theme.error());
+        createLabel(mainGroup, "Validation:");
+        Composite validationContainer = withLayoutData(
+            createComposite(mainGroup, withMarginOnly(new GridLayout(2, false), 0, 0)),
+            new GridData(SWT.FILL, SWT.TOP, true, false));
+        validationStatusLoader = widgets.loading.createWidgetWithImage(
+            validationContainer, widgets.theme.check(), widgets.theme.error());
         validationStatusLoader.setLayoutData(
             withIndents(new GridData(SWT.LEFT, SWT.BOTTOM, false, false), 0, 0));
-        validationStatusText = createLink(mainGroup, "", e-> {
+        validationStatusText = createLink(validationContainer, "", e-> {
           Program.launch(URLs.DEVICE_COMPATIBILITY_URL);
         });
         validationStatusText.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
         validationStatus = false;
+        validationStatusLoader.setVisible(false);
+        validationStatusText.setVisible(false);
 
         Group appGroup  = withLayoutData(
             createGroup(this, "Application", new GridLayout(2, false)),

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -612,8 +612,9 @@ public class TracerDialog {
           public String getText(Object element) {
             TraceTypeCapabilities ttc = (TraceTypeCapabilities)element;
             switch (ttc.getType()) {
-              case Graphics: return ttc.getApi();
+              case Graphics: return "Vulkan";
               case Perfetto: return "System Profile";
+              case ANGLE: return "OpenGL on ANGLE";
               default: throw new AssertionError();
             }
           }
@@ -814,13 +815,12 @@ public class TracerDialog {
       private void updateApiDropdown(
           DeviceTraceConfiguration config, SettingsProto.TraceOrBuilder trace) {
         if (api != null && config != null) {
-          List<TraceTypeCapabilities> caps = config.getApisList();
-          api.setInput(config.getApisList());
+          List<TraceTypeCapabilities> caps = config.getTypesList();
+          api.setInput(config.getTypesList());
           if (!caps.isEmpty()) {
             TraceTypeCapabilities deflt = caps.get(0);
             for (TraceTypeCapabilities c : caps) {
-              if (c.getType().name().equals(trace.getType()) &&
-                  (c.getApi().isEmpty() || c.getApi().equals(trace.getApi()))) {
+              if (c.getType().name().equals(trace.getType())) {
                 deflt = c;
                 break;
               }
@@ -974,7 +974,6 @@ public class TracerDialog {
         trace.setDeviceSerial(dev.device.getSerial());
         trace.setDeviceName(dev.device.getName());
         trace.setType(config.getType().name());
-        trace.setApi(config.getApi());
         trace.setUri(traceTarget.getText());
         trace.setArguments(arguments.getText());
         SettingsProto.Trace.Duration.Builder dur = isPerfetto(config) ?
@@ -994,7 +993,6 @@ public class TracerDialog {
         Service.TraceOptions.Builder options = Service.TraceOptions.newBuilder()
             .setDevice(dev.path)
             .setType(config.getType())
-            .addApis(config.getApi())
             .setUri(traceTarget.getText())
             .setAdditionalCommandLineArgs(arguments.getText())
             .setFramesToCapture(duration.getSelection())
@@ -1105,7 +1103,7 @@ public class TracerDialog {
       }
 
       private static boolean isAngle(TraceTypeCapabilities config) {
-        return config != null && config.getApi().equalsIgnoreCase("OpenGL on ANGLE");
+        return config != null && config.getType() == TraceType.ANGLE;
       }
     }
 

--- a/gapic/src/main/com/google/gapid/widgets/Widgets.java
+++ b/gapic/src/main/com/google/gapid/widgets/Widgets.java
@@ -1039,6 +1039,12 @@ public class Widgets {
     return layout;
   }
 
+  public static GridLayout withMarginOnly(GridLayout layout, int marginWidth, int marginHeight) {
+    layout.marginWidth = marginWidth;
+    layout.marginHeight = marginHeight;
+    return layout;
+  }
+
   public static GridLayout withMarginAndSpacing(GridLayout layout,
       int marginWidth, int marginHeight, int horizontalSpacing, int verticalSpacing) {
     layout.marginWidth = marginWidth;

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -38,8 +38,14 @@ option go_package = "github.com/google/gapid/gapis/service";
 /******************************************************************************/
 
 enum TraceType {
+  // A Frame Profiler Vulkan trace.
   Graphics = 0;
+  // A System Profiler Perfetto trace.
   Perfetto = 1;
+  // A Frame Profiler GLES on ANGLE trace. Note that when opening a trace,
+  // GAPIS currently doesn't distinguish between ANGLE and Vulkan and will not
+  // report this type (i.e. the Capture message's type field).
+  ANGLE = 2;
 }
 
 message Error {
@@ -145,7 +151,8 @@ message Value {
 
 // Capture describes single capture file held by the server.
 message Capture {
-  // The type of this capture.
+  // The type of this capture. Note that this will not distinguish Vulkan
+  // traces from ANGLE traces and report both as "Graphics".
   TraceType type = 7;
   // Name given to the capture. e.g. "KittyWorld"
   string name = 1;
@@ -416,7 +423,7 @@ message DeviceTraceConfiguration {
   // The default URI that should be used for looking at packages.
   string preferred_root_uri = 5;
   // Type and API-specific capabilities.
-  repeated TraceTypeCapabilities apis = 6;
+  repeated TraceTypeCapabilities types = 6;
   // Is there a cache that can be cleared.
   bool has_cache = 7;
 }
@@ -424,12 +431,8 @@ message DeviceTraceConfiguration {
 message TraceTypeCapabilities {
   // The type of trace this describes.
   TraceType type = 5;
-  // What is the API this is for.
-  string api = 1;
+  reserved 1;
   reserved 2;
-  // [deprecated] Does this API support MEC.
-  // This was used only for GLES.
-  // FeatureStatus mid_execution_capture_support = 3;
   reserved 3;
   // Whether unsupported extensions can be enabled.
   bool can_enable_unsupported_extensions = 4;
@@ -1377,8 +1380,8 @@ message TraceOptions {
   }
   // The type of this trace.
   TraceType type = 23;
-  // What APIs should we trace
-  repeated string apis = 5;
+  reserved 5;
+
   // Any additional command-line args to pass to the app
   string additional_command_line_args = 6;
   // What directory should be used for tracing

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -284,20 +284,20 @@ func NewTracer(dev bind.Device) tracer.Tracer {
 
 // TraceConfiguration returns the device's supported trace configuration.
 func (t *androidTracer) TraceConfiguration(ctx context.Context) (*service.DeviceTraceConfiguration, error) {
-	apis := make([]*service.TraceTypeCapabilities, 0, 3)
+	types := make([]*service.TraceTypeCapabilities, 0, 3)
 	if len(t.b.Instance().GetConfiguration().GetDrivers().GetVulkan().GetPhysicalDevices()) > 0 {
-		apis = append(apis, tracer.VulkanTraceOptions())
+		types = append(types, tracer.VulkanTraceOptions())
 		// If ANGLE is enabled and available, need to also append ANGLE trace mode
 		if t.b.SupportsAngle(ctx) {
-			apis = append(apis, tracer.AngleTraceOptions())
+			types = append(types, tracer.AngleTraceOptions())
 		}
 	}
 	if t.b.SupportsPerfetto(ctx) {
-		apis = append(apis, tracer.PerfettoTraceOptions())
+		types = append(types, tracer.PerfettoTraceOptions())
 	}
 
 	return &service.DeviceTraceConfiguration{
-		Apis:                 apis,
+		Types:                types,
 		ServerLocalPath:      false,
 		CanSpecifyCwd:        false,
 		CanUploadApplication: true,

--- a/gapis/trace/desktop/trace.go
+++ b/gapis/trace/desktop/trace.go
@@ -66,9 +66,9 @@ func (t *DesktopTracer) Validate(ctx context.Context) error {
 
 // TraceConfiguration returns the device's supported trace configuration.
 func (t *DesktopTracer) TraceConfiguration(ctx context.Context) (*service.DeviceTraceConfiguration, error) {
-	apis := make([]*service.TraceTypeCapabilities, 0, 1)
+	types := make([]*service.TraceTypeCapabilities, 0, 1)
 	if len(t.b.Instance().GetConfiguration().GetDrivers().GetVulkan().GetPhysicalDevices()) > 0 {
-		apis = append(apis, tracer.VulkanTraceOptions())
+		types = append(types, tracer.VulkanTraceOptions())
 	}
 
 	preferredRoot, err := t.b.GetWorkingDirectory(ctx)
@@ -82,11 +82,11 @@ func (t *DesktopTracer) TraceConfiguration(ctx context.Context) (*service.Device
 	}
 
 	if t.b.SupportsPerfetto(ctx) {
-		apis = append(apis, tracer.PerfettoTraceOptions())
+		types = append(types, tracer.PerfettoTraceOptions())
 	}
 
 	return &service.DeviceTraceConfiguration{
-		Apis:                 apis,
+		Types:                types,
 		ServerLocalPath:      isLocal,
 		CanSpecifyCwd:        true,
 		CanUploadApplication: false,

--- a/gapis/trace/trace.go
+++ b/gapis/trace/trace.go
@@ -154,15 +154,8 @@ func dumpTrace(ctx context.Context, buffer *bytes.Buffer) {
 }
 
 func isSupported(config *service.DeviceTraceConfiguration, options *service.TraceOptions) bool {
-	numApis := len(options.Apis)
-
-	// We don't support tracing more than one API at this time.
-	if numApis > 1 {
-		return false
-	}
-
-	for _, c := range config.Apis {
-		if c.Type == options.Type && (numApis < 1 || options.Apis[0] == c.Api) {
+	for _, c := range config.Types {
+		if c.Type == options.Type {
 			return true
 		}
 	}

--- a/gapis/trace/tracer/default_api_trace_options.go
+++ b/gapis/trace/tracer/default_api_trace_options.go
@@ -22,7 +22,6 @@ import (
 func VulkanTraceOptions() *service.TraceTypeCapabilities {
 	return &service.TraceTypeCapabilities{
 		Type:                           service.TraceType_Graphics,
-		Api:                            "Vulkan",
 		CanEnableUnsupportedExtensions: true,
 		RequiresApplication:            true,
 		CanSelectProcessName:           true,
@@ -32,8 +31,7 @@ func VulkanTraceOptions() *service.TraceTypeCapabilities {
 // AngleTraceOptions returns the default trace options for Angle.
 func AngleTraceOptions() *service.TraceTypeCapabilities {
 	return &service.TraceTypeCapabilities{
-		Type:                           service.TraceType_Graphics,
-		Api:                            "OpenGL on ANGLE",
+		Type:                           service.TraceType_ANGLE,
 		CanEnableUnsupportedExtensions: true,
 		RequiresApplication:            true,
 		CanSelectProcessName:           true,

--- a/gapis/trace/tracer/tracer.go
+++ b/gapis/trace/tracer/tracer.go
@@ -103,17 +103,8 @@ func LayersFromOptions(ctx context.Context, o *service.TraceOptions) []string {
 
 // GapiiOptions converts the given TraceOptions to gapii.Options.
 func GapiiOptions(o *service.TraceOptions) gapii.Options {
-	apis := uint32(0)
-	enableAngle := bool(false)
-	for _, api := range o.Apis {
-		if api == "Vulkan" {
-			apis |= gapii.VulkanAPI
-		}
-		if api == "OpenGL on ANGLE" {
-			apis |= gapii.VulkanAPI
-			enableAngle = true
-		}
-	}
+	apis := gapii.VulkanAPI
+	enableAngle := o.Type == service.TraceType_ANGLE
 
 	flags := gapii.Flags(0)
 	if o.DeferStart {


### PR DESCRIPTION
Changes the trace dialog to ask the user for the trace type first, followed by selecting a device for that trace type. Also contains a small refactor to remove the "API" field from the trace protos, and a small cleanup for the validation UI.

Bug: http://b/195970344