### PR TITLE
Resource View Polish

### DIFF
--- a/gapic/src/main/com/google/gapid/GraphicsTraceView.java
+++ b/gapic/src/main/com/google/gapid/GraphicsTraceView.java
@@ -189,7 +189,24 @@ public class GraphicsTraceView extends Composite
   @Override
   public void onTextureSelected(Service.Resource texture) {
     if (texture != null) {
-      showTab(MainTab.Type.TextureView);
+      showTab(MainTab.Type.Textures);
+    }
+  }
+
+  @Override
+  public void onTexturePinned(Resource texture) {
+    if (!tabs.showTab(texture)) {
+      String label = texture.getHandle();
+      if (!texture.getLabel().isEmpty()) {
+        label = "Image<" + texture.getLabel() + ">";
+      }
+      TabInfo tabInfo = new TabInfo(texture, Analytics.View.TextureView, label, parent -> {
+        Tab tab = new TextureView(parent, texture, models, widgets);
+        tab.reinitialize();
+        return tab;
+      });
+      tabs.addTabToLargestFolder(tabInfo);
+      tabs.showTab(texture);
     }
   }
 
@@ -460,7 +477,6 @@ public class GraphicsTraceView extends Composite
       Report(View.Report, "Report", DefaultPosition.Center, ReportView::new),
       Log(View.Log, "Log", DefaultPosition.Center, (p, m, w) -> new LogView(p, w)),
 
-      TextureView(View.TextureView, "Texture", DefaultPosition.Right, TextureView::new),
       ApiState(View.State, "State", DefaultPosition.Right, StateView::new),
       Memory(View.Memory, "Memory", DefaultPosition.Right, MemoryView::new);
 

--- a/gapic/src/main/com/google/gapid/models/Resources.java
+++ b/gapic/src/main/com/google/gapid/models/Resources.java
@@ -229,6 +229,10 @@ public class Resources extends CaptureDependentModel.ForValue<Resources.Data, Re
     }
   }
 
+  public void pinShader(Service.Resource shader) {
+    listeners.fire().onShaderPinned(shader);
+  }
+
   public Service.Resource getSelectedTexture() {
     return selectedTexture;
   }
@@ -327,6 +331,11 @@ public class Resources extends CaptureDependentModel.ForValue<Resources.Data, Re
      * Event indicating that a shader resource has been selected.
      */
     public default void onShaderSelected(Service.Resource shader) { /* empty */ }
+
+    /**
+     * Event indicating that a shader has been pinned.
+     */
+    public default void onShaderPinned(Service.Resource shader) { /* empty */ }
 
     /**
      * Event indicating that a texture resource has been selected.

--- a/gapic/src/main/com/google/gapid/models/Resources.java
+++ b/gapic/src/main/com/google/gapid/models/Resources.java
@@ -244,6 +244,10 @@ public class Resources extends CaptureDependentModel.ForValue<Resources.Data, Re
     }
   }
 
+  public void pinTexture(Service.Resource texture) {
+    listeners.fire().onTexturePinned(texture);
+  }
+
   public static class Data extends DeviceDependentModel.Data {
     public final Service.Resources resources;
 
@@ -341,5 +345,10 @@ public class Resources extends CaptureDependentModel.ForValue<Resources.Data, Re
      * Event indicating that a texture resource has been selected.
      */
     public default void onTextureSelected(Service.Resource texture) { /* empty */ }
+
+    /**
+     * Event indicating that a texture has been pinned.
+     */
+    public default void onTexturePinned(Service.Resource texture) { /* empty */ }
   }
 }

--- a/gapic/src/main/com/google/gapid/models/Settings.java
+++ b/gapic/src/main/com/google/gapid/models/Settings.java
@@ -380,7 +380,8 @@ public class Settings {
   }
 
   public static enum SplitterWeights {
-    Report(new int[] { 75, 25 });
+    Report(new int[] { 75, 25 }),
+    Shaders(new int[] { 20, 80 });
 
     private final int[] dflt;
 

--- a/gapic/src/main/com/google/gapid/models/Settings.java
+++ b/gapic/src/main/com/google/gapid/models/Settings.java
@@ -381,7 +381,8 @@ public class Settings {
 
   public static enum SplitterWeights {
     Report(new int[] { 75, 25 }),
-    Shaders(new int[] { 20, 80 });
+    Shaders(new int[] { 20, 80 }),
+    Textures(new int[] { 30, 70 });
 
     private final int[] dflt;
 

--- a/gapic/src/main/com/google/gapid/views/FramebufferView.java
+++ b/gapic/src/main/com/google/gapid/views/FramebufferView.java
@@ -133,7 +133,7 @@ public class FramebufferView extends Composite
     picker = withLayoutData(new AttachmentPicker(content, widgets, this::updateBuffer),
         new GridData(SWT.FILL, SWT.TOP, true, false));
     imagePanel = withLayoutData(
-        new ImagePanel(content, View.Framebuffer, models.analytics, widgets, true),
+        new ImagePanel(content, View.Framebuffer, models.analytics, widgets),
         new GridData(SWT.FILL, SWT.FILL, true, true));
 
     imagePanel.createToolbar(toolBar, widgets.theme);

--- a/gapic/src/main/com/google/gapid/views/FramebufferView.java
+++ b/gapic/src/main/com/google/gapid/views/FramebufferView.java
@@ -133,7 +133,7 @@ public class FramebufferView extends Composite
     picker = withLayoutData(new AttachmentPicker(content, widgets, this::updateBuffer),
         new GridData(SWT.FILL, SWT.TOP, true, false));
     imagePanel = withLayoutData(
-        new ImagePanel(content, View.Framebuffer, models.analytics, widgets),
+        new ImagePanel(content, false, View.Framebuffer, models.analytics, widgets),
         new GridData(SWT.FILL, SWT.FILL, true, true));
 
     imagePanel.createToolbar(toolBar, widgets.theme);

--- a/gapic/src/main/com/google/gapid/views/PipelineView.java
+++ b/gapic/src/main/com/google/gapid/views/PipelineView.java
@@ -529,7 +529,7 @@ public class PipelineView extends Composite
 
         case SHADER:
           ShaderView.ShaderWidget shaderView = withLayoutData(
-              new ShaderView.ShaderWidget(dataComposite, false, models, widgets),
+              ShaderView.createReadOnly(dataComposite, models, widgets),
               new GridData(SWT.FILL, SWT.FILL, true, true));
           Resources.Resource res = models.resources.getResource(dataGroup.getResource());
           shaderView.setShader((res == null) ? null : res.resource, dataGroup.getShader());

--- a/gapic/src/main/com/google/gapid/views/TextureView.java
+++ b/gapic/src/main/com/google/gapid/views/TextureView.java
@@ -100,7 +100,7 @@ public class TextureView extends Composite
       setLayout(new FillLayout(SWT.VERTICAL));
       Composite imageAndToolbar = createComposite(this, new GridLayout(2, false));
       ToolBar toolBar = new ToolBar(imageAndToolbar, SWT.VERTICAL | SWT.FLAT);
-      imagePanel = new ImagePanel(imageAndToolbar, View.TextureView, models.analytics, widgets, true);
+      imagePanel = new ImagePanel(imageAndToolbar, View.TextureView, models.analytics, widgets);
 
       toolBar.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, true));
       imagePanel.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));

--- a/gapic/src/main/com/google/gapid/views/TextureView.java
+++ b/gapic/src/main/com/google/gapid/views/TextureView.java
@@ -100,7 +100,8 @@ public class TextureView extends Composite
       setLayout(new FillLayout(SWT.VERTICAL));
       Composite imageAndToolbar = createComposite(this, new GridLayout(2, false));
       ToolBar toolBar = new ToolBar(imageAndToolbar, SWT.VERTICAL | SWT.FLAT);
-      imagePanel = new ImagePanel(imageAndToolbar, View.TextureView, models.analytics, widgets);
+      imagePanel =
+          new ImagePanel(imageAndToolbar, true, View.TextureView, models.analytics, widgets);
 
       toolBar.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, true));
       imagePanel.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
@@ -166,8 +167,20 @@ public class TextureView extends Composite
     }
 
     protected void setImage(FetchedImage result) {
+      imagePanel.setLabel(getLabel(textureResource));
       imagePanel.setImage(result);
       pinItem.setEnabled(!pinned);
+    }
+
+    private static String getLabel(Service.Resource resource) {
+      if (resource == null) {
+        return "Texture";
+      }
+      String label = resource.getHandle();
+      if (!resource.getLabel().isEmpty()) {
+        label += " " + resource.getLabel();
+      }
+      return label;
     }
 
     /**

--- a/gapic/src/main/com/google/gapid/widgets/ImagePanel.java
+++ b/gapic/src/main/com/google/gapid/widgets/ImagePanel.java
@@ -141,8 +141,7 @@ public class ImagePanel extends Composite implements Loadable {
     ZOOM_MANUAL
   }
 
-  public ImagePanel(
-      Composite parent, View view, Analytics analytics, Widgets widgets, boolean naturallyFlipped) {
+  public ImagePanel(Composite parent, View view, Analytics analytics, Widgets widgets) {
     super(parent, SWT.NONE);
     this.analyticsView = view;
     this.analytics = analytics;
@@ -152,7 +151,7 @@ public class ImagePanel extends Composite implements Loadable {
     setLayout(Widgets.withMargin(new GridLayout(1, false), 5, 2));
 
     loading = LoadablePanel.create(this, widgets, panel ->
-        new ImageComponent(panel, widgets.theme, this::showAlphaWarning, naturallyFlipped));
+        new ImageComponent(panel, widgets.theme, this::showAlphaWarning));
     status = new StatusBar(this, widgets.theme, this::loadLevel, this::setAlphaEnabled);
     imageComponent = loading.getContents();
 
@@ -695,7 +694,6 @@ public class ImagePanel extends Composite implements Loadable {
     private static final double HISTOGRAM_SNAP_THRESHOLD = 0.1;
 
     private final Consumer<AlphaWarning> showAlphaWarning;
-    private final boolean naturallyFlipped;
 
     private final ScrollBar scrollbars[];
     private final ScenePanel<SceneData> canvas;
@@ -719,8 +717,7 @@ public class ImagePanel extends Composite implements Loadable {
 
     private boolean alphaWasAutoDisabled = false;
 
-    public ImageComponent(Composite parent, Theme theme, Consumer<AlphaWarning> showAlphaWarning,
-        boolean naturallyFlipped) {
+    public ImageComponent(Composite parent, Theme theme, Consumer<AlphaWarning> showAlphaWarning) {
       // TODO: b/189382432 Enable scroll bars when compatibility issue between SWT & macOS resolves.
       super(parent, OS.isMac ? SWT.NO_BACKGROUND :
           SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL | SWT.NO_BACKGROUND);
@@ -735,10 +732,9 @@ public class ImagePanel extends Composite implements Loadable {
       setLayout(new FillLayout(SWT.VERTICAL));
 
       this.showAlphaWarning = showAlphaWarning;
-      this.naturallyFlipped = naturallyFlipped;
 
       data = new SceneData();
-      data.flipped = naturallyFlipped;
+      data.flipped = true;
       data.borderWidth = (int)BORDER_SIZE.x;
       data.borderColor = getDisplay().getSystemColor(SWT.COLOR_WIDGET_NORMAL_SHADOW);
       data.panelColor = getDisplay().getSystemColor(SWT.COLOR_WIDGET_BACKGROUND);
@@ -870,7 +866,7 @@ public class ImagePanel extends Composite implements Loadable {
     }
 
     protected void setFlipped(boolean flipped) {
-      data.flipped = flipped ^ naturallyFlipped;
+      data.flipped = !flipped;
       refresh();
     }
 

--- a/gapis/api/resource.go
+++ b/gapis/api/resource.go
@@ -100,8 +100,6 @@ func NewResourceData(data interface{}) *ResourceData {
 		return &ResourceData{Data: &ResourceData_Texture{data}}
 	case *Shader:
 		return &ResourceData{Data: &ResourceData_Shader{data}}
-	case *Program:
-		return &ResourceData{Data: &ResourceData_Program{data}}
 	case *Pipeline:
 		return &ResourceData{Data: &ResourceData_Pipeline{data}}
 	default:

--- a/gapis/api/service.proto
+++ b/gapis/api/service.proto
@@ -114,8 +114,7 @@ message ResourceData {
   oneof data {
     Texture texture = 1;
     Shader shader = 2;
-    Program program = 3;
-    Pipeline pipeline = 4;
+    Pipeline pipeline = 3;
   }
 }
 
@@ -153,12 +152,6 @@ message Shader {
     uint32 temp_registers = 4;
   }
   StaticAnalysis static_analysis = 6;
-}
-
-// Program represents a shader resource.
-message Program {
-  repeated Shader shaders = 1;
-  repeated Uniform uniforms = 2;
 }
 
 // Uniform respresents a uniform/active uniform resource.

--- a/gapis/service/path/path.proto
+++ b/gapis/service/path/path.proto
@@ -482,10 +482,8 @@ enum ResourceType {
   Texture = 1;
   // Shader represents the Shader resource type
   Shader = 2;
-  // Program represents the Program resource type
-  Program = 3;
   // Pipeline respresents the Pipeline resource type
-  Pipeline = 4;
+  Pipeline = 3;
 }
 
 // Resources is a path to a list of resources used in a capture.


### PR DESCRIPTION
Show the texture image in the texture view and the shader data in the shader view as we used to, but allow textures and shaders to be pinned into their own tabs. This gets rid of the blank "Texture" and "Shader" tabs, but still allows viewing textures and shaders in their own tabs. Pinning is done via a new button in the button bars of the respective UIs.

Bug: http://b/200556859