### PR TITLE
Don't show the filter and metadata button in the ProfileView.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/TraceView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/TraceView.java
@@ -72,7 +72,8 @@ public class TraceView extends Composite
 
   private static TraceComposite<State.ForSystemTrace> createTraceUi(
       Composite parent, Models models, Theme theme) {
-    return new TraceComposite<State.ForSystemTrace>(parent, models.analytics, models.perfetto, theme) {
+    return new TraceComposite<State.ForSystemTrace>(
+        parent, models.analytics, models.perfetto, theme, /*fullView*/ true) {
       @Override
       protected State.ForSystemTrace createState() {
         return new State.ForSystemTrace(this);

--- a/gapic/src/main/com/google/gapid/views/ProfileView.java
+++ b/gapic/src/main/com/google/gapid/views/ProfileView.java
@@ -188,7 +188,7 @@ public class ProfileView extends Composite implements Tab, Capture.Listener, Pro
     protected final List<Panel> panels = Lists.newArrayList();
 
     public TraceUi(Composite parent, Analytics analytics, Perfetto perfetto, Theme theme) {
-      super(parent, analytics, perfetto, theme);
+      super(parent, analytics, perfetto, theme, /*fullView*/ false);
     }
 
     public void update(Profile.Data data) {


### PR DESCRIPTION
When showing the system profiler view in the frame profiler, hide some of the UI elements that don't make sense in this view.

Bug: http://b/211637885