### PR TITLE
Improve Command Tree Filtering

### DIFF
--- a/gapis/api/cmd_id_group.go
+++ b/gapis/api/cmd_id_group.go
@@ -602,6 +602,22 @@ func (g *CmdIDGroup) Cluster(maxChildren, maxNeighbours uint64) {
 	}
 }
 
+// Flatten replaces this node's children with its grandchildren.
+func (g *CmdIDGroup) Flatten() {
+	var newSpans Spans
+	for _, s := range g.Spans {
+		switch v := s.(type) {
+		case *SubCmdRoot:
+			newSpans = append(newSpans, v.SubGroup.Spans...)
+		case *CmdIDGroup:
+			newSpans = append(newSpans, v.Spans...)
+		default:
+			newSpans = append(newSpans, s)
+		}
+	}
+	g.Spans = newSpans
+}
+
 // Split returns a new list of spans where each new span will represent no more
 // than the given number of items.
 func (l Spans) Split(max uint64) Spans {

--- a/gapis/resolve/command_tree.go
+++ b/gapis/resolve/command_tree.go
@@ -308,7 +308,7 @@ func (r *CommandTreeResolvable) Resolve(ctx context.Context) (interface{}, error
 			},
 			"Draw")
 	}
-	if p.GroupBySubmission {
+	if p.GroupBySubmission && !p.Filter.GetSuppressHostCommands() {
 		addContainingGroups(ctx, p, out, c.Commands,
 			func(id api.CmdID, cmd api.Cmd, s *api.GlobalState, idx api.SubCmdIdx) bool {
 				return cmd.CmdFlags().IsSubmission()

--- a/gapis/resolve/command_tree.go
+++ b/gapis/resolve/command_tree.go
@@ -356,6 +356,14 @@ func (r *CommandTreeResolvable) Resolve(ctx context.Context) (interface{}, error
 					return false
 				})
 			}
+
+			// In the current design, it's easier to flatten the tree after the fact,
+			// rather than avoid creating the tree structure in the first place.
+			// TODO(pmuetschard): re-design this to suit Vulkan and avoid this.
+			if p.SuppressSubmitInfoNodes && cmd.CmdFlags().IsSubmission() {
+				subr.SubGroup.Flatten()
+			}
+
 			return nil
 		}
 

--- a/gapis/resolve/command_tree.go
+++ b/gapis/resolve/command_tree.go
@@ -482,26 +482,33 @@ func (f frame) addGroup(t *commandTree) {
 }
 
 func addFrameGroups(ctx context.Context, p *path.CommandTree, t *commandTree, cmds []api.Cmd) {
-
-	eofCommands := make([]api.Cmd, 0)
-	for _, cmd := range cmds {
+	eofCommands := []int{}
+	for idx, cmd := range cmds {
 		if cmd.CmdFlags().IsEndOfFrame() {
-			eofCommands = append(eofCommands, cmd)
+			eofCommands = append(eofCommands, idx)
 		}
+	}
+
+	// No end of frame commands in the trace, no grouping necessary.
+	if len(eofCommands) == 0 {
+		return
+	}
+
+	needIncompleteFrame := eofCommands[len(eofCommands)-1] < len(cmds)-1
+	if len(eofCommands) == 1 && !needIncompleteFrame {
+		// Only one frame, so the group would span the entire range. Don't bother adding it.
+		return
 	}
 
 	frameCount := 0
 	startFrame := 0
-
-	for i, cmd := range cmds {
-		if cmd.CmdFlags().IsEndOfFrame() {
-			t.root.AddGroup(api.CmdID(startFrame), api.CmdID(i+1), fmt.Sprintf("Frame %v", frameCount+1), []api.SubCmdIdx{})
-			startFrame = i + 1
-			frameCount++
-		}
+	for _, idx := range eofCommands {
+		t.root.AddGroup(api.CmdID(startFrame), api.CmdID(idx+1), fmt.Sprintf("Frame %v", frameCount+1), []api.SubCmdIdx{})
+		startFrame = idx + 1
+		frameCount++
 	}
 
-	if p.AllowIncompleteFrame && frameCount > 0 && len(cmds) > startFrame {
+	if p.AllowIncompleteFrame && needIncompleteFrame {
 		t.root.AddGroup(api.CmdID(startFrame), api.CmdID(len(cmds)), fmt.Sprintf("[Incomplete] Frame", frameCount+1), []api.SubCmdIdx{})
 	}
 }

--- a/gapis/service/path/path.proto
+++ b/gapis/service/path/path.proto
@@ -327,6 +327,8 @@ message CommandTree {
   bool group_by_user_markers = 9;
   // If true then commands will be grouped by submission.
   bool group_by_submission = 10;
+  // If true, no tree nodes are created for submit infos.
+  bool suppress_submit_info_nodes = 15;
   // If true and grouping by frames, commands after the last frame will be
   // grouped into an 'incomplete frame' group. Only if there is at least one
   // complete frame.


### PR DESCRIPTION
This contains some some of the followups from #935:
- Don't show the "Host Coordination" group if it's empty.
- Allow filtering out the submit info nodes.
- Don't group by frame if there's only one.