### PR TITLE
Ensure resource IDs for MEC resources are unique.

### DIFF
--- a/gapis/resolve/resource_data.go
+++ b/gapis/resolve/resource_data.go
@@ -78,7 +78,7 @@ func buildResources(ctx context.Context, p *path.Command, t path.ResourceType, r
 		return nil, err
 	}
 	state := capture.NewUninitializedState(ctx).ReserveMemory(ranges)
-	var currentCmdIndex uint64
+	var currentCmdIndex uint64 = 0xffffffffffffffff
 	var currentCmdResourceCount int
 	idMap := api.ResourceMap{}
 
@@ -230,7 +230,7 @@ func ResourceExtras(ctx context.Context, p *path.ResourceExtras, r *path.Resolve
 		return nil, err
 	}
 
-	var currentCmdIndex uint64
+	var currentCmdIndex uint64 = 0xffffffffffffffff
 	var currentCmdResourceCount int
 	var resource api.Resource
 	state := capture.NewUninitializedState(ctx).ReserveMemory(ranges)

--- a/gapis/resolve/resources.go
+++ b/gapis/resolve/resources.go
@@ -50,7 +50,7 @@ func (r *ResourcesResolvable) Resolve(ctx context.Context) (interface{}, error) 
 	resourceTypes := map[string]path.ResourceType{}
 	seen := map[api.Resource]int{}
 
-	var currentCmdIndex uint64
+	var currentCmdIndex uint64 = 0xffffffffffffffff
 	var currentCmdResourceCount int
 	// If the capture contains initial state, build the necessary commands to recreate it.
 	initialCmds, ranges, err := initialcmds.InitialCommands(ctx, r.Capture)


### PR DESCRIPTION
If the first command in the trace creates resources, their IDs would match the IDs generated for the resources serialized as part of the MEC state. This happened because the command ID used to generate the resource IDs for the MEC resources was the same as that of the first command. This would result in the first MEC resource to get ID 0xdd3d... and the first resource of the traced commands to get a matching ID. This change fixes this, by ensuring the MEC resources get gen'ed off a unique command ID.

BUG: http://b/223822750