### PR TITLE
Add a `adb reconnect` at the start of swarming scripts.

### DIFF
--- a/test/swarming/bot-harness.py
+++ b/test/swarming/bot-harness.py
@@ -77,7 +77,8 @@ def main():
 
     #### Check Android device access
     # This first adb command may take a while if the adb deamon has to launch
-    bu.adb(['reconnect'], timeout=10)
+    p = bu.adb(['reconnect'], timeout=10)
+    print('Connect output: {}{}'.format(p.stdout, p.stderr))
     bu.adb(['shell', 'true'], timeout=10)
     # Print device fingerprint
     p = bu.adb(['shell', 'getprop', 'ro.build.fingerprint'])

--- a/test/swarming/bot-harness.py
+++ b/test/swarming/bot-harness.py
@@ -77,9 +77,10 @@ def main():
 
     #### Check Android device access
     # This first adb command may take a while if the adb deamon has to launch
-    p = bu.adb(['reconnect'], timeout=10)
-    print('Connect output: {}{}'.format(p.stdout, p.stderr))
-    bu.adb(['shell', 'true'], timeout=10)
+    bu.adb(['kill-server'], timeout=10)
+    p = bu.adb(['devices'], timeout=10)
+    print('Devices output: {}{}'.format(p.stdout, p.stderr))
+    bu.adb(['shell', 'true'])
     # Print device fingerprint
     p = bu.adb(['shell', 'getprop', 'ro.build.fingerprint'])
     print('Device fingerprint: ' + p.stdout)

--- a/test/swarming/bot-harness.py
+++ b/test/swarming/bot-harness.py
@@ -77,10 +77,8 @@ def main():
 
     #### Check Android device access
     # This first adb command may take a while if the adb deamon has to launch
-    p = bu.adb(['shell', 'true'], timeout=10)
-    if p.returncode != 0:
-        print('Error: zero or more than one device connected')
-        return 1
+    bu.adb(['reconnect'], timeout=10)
+    bu.adb(['shell', 'true'], timeout=10)
     # Print device fingerprint
     p = bu.adb(['shell', 'getprop', 'ro.build.fingerprint'])
     print('Device fingerprint: ' + p.stdout)

--- a/test/swarming/bot-scripts/botutil.py
+++ b/test/swarming/bot-scripts/botutil.py
@@ -75,7 +75,12 @@ class BotUtil:
         '''Log and run an ADB command, returning a subprocess.CompletedProcess with output captured'''
         cmd = [self.adb_path] + args
         print('ADB command: ' + ' '.join(cmd), flush=True)
-        return subprocess.run(cmd, timeout=timeout, check=True, capture_output=True, text=True)
+        p = subprocess.run(cmd, timeout=timeout, capture_output=True, text=True)
+        if p.returncode:
+            print('ADB command failed: {}, stdout:\n{}\nstderr:\n{}'.format(p.returncode, p.stdout, p.stderr))
+            p.check_returncode() # raises an error
+        return p
+
 
     def set_gapit_path(self, gapit_path):
         '''Set path to gapit, must be called once before gapit() can be used.'''


### PR DESCRIPTION
This should fix issues where the following `adb shell` command fails. Also removes an unnecessary check, since we already fail if the `adb` invocation returns a non-zero exit status.