### PR TITLE
Fix minor issue with mouse cursor in the command tree.

### DIFF
--- a/gapic/src/main/com/google/gapid/views/CommandTree.java
+++ b/gapic/src/main/com/google/gapid/views/CommandTree.java
@@ -1188,7 +1188,12 @@ public class CommandTree extends Canvas
       }
     }
 
-    updateCursor(ex - size.tree.x + treeHBar.getSelection());
+    if (ex < size.tree.x || ex >= size.tree.x + size.tree.w) {
+      setCursor(null);
+    } else {
+      double x = ex - size.tree.x + treeHBar.getSelection();
+      setCursor(getFollow(x) != null ? getDisplay().getSystemCursor(SWT.CURSOR_HAND) : null);
+    }
   }
 
   private void checkHoveredRow() {
@@ -1234,10 +1239,6 @@ public class CommandTree extends Canvas
   private boolean shouldShowImage(CommandStream.Node node) {
     return models.images.isReady() &&
         node.getData() != null && !node.getData().getGroup().isEmpty();
-  }
-
-  private void updateCursor(double x) {
-    setCursor(getFollow(x) != null ? getDisplay().getSystemCursor(SWT.CURSOR_HAND) : null);
   }
 
   @Override


### PR DESCRIPTION
When hovering in the counter area on a row where the command in the tree portion of the view is truncated, the mouse may change to the hand cursor, hen it shouldn't, as it is looking at the truncated portion of the command when determining if there's a link under the mouse cursor.