### PR TITLE
Fix an issue with an update on a disposed widget.

### DIFF
--- a/gapic/src/main/com/google/gapid/views/FramebufferView.java
+++ b/gapic/src/main/com/google/gapid/views/FramebufferView.java
@@ -433,9 +433,11 @@ public class FramebufferView extends Composite
               new GridData(SWT.FILL, SWT.CENTER, true, false));
 
           img.setImage(attachment.getImage(widgets, contents, () -> {
-            img.setImage(attachment.getImage(widgets, contents, this));
-            img.requestLayout();
-            shell.setSize(shell.computeSize(size.width, SWT.DEFAULT));
+            if (!img.isDisposed()) {
+              img.setImage(attachment.getImage(widgets, contents, this));
+              img.requestLayout();
+              shell.setSize(shell.computeSize(size.width, SWT.DEFAULT));
+            }
           }));
 
           img.setBackground(COLOR_LIST_BACKGROUND);


### PR DESCRIPTION
If the framebuffer attachment drop down is closed before the thumbnail finished loading, we end up calling an update function on a disposed widget at 60Hz.

Bug: http://b/204233029