### PR TITLE
Fix the rendering of EAC formats.

### DIFF
--- a/core/image/etc2.go
+++ b/core/image/etc2.go
@@ -15,6 +15,8 @@
 package image
 
 import (
+	"fmt"
+
 	"github.com/google/gapid/core/math/sint"
 	"github.com/google/gapid/core/stream"
 )
@@ -32,7 +34,9 @@ func NewETC2(name string, colorMode FmtETC2_ColorMode, alphaMode FmtETC2_AlphaMo
 }
 
 func (f *FmtETC2) key() interface{} {
-	return f.String()
+	// If enum value is 0, it's not included in f.String()
+	// causes FmtETC2_R11's string to be empty
+	return fmt.Sprintf("FmtETCS{ColorMode:%v, AlphaMode:%v}", f.ColorMode, f.AlphaMode)
 }
 
 func (f *FmtETC2) size(w, h, d int) int {

--- a/core/image/uncompressed.go
+++ b/core/image/uncompressed.go
@@ -34,6 +34,10 @@ var (
 	RG_S16_NORM   = newUncompressed(fmts.RG_S16_NORM)
 	Gray_U8_NORM  = newUncompressed(fmts.Gray_U8_NORM)
 	D_U16_NORM    = newUncompressed(fmts.D_U16_NORM)
+
+	Luminance_R32      = newUncompressed(fmts.L_F32)
+	Luminance_U8_NORM  = newUncompressed(fmts.L_U8_NORM)
+	LuminanceA_U8_NORM = newUncompressed(fmts.LA_U8_NORM)
 )
 
 // newUncompressed returns a new uncompressed format containing with the default
@@ -66,7 +70,7 @@ func (f *FmtUncompressed) channels() stream.Channels {
 }
 
 func (f *FmtUncompressed) resize(data []byte, srcW, srcH, srcD, dstW, dstH, dstD int) ([]byte, error) {
-	format := &Format{Name: "", Format: &Format_Uncompressed{f}}
+	format := &Format{Name: "Temporary Uncompressed Format", Format: &Format_Uncompressed{f}}
 	data, err := Convert(data, srcW, srcH, srcD, format, RGBA_F32)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- RG formats will be rendered into RGBA
- R formats will be rendered into luminance

For this purpose, this PR adds:

- R16 to Luminance Float conversion support
- Some fixing with the format naming to prevent empty format names in logs

b/150716494