### PR TITLE
Add third set of Mali counters for validation

### DIFF
--- a/core/os/device/device.proto
+++ b/core/os/device/device.proto
@@ -145,6 +145,8 @@ message GPU {
   string name = 1;
   // Vendor is the vendor of this GPU.
   string vendor = 2;
+  // Version is the version of the driver software of this GPU
+  uint32 version = 3;
 }
 
 // Hardware describes the physical configuration of a computing device.

--- a/core/os/device/deviceinfo/cc/query.cpp
+++ b/core/os/device/deviceinfo/cc/query.cpp
@@ -124,6 +124,7 @@ device::Instance* getDeviceInstance(const Option& opt, std::string* error) {
 
   std::string gpuVendor = "";
   std::string gpuName = "";
+  uint32_t gpuDriverVersion = 0u;
 
   // Checks if the device supports Vulkan (have Vulkan loader) first, then
   // populates the VulkanDriver message.
@@ -138,6 +139,7 @@ device::Instance* getDeviceInstance(const Option& opt, std::string* error) {
         gpuVendor =
             getVendorName(vulkan_driver->physical_devices(0).vendor_id());
         gpuName = vulkan_driver->physical_devices(0).device_name();
+        gpuDriverVersion = vulkan_driver->physical_devices(0).driver_version();
       }
     }
     drivers->set_allocated_vulkan(vulkan_driver);
@@ -154,6 +156,7 @@ device::Instance* getDeviceInstance(const Option& opt, std::string* error) {
   auto gpu = new GPU();
   gpu->set_name(gpuName);
   gpu->set_vendor(gpuVendor);
+  gpu->set_version(gpuDriverVersion);
 
   // Instance.Configuration.Hardware
   auto hardware = new Hardware();

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -82,11 +82,12 @@ type androidTracer struct {
 }
 
 func newValidator(dev bind.Device) validate.Validator {
-	gpuName := dev.Instance().GetConfiguration().GetHardware().GetGPU().GetName()
+	gpu := dev.Instance().GetConfiguration().GetHardware().GetGPU()
+	gpuName := gpu.GetName()
 	if strings.Contains(gpuName, "Adreno") {
 		return &adreno.AdrenoValidator{}
 	} else if strings.Contains(gpuName, "Mali") {
-		return mali.NewMaliValidator(gpuName)
+		return mali.NewMaliValidator(gpuName, gpu.GetVersion())
 	}
 	return nil
 }


### PR DESCRIPTION
 * Add driver version to GPU protobuf
 * Introduce a hardware-agnostic mapping between `id` and Mali counter
 * Use the new driverVersion field in the GPU protobuf to determine
   which set of counters to use for validation
 * Note: this is a breaking change for users who have a text-based
   perfetto config, since counter IDs have changed