### PR TITLE
Handle malformed dumpsys package output.

### DIFF
--- a/core/os/android/adb/adb_data_test.go
+++ b/core/os/android/adb/adb_data_test.go
@@ -95,7 +95,10 @@ Activity Resolver Table:
 Packages:
   Package [com.google.foo] (ffffffc):
     userId=12345
-    primaryCpuAbi=armeabi-v7a
+    *** extra whitespace on next line is for testing https://github.com/google/agi/issues/1077 ***
+    *** Do not remove it, doing so will make the tests fail ***
+
+primaryCpuAbi=armeabi-v7a
     secondaryCpuAbi=null
     versionCode=902107 minSdk=14 targetSdk=15
     flags=[ HAS_CODE ALLOW_CLEAR_USER_DATA ALLOW_BACKUP ]


### PR DESCRIPTION
Some devices produce malformed `dumpsys package` output, adding in extra newlines. This change handles a specific version of how this extra whitespace breaks the parser.

Parsing the output of `dumpsys package` is not really a good way to do this. Fixing this in a better way is tracked in http://b/229287771

Fixes #1077