### PR TITLE
Split shader static analysis into a separate request

### DIFF
--- a/gapic/src/main/com/google/gapid/models/Resources.java
+++ b/gapic/src/main/com/google/gapid/models/Resources.java
@@ -21,6 +21,7 @@ import static com.google.gapid.util.Paths.isNull;
 import static com.google.gapid.util.Paths.pipelinesAfter;
 import static com.google.gapid.util.Paths.resourceAfter;
 import static com.google.gapid.util.Paths.resourcesAfter;
+import static com.google.gapid.util.Paths.resourceExtrasAfter;
 import static java.util.Collections.emptyList;
 import static java.util.logging.Level.WARNING;
 
@@ -154,6 +155,18 @@ public class Resources extends CaptureDependentModel.ForValue<Resources.Data, Re
     return MoreFutures.transform(
         client.get(resourceAfter(after, resource.getID()), getData().device),
         Service.Value::getResourceData);
+  }
+
+  public ListenableFuture<API.ResourceExtras> loadResourceExtras(Service.Resource resource) {
+    CommandIndex after = commands.getSelectedCommands();
+    if (after == null) {
+      return Futures.immediateFailedFuture(new RuntimeException("No command selected"));
+    }
+
+    // TODO: don't get the device via getData
+    return MoreFutures.transform(
+        client.get(resourceExtrasAfter(after, resource.getID()), getData().device),
+        Service.Value::getResourceExtras);
   }
 
   public ListenableFuture<Service.MultiResourceData> loadResources(Path.ResourceType type) {

--- a/gapic/src/main/com/google/gapid/util/Paths.java
+++ b/gapic/src/main/com/google/gapid/util/Paths.java
@@ -240,6 +240,17 @@ public class Paths {
         .build();
   }
 
+  public static Path.Any resourceExtrasAfter(CommandIndex command, Path.ID id) {
+    if (command == null || id == null) {
+      return null;
+    }
+    return Path.Any.newBuilder()
+        .setResourceExtras(Path.ResourceExtras.newBuilder()
+            .setAfter(command.getCommand())
+            .setID(id))
+        .build();
+  }
+
   public static Path.Any pipelinesAfter(CommandIndex command) {
     if (command == null) {
       return null;

--- a/gapic/src/main/com/google/gapid/views/ShaderView.java
+++ b/gapic/src/main/com/google/gapid/views/ShaderView.java
@@ -230,11 +230,11 @@ public class ShaderView extends Composite
       statTable.setContentProvider(new IStructuredContentProvider() {
         @Override
         public Object[] getElements(Object inputElement) {
-          if (!(inputElement instanceof API.Shader.StaticAnalysis)) {
+          if (!(inputElement instanceof API.ShaderExtras.StaticAnalysis)) {
             return null;
           }
 
-          API.Shader.StaticAnalysis analysis = (API.Shader.StaticAnalysis)inputElement;
+          API.ShaderExtras.StaticAnalysis analysis = (API.ShaderExtras.StaticAnalysis)inputElement;
           return new Object[] {
               new Object[] { "ALU Instructions", analysis.getAluInstructions() },
               new Object[] { "Texture Instructions", analysis.getTextureInstructions() },
@@ -243,7 +243,7 @@ public class ShaderView extends Composite
           };
         }
       });
-      statTable.setInput(API.Shader.StaticAnalysis.getDefaultInstance());
+      statTable.setInput(API.ShaderExtras.StaticAnalysis.getDefaultInstance());
       packColumns(statTable.getTable());
 
       clear();
@@ -281,6 +281,19 @@ public class ShaderView extends Composite
     }
 
     public void setShader(Service.Resource resource, API.Shader shader) {
+      rpcController.start().listen(models.resources.loadResourceExtras(resource),
+          new UiCallback<API.ResourceExtras, API.ShaderExtras>(this, LOG) {
+        @Override
+        protected API.ShaderExtras onRpcThread(Rpc.Result<API.ResourceExtras> result)
+            throws RpcException, ExecutionException {
+          return result.get().getShaderExtras();
+        }
+
+        @Override
+        protected void onUiThread(API.ShaderExtras result) {
+          statTable.setInput(result.getStaticAnalysis());
+        }
+      });
       loading.stopLoading();
 
       shaderResource = resource;
@@ -310,8 +323,6 @@ public class ShaderView extends Composite
         sourceTab.dispose();
         sourceTab = null;
       }
-
-      statTable.setInput(shader.getStaticAnalysis());
     }
 
     private void save() {

--- a/gapis/api/resource.go
+++ b/gapis/api/resource.go
@@ -56,6 +56,9 @@ type Resource interface {
 		edits ReplaceCallback,
 		mutate MutateInitialState,
 		r *path.ResolveConfig) error
+
+	// ResourceExtras returns the resource data given the current state.
+	ResourceExtras(ctx context.Context, s *GlobalState, cmd *path.Command, r *path.ResolveConfig) (*ResourceExtras, error)
 }
 
 // ReplaceCallback is called from SetResourceData to propagate changes to current command stream.
@@ -104,6 +107,16 @@ func NewResourceData(data interface{}) *ResourceData {
 		return &ResourceData{Data: &ResourceData_Pipeline{data}}
 	default:
 		panic(fmt.Errorf("%T is not a ResourceData type", data))
+	}
+}
+
+// NewResourceExtras returns a new *ResourceExtras with the specified data.
+func NewResourceExtras(data interface{}) *ResourceExtras {
+	switch data := data.(type) {
+	case *ShaderExtras:
+		return &ResourceExtras{Data: &ResourceExtras_ShaderExtras{data}}
+	default:
+		panic(fmt.Errorf("%T is not a ResourceExtras type", data))
 	}
 }
 

--- a/gapis/api/service.proto
+++ b/gapis/api/service.proto
@@ -118,6 +118,14 @@ message ResourceData {
   }
 }
 
+// ResourceExtras represents extra resource state that may be too expensive to
+// pre-compute
+message ResourceExtras {
+  oneof data {
+    ShaderExtras shader_extras = 1;
+  }
+}
+
 // MultiResourceData represents the state  of resources at a single point in a
 // capture
 message MultiResourceData {
@@ -144,14 +152,17 @@ message Shader {
   string source_language = 3;
   string spirv_source = 4;
   bool cross_compiled = 5;
+}
 
+// Extra data for a shader resource.
+message ShaderExtras {
   message StaticAnalysis {
     uint32 alu_instructions = 1;
     uint32 texture_instructions = 2;
     uint32 branch_instructions = 3;
     uint32 temp_registers = 4;
   }
-  StaticAnalysis static_analysis = 6;
+  StaticAnalysis static_analysis = 1;
 }
 
 // Uniform respresents a uniform/active uniform resource.

--- a/gapis/resolve/resolve.go
+++ b/gapis/resolve/resolve.go
@@ -349,6 +349,8 @@ func ResolveInternal(ctx context.Context, p path.Node, r *path.ResolveConfig) (i
 		return Report(ctx, p, r)
 	case *path.ResourceData:
 		return ResourceData(ctx, p, r)
+	case *path.ResourceExtras:
+		return ResourceExtras(ctx, p, r)
 	case *path.MultiResourceData:
 		return ResourceDatas(ctx, p, r)
 	case *path.Resources:

--- a/gapis/service/path/path.go
+++ b/gapis/service/path/path.go
@@ -98,6 +98,7 @@ func (n *StateTreeNodeForPath) Path() *Any      { return &Any{Path: &Any_StateTr
 func (n *Stats) Path() *Any                     { return &Any{Path: &Any_Stats{n}} }
 func (n *Thumbnail) Path() *Any                 { return &Any{Path: &Any_Thumbnail{n}} }
 func (n *Type) Path() *Any                      { return &Any{Path: &Any_Type{n}} }
+func (n *ResourceExtras) Path() *Any            { return &Any{Path: &Any_ResourceExtras{n}} }
 
 func (n API) Parent() Node                       { return nil }
 func (n ArrayIndex) Parent() Node                { return oneOfNode(n.Array) }
@@ -129,6 +130,7 @@ func (n Parameter) Parent() Node                 { return n.Command }
 func (n Pipelines) Parent() Node                 { return oneOfNode(n.Object) }
 func (n Report) Parent() Node                    { return n.Capture }
 func (n ResourceData) Parent() Node              { return n.After }
+func (n ResourceExtras) Parent() Node            { return n.After }
 func (n MultiResourceData) Parent() Node         { return n.After }
 func (n Resources) Parent() Node                 { return n.Capture }
 func (n Result) Parent() Node                    { return n.Command }
@@ -165,6 +167,7 @@ func (n *Messages) SetParent(p Node)                  { n.Capture, _ = p.(*Captu
 func (n *Parameter) SetParent(p Node)                 { n.Command, _ = p.(*Command) }
 func (n *Report) SetParent(p Node)                    { n.Capture, _ = p.(*Capture) }
 func (n *ResourceData) SetParent(p Node)              { n.After, _ = p.(*Command) }
+func (n *ResourceExtras) SetParent(p Node)            { n.After, _ = p.(*Command) }
 func (n *MultiResourceData) SetParent(p Node)         { n.After, _ = p.(*Command) }
 func (n *Resources) SetParent(p Node)                 { n.Capture, _ = p.(*Capture) }
 func (n *Result) SetParent(p Node)                    { n.Command, _ = p.(*Command) }
@@ -273,6 +276,11 @@ func (n Report) Format(f fmt.State, c rune) { fmt.Fprintf(f, "%v.report", n.Pare
 // Format implements fmt.Formatter to print the path.
 func (n ResourceData) Format(f fmt.State, c rune) {
 	fmt.Fprintf(f, "%v.resource-data<%x>", n.Parent(), n.ID)
+}
+
+// Format implements fmt.Formatter to print the path.
+func (n ResourceExtras) Format(f fmt.State, c rune) {
+	fmt.Fprintf(f, "%v.resource-extras<%x>", n.Parent(), n.ID)
 }
 
 // Format implements fmt.Formatter to print the path.

--- a/gapis/service/path/path.proto
+++ b/gapis/service/path/path.proto
@@ -67,6 +67,7 @@ message Any {
     Thumbnail thumbnail = 42;
     Type type = 43;
     Framegraph framegraph = 44;
+    ResourceExtras resource_extras = 45;
   }
 }
 
@@ -489,6 +490,13 @@ message Resources {
 // ResourceData is a path to a single resource snapshot at a given point in an
 // command stream.
 message ResourceData {
+  ID ID = 1;
+  Command after = 2;
+}
+
+// ResourceExtras is a path to extra data for a single resource at a given point
+// in an command stream.
+message ResourceExtras {
   ID ID = 1;
   Command after = 2;
 }

--- a/gapis/service/path/validate.go
+++ b/gapis/service/path/validate.go
@@ -267,6 +267,14 @@ func (n *ResourceData) Validate() error {
 }
 
 // Validate checks the path is valid.
+func (n *ResourceExtras) Validate() error {
+	return anyErr(
+		checkNotNilAndValidate(n, n.After, "after"),
+		checkIsValid(n, n.ID, "id"),
+	)
+}
+
+// Validate checks the path is valid.
 func (n *MultiResourceData) Validate() error {
 	if err := checkNotNilAndValidate(n, n.After, "after"); err != nil {
 		return err

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -286,6 +286,8 @@ func NewValue(v interface{}) *Value {
 		return &Value{Val: &Value_Metrics{v}}
 	case *api.ResourceData:
 		return &Value{Val: &Value_ResourceData{v}}
+	case *api.ResourceExtras:
+		return &Value{Val: &Value_ResourceExtras{v}}
 	case *image.Info:
 		return &Value{Val: &Value_ImageInfo{v}}
 	case *device.Instance:
@@ -304,7 +306,6 @@ func NewValue(v interface{}) *Value {
 		return &Value{Val: &Value_TraceConfig{v}}
 	case *types.Type:
 		return &Value{Val: &Value_Type{v}}
-
 	default:
 		if v := box.NewValue(v); v != nil {
 			return &Value{Val: &Value_Box{v}}

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -140,6 +140,7 @@ message Value {
     FramebufferAttachments framebuffer_attachments = 35;
     FramebufferAttachment framebuffer_attachment = 36;
     api.Framegraph framegraph = 37;
+    api.ResourceExtras resource_extras = 39;
 
     image.Info image_info = 40;
 


### PR DESCRIPTION
Pre-computing shader static analysis for every shader as part of
ResourceData was taking too long. This change splits static analysis
data into a new ResourceExtras request that is made as needed for each
individual shader.

Fixes b/214238704: Shader view is really slow as it's doing static analysis for every shader
