### PR TITLE
Improves the GPU counter selection.

### DIFF
--- a/gapic/src/main/com/google/gapid/settings.proto
+++ b/gapic/src/main/com/google/gapid/settings.proto
@@ -142,13 +142,18 @@ message Perfetto {
   }
   CPU cpu = 1;
 
+  message GPUCounters {
+    repeated int32 counter_ids = 1;
+  }
+
   message GPU {
     bool enabled = 1;
     bool slices = 2;
     bool counters = 3;
     int32 counter_rate = 4;
-    repeated int32 counter_ids = 5;
+    reserved 5;
     bool surface_flinger = 6;
+    map<string, GPUCounters> counters_by_gpu = 7;
   }
   GPU gpu = 2;
 


### PR DESCRIPTION
- Use the select-by-default field of the counter info to determine whether a counter should be enabled by default.
- Remember selected counters by GPU name, as counter IDs vary by GPU model and vendor, making the remembered counter IDs messy for users tracing on multiple devices.

Bug: http://b/172579026