### PR TITLE
Some Random Small Fixes

### DIFF
--- a/gapis/api/sync/sync.go
+++ b/gapis/api/sync/sync.go
@@ -176,6 +176,7 @@ func MutationCmdsFor(ctx context.Context, c *path.Capture, data *Data, cmds []ap
 // Cmd, the given post-Cmd callback will be called. And the given
 // pre-subcommand callback and the post-subcommand callback will be called
 // before and after calling each subcommand callback function.
+// If cmds is nil, all commands from the capture are used instead.
 func MutateWithSubcommands(ctx context.Context, c *path.Capture, cmds []api.Cmd,
 	postCmdCb func(*api.GlobalState, api.SubCmdIdx, api.Cmd),
 	preSubCmdCb func(s *api.GlobalState, idx api.SubCmdIdx, cmd api.Cmd, subCmdRef interface{}),
@@ -192,6 +193,10 @@ func MutateWithSubcommands(ctx context.Context, c *path.Capture, cmds []api.Cmd,
 		return err
 	}
 	s := rc.NewState(ctx)
+
+	if cmds == nil {
+		cmds = rc.Commands
+	}
 
 	return api.ForeachCmd(ctx, cmds, false, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
 		if sync, ok := cmd.API().(SynchronizedAPI); ok {

--- a/gapis/api/templates/specific_gfx_api.cpp.tmpl
+++ b/gapis/api/templates/specific_gfx_api.cpp.tmpl
@@ -158,11 +158,6 @@
         {{if not (IsVoid $.Return.Type)}}
           {{Template "C++.ReturnType" $}} return_value = {{Template "Call" $}};
           GAPID_DEBUG("[%u]{{$name}} returned {{Template "C++.PrintfFormatCode" $.Return.Type}}", cmdLabel, return_value);
-          {{if eq $name "glGetError"}}
-            if (return_value != Gles::GLenum::GL_NO_ERROR) {
-              GAPID_ERROR("[%u]glGetError() returned: 0x%x", cmdLabel, return_value);
-            }
-          {{end}}
           if (pushReturn) {
             {{$ty := TypeOf $.Return.Type | Underlying | Unpack}}
             {{if IsSize $ty}}

--- a/gapis/api/vulkan/framegraph.go
+++ b/gapis/api/vulkan/framegraph.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/api/sync"
-	"github.com/google/gapid/gapis/capture"
 	"github.com/google/gapid/gapis/memory"
 	"github.com/google/gapid/gapis/resolve/dependencygraph2"
 	"github.com/google/gapid/gapis/service/path"
@@ -738,11 +737,7 @@ func (API) GetFramegraph(ctx context.Context, p *path.Capture) (*api.Framegraph,
 	}
 
 	// Iterate on the capture commands to collect information
-	c, err := capture.ResolveGraphicsFromPath(ctx, p)
-	if err != nil {
-		return nil, err
-	}
-	if err := sync.MutateWithSubcommands(ctx, p, c.Commands, nil, nil, postSubCmdCb); err != nil {
+	if err := sync.MutateWithSubcommands(ctx, p, nil, nil, nil, postSubCmdCb); err != nil {
 		return nil, err
 	}
 

--- a/gapis/api/vulkan/replay_types.go
+++ b/gapis/api/vulkan/replay_types.go
@@ -91,7 +91,7 @@ type profileRequest struct {
 	traceOptions   *service.TraceOptions
 	handler        *replay.SignalHandler
 	buffer         *bytes.Buffer
-	handleMappings *map[uint64][]service.VulkanHandleMappingItem
+	handleMappings map[uint64][]service.VulkanHandleMappingItem
 	experiments    replay.ProfileExperiments
 	loopCount      int32
 }
@@ -190,8 +190,8 @@ func (a API) QueryProfile(
 	c := uniqueConfig()
 	handler := replay.NewSignalHandler()
 	var buffer bytes.Buffer
-	handleMappings := make(map[uint64][]service.VulkanHandleMappingItem)
-	r := profileRequest{traceOptions, handler, &buffer, &handleMappings, experiments, loopCount}
+	handleMappings := map[uint64][]service.VulkanHandleMappingItem{}
+	r := profileRequest{traceOptions, handler, &buffer, handleMappings, experiments, loopCount}
 	_, err := mgr.Replay(ctx, intent, c, r, a, hints, true)
 	if err != nil {
 		return nil, err
@@ -203,6 +203,6 @@ func (a API) QueryProfile(
 		return nil, err
 	}
 
-	d, err := trace.ProcessProfilingData(ctx, intent.Device, intent.Capture, &buffer, &handleMappings, s)
+	d, err := trace.ProcessProfilingData(ctx, intent.Device, intent.Capture, &buffer, handleMappings, s)
 	return d, err
 }

--- a/gapis/api/vulkan/transform_mapping_exporter.go
+++ b/gapis/api/vulkan/transform_mapping_exporter.go
@@ -237,11 +237,11 @@ func (mappingTransform *mappingExporter) processNotification(ctx context.Context
 	mappingTransform.notificationID = 0
 
 	if len(mappingTransform.path) > 0 {
-		printToFile2(ctx, mappingTransform.path, mappingTransform.mappings)
+		printMappingsToFile(ctx, mappingTransform.path, mappingTransform.mappings)
 	}
 }
 
-func printToFile2(ctx context.Context, path string, mappings *map[uint64][]service.VulkanHandleMappingItem) {
+func printMappingsToFile(ctx context.Context, path string, mappings *map[uint64][]service.VulkanHandleMappingItem) {
 	f, err := os.Create(path)
 	if err != nil {
 		log.E(ctx, "Failed to create mapping file %v: %v", path, err)

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -160,11 +160,7 @@ func (s *State) TrimInitialState(ctx context.Context, capturePath *path.Capture)
 			pipelines[args.Pipeline()] = struct{}{}
 		}
 	}
-	c, err := capture.ResolveGraphicsFromPath(ctx, capturePath)
-	if err != nil {
-		return err
-	}
-	if err := sync.MutateWithSubcommands(ctx, capturePath, c.Commands, postCmdCb, nil, postSubCmdCb); err != nil {
+	if err := sync.MutateWithSubcommands(ctx, capturePath, nil, postCmdCb, nil, postSubCmdCb); err != nil {
 		return err
 	}
 

--- a/gapis/resolve/framebuffer_changes.go
+++ b/gapis/resolve/framebuffer_changes.go
@@ -21,7 +21,6 @@ import (
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/api/sync"
-	"github.com/google/gapid/gapis/capture"
 	"github.com/google/gapid/gapis/database"
 	"github.com/google/gapid/gapis/messages"
 	"github.com/google/gapid/gapis/service"
@@ -64,11 +63,6 @@ const errDetached = fault.Const("Attachment detached from Framebuffer")
 // Resolve implements the database.Resolver interface.
 func (r *FramebufferChangesResolvable) Resolve(ctx context.Context) (interface{}, error) {
 	ctx = SetupContext(ctx, r.Capture, r.Config)
-
-	c, err := capture.ResolveGraphics(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	out := &AttachmentFramebufferChanges{
 		// TODO: Remove hardcoded upper limit
@@ -117,6 +111,6 @@ func (r *FramebufferChangesResolvable) Resolve(ctx context.Context) (interface{}
 		postCmd(s, idx, cmd)
 	}
 
-	sync.MutateWithSubcommands(ctx, r.Capture, c.Commands, postCmd, nil, postSubCmd)
+	sync.MutateWithSubcommands(ctx, r.Capture, nil, postCmd, nil, postSubCmd)
 	return out, nil
 }

--- a/gapis/trace/android/adreno/profiling_data.go
+++ b/gapis/trace/android/adreno/profiling_data.go
@@ -46,7 +46,7 @@ var (
 	renderPassSliceName = "Surface"
 )
 
-func ProcessProfilingData(ctx context.Context, processor *perfetto.Processor, capture *path.Capture, desc *device.GpuCounterDescriptor, handleMapping *map[uint64][]service.VulkanHandleMappingItem, syncData *sync.Data) (*service.ProfilingData, error) {
+func ProcessProfilingData(ctx context.Context, processor *perfetto.Processor, capture *path.Capture, desc *device.GpuCounterDescriptor, handleMapping map[uint64][]service.VulkanHandleMappingItem, syncData *sync.Data) (*service.ProfilingData, error) {
 	slices, err := processGpuSlices(ctx, processor, capture, handleMapping, syncData)
 	if err != nil {
 		log.Err(ctx, err, "Failed to get GPU slices")
@@ -67,9 +67,9 @@ func ProcessProfilingData(ctx context.Context, processor *perfetto.Processor, ca
 	}, nil
 }
 
-func extractTraceHandles(ctx context.Context, replayHandles *[]int64, replayHandleType string, handleMapping *map[uint64][]service.VulkanHandleMappingItem) {
+func extractTraceHandles(ctx context.Context, replayHandles *[]int64, replayHandleType string, handleMapping map[uint64][]service.VulkanHandleMappingItem) {
 	for i, v := range *replayHandles {
-		handles, ok := (*handleMapping)[uint64(v)]
+		handles, ok := handleMapping[uint64(v)]
 		if !ok {
 			log.E(ctx, "%v not found in replay: %v", replayHandleType, v)
 			continue
@@ -125,7 +125,7 @@ func fixContextIds(contextIDs []int64) {
 	}
 }
 
-func processGpuSlices(ctx context.Context, processor *perfetto.Processor, capture *path.Capture, handleMapping *map[uint64][]service.VulkanHandleMappingItem, syncData *sync.Data) (*service.ProfilingData_GpuSlices, error) {
+func processGpuSlices(ctx context.Context, processor *perfetto.Processor, capture *path.Capture, handleMapping map[uint64][]service.VulkanHandleMappingItem, syncData *sync.Data) (*service.ProfilingData_GpuSlices, error) {
 	slicesQueryResult, err := processor.Query(slicesQuery)
 	if err != nil {
 		return nil, log.Errf(ctx, err, "SQL query failed: %v", slicesQuery)

--- a/gapis/trace/android/mali/profiling_data.go
+++ b/gapis/trace/android/mali/profiling_data.go
@@ -45,7 +45,7 @@ var (
 		"SELECT ts, value FROM counter c WHERE c.track_id = %d ORDER BY ts"
 )
 
-func ProcessProfilingData(ctx context.Context, processor *perfetto.Processor, capture *path.Capture, desc *device.GpuCounterDescriptor, handleMapping *map[uint64][]service.VulkanHandleMappingItem, syncData *sync.Data) (*service.ProfilingData, error) {
+func ProcessProfilingData(ctx context.Context, processor *perfetto.Processor, capture *path.Capture, desc *device.GpuCounterDescriptor, handleMapping map[uint64][]service.VulkanHandleMappingItem, syncData *sync.Data) (*service.ProfilingData, error) {
 	slices, err := processGpuSlices(ctx, processor, capture, handleMapping, syncData)
 	if err != nil {
 		log.Err(ctx, err, "Failed to get GPU slices")
@@ -66,9 +66,9 @@ func ProcessProfilingData(ctx context.Context, processor *perfetto.Processor, ca
 	}, nil
 }
 
-func extractTraceHandles(ctx context.Context, replayHandles *[]int64, replayHandleType string, handleMapping *map[uint64][]service.VulkanHandleMappingItem) {
+func extractTraceHandles(ctx context.Context, replayHandles *[]int64, replayHandleType string, handleMapping map[uint64][]service.VulkanHandleMappingItem) {
 	for i, v := range *replayHandles {
-		handles, ok := (*handleMapping)[uint64(v)]
+		handles, ok := handleMapping[uint64(v)]
 		if !ok {
 			log.E(ctx, "%v not found in replay: %v", replayHandleType, v)
 			continue
@@ -89,7 +89,7 @@ func extractTraceHandles(ctx context.Context, replayHandles *[]int64, replayHand
 	}
 }
 
-func processGpuSlices(ctx context.Context, processor *perfetto.Processor, capture *path.Capture, handleMapping *map[uint64][]service.VulkanHandleMappingItem, syncData *sync.Data) (*service.ProfilingData_GpuSlices, error) {
+func processGpuSlices(ctx context.Context, processor *perfetto.Processor, capture *path.Capture, handleMapping map[uint64][]service.VulkanHandleMappingItem, syncData *sync.Data) (*service.ProfilingData_GpuSlices, error) {
 	slicesQueryResult, err := processor.Query(slicesQuery)
 	if err != nil {
 		return nil, log.Errf(ctx, err, "SQL query failed: %v", slicesQuery)

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -126,7 +126,7 @@ func (t *androidTracer) GetDevice() bind.Device {
 	return t.b
 }
 
-func (t *androidTracer) ProcessProfilingData(ctx context.Context, buffer *bytes.Buffer, capture *path.Capture, handleMappings *map[uint64][]service.VulkanHandleMappingItem, syncData *sync.Data) (*service.ProfilingData, error) {
+func (t *androidTracer) ProcessProfilingData(ctx context.Context, buffer *bytes.Buffer, capture *path.Capture, handleMappings map[uint64][]service.VulkanHandleMappingItem, syncData *sync.Data) (*service.ProfilingData, error) {
 	// Load Perfetto trace and create trace processor.
 	rawData := make([]byte, buffer.Len())
 	_, err := buffer.Read(rawData)

--- a/gapis/trace/desktop/trace.go
+++ b/gapis/trace/desktop/trace.go
@@ -56,7 +56,7 @@ func (t *DesktopTracer) GetDevice() bind.Device {
 	return t.b
 }
 
-func (t *DesktopTracer) ProcessProfilingData(ctx context.Context, buffer *bytes.Buffer, capture *gapis_path.Capture, handleMapping *map[uint64][]service.VulkanHandleMappingItem, syncData *sync.Data) (*service.ProfilingData, error) {
+func (t *DesktopTracer) ProcessProfilingData(ctx context.Context, buffer *bytes.Buffer, capture *gapis_path.Capture, handleMapping map[uint64][]service.VulkanHandleMappingItem, syncData *sync.Data) (*service.ProfilingData, error) {
 	return nil, log.Err(ctx, nil, "Desktop replay profiling is unsupported.")
 }
 

--- a/gapis/trace/fuchsia/trace.go
+++ b/gapis/trace/fuchsia/trace.go
@@ -138,7 +138,7 @@ func (t *fuchsiaTracer) GetDevice() bind.Device {
 
 // ProcessProfilingData takes a buffer for a Perfetto trace and translates it into
 // a ProfilingData
-func (t *fuchsiaTracer) ProcessProfilingData(ctx context.Context, buffer *bytes.Buffer, capture *path.Capture, handleMapping *map[uint64][]service.VulkanHandleMappingItem, syncData *sync.Data) (*service.ProfilingData, error) {
+func (t *fuchsiaTracer) ProcessProfilingData(ctx context.Context, buffer *bytes.Buffer, capture *path.Capture, handleMapping map[uint64][]service.VulkanHandleMappingItem, syncData *sync.Data) (*service.ProfilingData, error) {
 	return nil, nil
 }
 

--- a/gapis/trace/trace.go
+++ b/gapis/trace/trace.go
@@ -102,7 +102,7 @@ func TraceConfiguration(ctx context.Context, device *path.Device) (*service.Devi
 	return t.TraceConfiguration(ctx)
 }
 
-func ProcessProfilingData(ctx context.Context, device *path.Device, capture *path.Capture, buffer *bytes.Buffer, handleMapping *map[uint64][]service.VulkanHandleMappingItem, syncData *sync.Data) (*service.ProfilingData, error) {
+func ProcessProfilingData(ctx context.Context, device *path.Device, capture *path.Capture, buffer *bytes.Buffer, handleMapping map[uint64][]service.VulkanHandleMappingItem, syncData *sync.Data) (*service.ProfilingData, error) {
 	t, err := GetTracer(ctx, device)
 	if err != nil {
 		return nil, err

--- a/gapis/trace/tracer/tracer.go
+++ b/gapis/trace/tracer/tracer.go
@@ -75,7 +75,7 @@ type Tracer interface {
 	GetDevice() bind.Device
 	// ProcessProfilingData takes a buffer for a Perfetto trace and translates it into
 	// a ProfilingData
-	ProcessProfilingData(ctx context.Context, buffer *bytes.Buffer, capture *path.Capture, handleMapping *map[uint64][]service.VulkanHandleMappingItem, syncData *sync.Data) (*service.ProfilingData, error)
+	ProcessProfilingData(ctx context.Context, buffer *bytes.Buffer, capture *path.Capture, handleMapping map[uint64][]service.VulkanHandleMappingItem, syncData *sync.Data) (*service.ProfilingData, error)
 	// Validate validates the GPU profiling capabilities of the given device and returns
 	// an error if validation failed or the GPU profiling data is invalid.
 	Validate(ctx context.Context) error


### PR DESCRIPTION
- Small optimization to not have to resolve the capture multiple times for `MutateWithSubcommands`.
- Clean up error construction in `GpuProfile`
- Rename `printToFile2` to a more descriptive name without the `2`.
- Remove unnecessary map pointer stuff for the handle mapping code (maps are passed by reference).
- Remove a dead-code GLES thing left-over in a template.