### PR TITLE
Add server side command filtering

### DIFF
--- a/gapis/api/cmd_flags.go
+++ b/gapis/api/cmd_flags.go
@@ -29,6 +29,7 @@ const (
 	ExecutedDispatch
 	ExecutedCommandBuffer
 	Submission
+	SyncCommand
 )
 
 // IsDrawCall returns true if the command is a draw call.
@@ -71,3 +72,6 @@ func (f CmdFlags) IsExecutedCommandBuffer() bool { return (f & ExecutedCommandBu
 
 // IsSubmission returns true if the command is a submission
 func (f CmdFlags) IsSubmission() bool { return (f & Submission) != 0 }
+
+// IsSyncCommand returns true if the command is a synchronisation command
+func (f CmdFlags) IsSyncCommand() bool { return (f & SyncCommand) != 0 }

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -1821,8 +1821,8 @@ import (
   }
 
   func (ϟc *{{$name}}) CmdFlags() ϟapi.CmdFlags {
-    {{$names := Strings "draw_call" "transform_feedback" "clear"  "frame_end"  "user_marker" "push_user_marker" "pop_user_marker" "executed_draw" "executed_dispatch" "executed_command_buffer" "submission"}}
-    {{$flags := Strings "DrawCall"  "TransformFeedback"  "Clear"  "EndOfFrame" "UserMarker"  "PushUserMarker"   "PopUserMarker" "ExecutedDraw" "ExecutedDispatch" "ExecutedCommandBuffer" "Submission"}}
+    {{$names := Strings "draw_call" "transform_feedback" "clear"  "frame_end"  "user_marker" "push_user_marker" "pop_user_marker" "executed_draw" "executed_dispatch" "executed_command_buffer" "submission" "sync_command"}}
+    {{$flags := Strings "DrawCall"  "TransformFeedback"  "Clear"  "EndOfFrame" "UserMarker"  "PushUserMarker"   "PopUserMarker" "ExecutedDraw" "ExecutedDispatch" "ExecutedCommandBuffer" "Submission" "SyncCommand"}}
 
     var out ϟapi.CmdFlags
     {{range $i, $name := $names}}

--- a/gapis/api/vulkan/api/synchronization.api
+++ b/gapis/api/vulkan/api/synchronization.api
@@ -48,6 +48,7 @@
 }
 
 @indirect("VkDevice")
+@sync_command
 cmd VkResult vkCreateFence(
     VkDevice                     device,
     const VkFenceCreateInfo*     pCreateInfo,
@@ -85,6 +86,7 @@ cmd VkResult vkCreateFence(
 }
 
 @indirect("VkDevice")
+@sync_command
 cmd void vkDestroyFence(
     VkDevice                     device,
     VkFence                      fence,
@@ -94,6 +96,7 @@ cmd void vkDestroyFence(
 }
 
 @indirect("VkDevice")
+@sync_command
 cmd VkResult vkResetFences(
     VkDevice       device,
     u32            fenceCount,
@@ -110,6 +113,7 @@ cmd VkResult vkResetFences(
 }
 
 @indirect("VkDevice")
+@sync_command
 @custom
 cmd VkResult vkGetFenceStatus(
     VkDevice device,
@@ -130,6 +134,7 @@ cmd VkResult vkGetFenceStatus(
 }
 
 @indirect("VkDevice")
+@sync_command
 @threadsafe
 @alive
 @custom
@@ -172,6 +177,7 @@ cmd VkResult vkWaitForFences(
 }
 
 @indirect("VkDevice")
+@sync_command
 cmd VkResult vkCreateSemaphore(
     VkDevice                     device,
     const VkSemaphoreCreateInfo* pCreateInfo,
@@ -208,6 +214,7 @@ cmd VkResult vkCreateSemaphore(
 }
 
 @indirect("VkDevice")
+@sync_command
 cmd void vkDestroySemaphore(
     VkDevice                     device,
     VkSemaphore                  semaphore,
@@ -217,6 +224,7 @@ cmd void vkDestroySemaphore(
 }
 
 // Partial implementation
+@sync_command
 @since("1.2")
 @indirect("VkDevice")
 cmd VkResult vkSignalSemaphore(
@@ -226,6 +234,7 @@ cmd VkResult vkSignalSemaphore(
 }
 
 // Partial implementation
+@sync_command
 @since("1.2")
 @indirect("VkDevice")
 cmd VkResult vkWaitSemaphores(
@@ -236,6 +245,7 @@ cmd VkResult vkWaitSemaphores(
 }
 
 // Partial implementation
+@sync_command
 @since("1.2")
 @indirect("VkDevice")
 cmd VkResult vkGetSemaphoreCounterValue(
@@ -258,6 +268,7 @@ cmd VkResult vkGetSemaphoreCounterValue(
 }
 
 @indirect("VkDevice")
+@sync_command
 cmd VkResult vkCreateEvent(
     VkDevice                     device,
     const VkEventCreateInfo*     pCreateInfo,
@@ -291,6 +302,7 @@ cmd VkResult vkCreateEvent(
 }
 
 @indirect("VkDevice")
+@sync_command
 cmd void vkDestroyEvent(
     VkDevice                     device,
     VkEvent                      event,
@@ -299,6 +311,7 @@ cmd void vkDestroyEvent(
 }
 
 @indirect("VkDevice")
+@sync_command
 @custom
 cmd VkResult vkGetEventStatus(
     VkDevice device,
@@ -309,6 +322,7 @@ cmd VkResult vkGetEventStatus(
 }
 
 @indirect("VkDevice")
+@sync_command
 cmd VkResult vkSetEvent(
     VkDevice device,
     VkEvent  event) {
@@ -329,6 +343,7 @@ cmd VkResult vkSetEvent(
 }
 
 @indirect("VkDevice")
+@sync_command
 cmd VkResult vkResetEvent(
     VkDevice device,
     VkEvent  event) {
@@ -354,6 +369,7 @@ sub void dovkCmdSetEvent(ref!vkCmdSetEventArgs event) {
 }
 
 @indirect("VkCommandBuffer", "VkDevice")
+@sync_command
 cmd void vkCmdSetEvent(
     VkCommandBuffer      commandBuffer,
     VkEvent              event,
@@ -387,6 +403,7 @@ sub void dovkCmdResetEvent(ref!vkCmdResetEventArgs event) {
 }
 
 @indirect("VkCommandBuffer", "VkDevice")
+@sync_command
 cmd void vkCmdResetEvent(
     VkCommandBuffer      commandBuffer,
     VkEvent              event,
@@ -436,6 +453,7 @@ sub void dovkCmdWaitEvents(ref!vkCmdWaitEventsArgs args) {
 }
 
 @indirect("VkCommandBuffer", "VkDevice")
+@sync_command
 cmd void vkCmdWaitEvents(
     VkCommandBuffer              commandBuffer,
     u32                          eventCount,
@@ -565,6 +583,7 @@ sub void handleImageMemoryBarriersPNext(const VkImageMemoryBarrier* pBarriers, u
 }
 
 @indirect("VkCommandBuffer", "VkDevice")
+@sync_command
 cmd void vkCmdPipelineBarrier(
     VkCommandBuffer              commandBuffer,
     VkPipelineStageFlags         srcStageMask,

--- a/gapis/resolve/filter.go
+++ b/gapis/resolve/filter.go
@@ -70,5 +70,26 @@ func buildFilter(
 			return (cmd.CmdFlags().IsExecutedDraw() && len(idx) > 1) || cmd.CmdFlags().IsSubmission()
 		})
 	}
+	if f.GetSuppressHostCommands() {
+		filters = append(filters, func(id api.CmdID, cmd api.Cmd, s *api.GlobalState, idx api.SubCmdIdx) bool {
+			return cmd.CmdFlags().IsSubmission()
+		})
+	}
+	if f.GetSuppressBeginEndMarkers() {
+		filters = append(filters, func(id api.CmdID, cmd api.Cmd, s *api.GlobalState, idx api.SubCmdIdx) bool {
+			return !(cmd.CmdFlags().IsPushUserMarker() || cmd.CmdFlags().IsPopUserMarker() || cmd.CmdFlags().IsUserMarker())
+		})
+	}
+	if f.GetSuppressNonRenderpassCommands() {
+		filters = append(filters, func(id api.CmdID, cmd api.Cmd, s *api.GlobalState, idx api.SubCmdIdx) bool {
+			return len(idx) < 2 || cmd.CmdFlags().IsExecutedDraw()
+		})
+	}
+	if f.GetSuppressSyncCommands() {
+		filters = append(filters, func(id api.CmdID, cmd api.Cmd, s *api.GlobalState, idx api.SubCmdIdx) bool {
+			return !cmd.CmdFlags().IsSyncCommand()
+		})
+	}
+
 	return filters.All, nil
 }

--- a/gapis/service/path/path.proto
+++ b/gapis/service/path/path.proto
@@ -303,10 +303,27 @@ message Framegraph {
 
 // CommandFilter are the optional filters applied to CommandTrees and Events.
 message CommandFilter {
+
   // thread filters the commands to those with the specified threads.
   repeated uint64 threads = 2;
+
   // If true, only shows draw calls from inside a command buffer
   bool only_executed_draws = 3;
+
+  // If true, do not include host commands in results
+  bool suppress_host_commands = 4;
+
+  // If true, do not include begin and end markets in results
+  bool suppress_begin_end_markers = 5;
+
+  // If true, do not include non renderpass commands in results
+  bool suppress_non_renderpass_commands = 6;
+
+  // If true, do not include submission groupings in results
+  bool suppress_submit_grouping = 7;
+
+  // If true, do not include synchronisation commands in results
+  bool suppress_sync_commands = 8;
 }
 
 // CommandTree is a path to a hierarchy of command tree nodes.
@@ -316,6 +333,7 @@ message CommandTree {
   Capture capture = 1;
   // The command filter used to create the tree.
   CommandFilter filter = 2;
+
   // If true then commands will be grouped by API.
   bool group_by_api = 3;
   // If true then commands will be grouped by thread.


### PR DESCRIPTION
When listing the commands for the command tree, support filtering by:

Host Commands
Begin/End Marker Commands
Non Renderpass Commands
Sync Commands