### PR TITLE
Fix validation segfault

### DIFF
--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -275,7 +275,6 @@ func (t *androidTracer) Validate(ctx context.Context, enableLocalFiles bool) (*s
 			traceLoadingErr = log.Err(ctx, err, "Failed to initialize the perfetto processor")
 			return
 		}
-		defer processor.Close()
 
 		file, err := os.OpenFile(temp.System(), os.O_APPEND|os.O_WRONLY, fs.ModeAppend)
 		if err != nil {
@@ -297,6 +296,7 @@ func (t *androidTracer) Validate(ctx context.Context, enableLocalFiles bool) (*s
 	res := &service.DeviceValidationResult{
 		TracePath: temp.System(),
 	}
+	defer processor.Close()
 	ctx = status.Start(ctx, "Validation")
 	defer status.Finish(ctx)
 


### PR DESCRIPTION
Move `defer processor.Close()` out of the block to fix segfault from processor being closed before it could be used