### PR TITLE
Fix VK_KHR_separate_depth_stencil_layouts

### DIFF
--- a/gapis/api/vulkan/api/renderpass_framebuffer.api
+++ b/gapis/api/vulkan/api/renderpass_framebuffer.api
@@ -366,7 +366,7 @@ sub ref!RenderPassObject createRenderPassObjectFromInfo2(
   attachments := info.pAttachments[0:info.attachmentCount]
   for i in (0 .. info.attachmentCount) {
     attachment := attachments[i]
-    renderPass.AttachmentDescriptions[i] = AttachmentDescription(
+    attachmentDescription := AttachmentDescription(
       Flags: attachment.flags,
       Format: attachment.format,
       Samples: attachment.samples,
@@ -386,7 +386,7 @@ sub ref!RenderPassObject createRenderPassObjectFromInfo2(
         switch sType {
           case VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT: {
             ext := as!VkAttachmentDescriptionStencilLayout*(next.Ptr)[0]
-            renderPass.AttachmentDescriptions[j].StencilLayout = new!AttachmentDescriptionStencilLayout(
+            attachmentDescription.StencilLayout = new!AttachmentDescriptionStencilLayout(
               StencilInitialLayout: ext.stencilInitialLayout,
               StencilFinalLayout: ext.stencilFinalLayout,
             )
@@ -394,6 +394,7 @@ sub ref!RenderPassObject createRenderPassObjectFromInfo2(
         }
       }
     }
+    renderPass.AttachmentDescriptions[i] = attachmentDescription
   }
 
   subpasses := info.pSubpasses[0:info.subpassCount]


### PR DESCRIPTION
Even though the test app captured and replayed without issue, the state view
showed that `VkAttachmentDescriptionStencilLayout` was not saved for the
render passes that included it. This appears to be caused by the api
file silently failing to modify `renderPass.AttachmentDescriptions[i]`
after initially setting it, so set it after processing the pNext chain
instead.