### PR TITLE
Revert "Rename TARGET_OS_* macros to avoid name conflict (#1017)"

### DIFF
--- a/core/cc/target.h
+++ b/core/cc/target.h
@@ -27,7 +27,7 @@
 #define WINDOWS_ONLY(x)
 #define ANDROID_ONLY(x)
 
-#if defined(GAPID_TARGET_OS_LINUX)
+#if defined(TARGET_OS_LINUX)
 #define TARGET_OS GAPID_OS_LINUX
 #define STDCALL
 #define EXPORT __attribute__((visibility("default")))
@@ -37,7 +37,7 @@
 #define LINUX_ONLY(x) x
 #endif
 
-#if defined(GAPID_TARGET_OS_OSX)
+#if defined(TARGET_OS_OSX)
 #define TARGET_OS GAPID_OS_OSX
 #define STDCALL
 #define EXPORT __attribute__((visibility("default")))
@@ -47,12 +47,12 @@
 #define OSX_ONLY(x) x
 #include <stdint.h>
 using size_val = uint64_t;
-#else  // defined(GAPID_TARGET_OS_OSX)
+#else  // defined(TARGET_OS_OSX)
 #include <stddef.h>
 using size_val = size_t;
 #endif
 
-#if defined(GAPID_TARGET_OS_ANDROID)
+#if defined(TARGET_OS_ANDROID)
 #define TARGET_OS GAPID_OS_ANDROID
 #define STDCALL
 #define EXPORT __attribute__((visibility("default")))
@@ -62,7 +62,7 @@ using size_val = size_t;
 #define ANDROID_ONLY(x) x
 #endif
 
-#if defined(GAPID_TARGET_OS_WINDOWS)
+#if defined(TARGET_OS_WINDOWS)
 #define TARGET_OS GAPID_OS_WINDOWS
 #define STDCALL __stdcall
 #define EXPORT __declspec(dllexport)
@@ -76,7 +76,7 @@ using size_val = size_t;
 #error "OS not defined correctly."
 #error \
     "Exactly one of the following macro have to be defined:" \
-           "GAPID_TARGET_OS_LINUX, GAPID_TARGET_OS_OSX, GAPID_TARGET_OS_WINDOWS, GAPID_TARGET_OS_ANDROID"
+           "TARGET_OS_LINUX, TARGET_OS_OSX, TARGET_OS_WINDOWS, TARGET_OS_ANDROID"
 #endif
 
 #ifdef _MSC_VER  // MSVC

--- a/core/cc/vulkan_ptr_types.h
+++ b/core/cc/vulkan_ptr_types.h
@@ -36,12 +36,12 @@
 
 #include "core/cc/target.h"
 
-#if TARGET_OS == GAPID_OS_WINDOWS
+#if defined(TARGET_OS_WINDOWS)
 // On Windows, Vulkan commands use the stdcall convention
 #define VKAPI_ATTR
 #define VKAPI_CALL __stdcall
 #define VKAPI_PTR VKAPI_CALL
-#elif TARGET_OS == GAPID_OS_ANDROID && defined(__ARM_ARCH_7A__)
+#elif defined(TARGET_OS_ANDROID) && defined(__ARM_ARCH_7A__)
 // On Android/ARMv7a, Vulkan functions use the armeabi-v7a-hard calling
 // convention, even if the application's native code is compiled with the
 // armeabi-v7a calling convention.

--- a/tools/build/rules/cc.bzl
+++ b/tools/build/rules/cc.bzl
@@ -20,15 +20,15 @@ _ANDROID_COPTS = [
     "-ffunction-sections",
     "-fvisibility-inlines-hidden",
     "-DANDROID",
-    "-DGAPID_TARGET_OS_ANDROID",
+    "-DTARGET_OS_ANDROID",
 ]
 
 # This should probably all be done by fixing the toolchains...
 def cc_copts():
     return ["-Werror"] + select({
-        "@gapid//tools/build:linux": ["-DGAPID_TARGET_OS_LINUX"],
-        "@gapid//tools/build:darwin": ["-DGAPID_TARGET_OS_OSX"],
-        "@gapid//tools/build:windows": ["-DGAPID_TARGET_OS_WINDOWS"],
+        "@gapid//tools/build:linux": ["-DTARGET_OS_LINUX"],
+        "@gapid//tools/build:darwin": ["-DTARGET_OS_OSX"],
+        "@gapid//tools/build:windows": ["-DTARGET_OS_WINDOWS"],
         "@gapid//tools/build:android-armeabi-v7a": _ANDROID_COPTS,
         "@gapid//tools/build:android-arm64-v8a": _ANDROID_COPTS,
         "@gapid//tools/build:android-x86": _ANDROID_COPTS,


### PR DESCRIPTION
This reverts commit 10e5468be49daac157c1da77c67c74703a7a5b93.