### PR TITLE
Add more UI for device validation

### DIFF
--- a/gapis/trace/android/validate/validate.go
+++ b/gapis/trace/android/validate/validate.go
@@ -168,14 +168,14 @@ func ValidateGpuCounters(ctx context.Context, processor *perfetto.Processor, cou
 			return log.Errf(ctx, err, "Failed to query with %v", fmt.Sprintf(counterIDQuery, counter.Name))
 		}
 		if len(queryResult.GetColumns()) != 1 {
-			return log.Errf(ctx, err, "Expect one result with query: %v", fmt.Sprintf(counterIDQuery, counter.Name))
+			return log.Errf(ctx, err, "Expected one result with query: %v", fmt.Sprintf(counterIDQuery, counter.Name))
 		}
 		var counterID int64
 		for _, column := range queryResult.GetColumns() {
 			longValues := column.GetLongValues()
 			if len(longValues) != 1 {
 				// This should never happen, but sill have a check.
-				return log.Errf(ctx, nil, "Query result is not 1: %v", counter)
+				return log.Errf(ctx, nil, "Queried result is not 1: %v", counter)
 			}
 			counterID = longValues[0]
 			break


### PR DESCRIPTION
Add UI elements to display more info around validation failure

Here's what it looks like for failures before tracing (no trace file link). We don't actually require Android API level 99 lol
<img width="903" alt="Screen Shot 2022-03-02 at 7 02 24 PM" src="https://user-images.githubusercontent.com/14023901/156436774-dff0bc1f-e28d-4575-85bb-964ad15d9bf9.png">

Here's what it looks like when the trace validation fails (also shows what it looks like in a different dialog)
<img width="911" alt="Screen Shot 2022-03-02 at 7 05 20 PM" src="https://user-images.githubusercontent.com/14023901/156436887-e4c7bab6-edce-4026-bef5-9104fa34ff84.png">

And for good measure here's what it looks like when it passes:
<img width="881" alt="Screen Shot 2022-03-02 at 7 07 43 PM" src="https://user-images.githubusercontent.com/14023901/156436765-52732f78-7b4a-4f91-9952-ab6c91ab9416.png">