### PR TITLE
Fixes an issue with MEC resources' creation command reference.

### DIFF
--- a/gapic/src/main/com/google/gapid/views/ShaderView.java
+++ b/gapic/src/main/com/google/gapid/views/ShaderView.java
@@ -123,7 +123,7 @@ public class ShaderView extends Composite
     private final TabFolder tabFolder;
     private final Composite sourceContainer;
     private final Group statGroup;
-    private final TableViewer statTable;
+    protected final TableViewer statTable;
     private final GridData crossCompileGridData;
     private final SourceViewer spirvViewer;
     private final SourceViewer sourceViewer;
@@ -281,19 +281,22 @@ public class ShaderView extends Composite
     }
 
     public void setShader(Service.Resource resource, API.Shader shader) {
-      rpcController.start().listen(models.resources.loadResourceExtras(resource),
-          new UiCallback<API.ResourceExtras, API.ShaderExtras>(this, LOG) {
-        @Override
-        protected API.ShaderExtras onRpcThread(Rpc.Result<API.ResourceExtras> result)
-            throws RpcException, ExecutionException {
-          return result.get().getShaderExtras();
-        }
+      if (resource != null) {
+        rpcController.start().listen(models.resources.loadResourceExtras(resource),
+            new UiCallback<API.ResourceExtras, API.ShaderExtras>(this, LOG) {
+          @Override
+          protected API.ShaderExtras onRpcThread(Rpc.Result<API.ResourceExtras> result)
+              throws RpcException, ExecutionException {
+            return result.get().getShaderExtras();
+          }
 
-        @Override
-        protected void onUiThread(API.ShaderExtras result) {
-          statTable.setInput(result.getStaticAnalysis());
-        }
-      });
+          @Override
+          protected void onUiThread(API.ShaderExtras result) {
+            statTable.setInput(result.getStaticAnalysis());
+          }
+        });
+      }
+
       loading.stopLoading();
 
       shaderResource = resource;


### PR DESCRIPTION
We track at what command resources are created. Resources created before the trace (in the MEC state) do not have a "creation command". In the past they were associated with the first command in the trace, which has caused some minor reporting type problems, but also later on a crash. This was partially fixed in 21f0184, but together with e313301 caused a
regression in the pipeline view, which now was no longer properly referring to shader resources due to the now negative creation reference.

Fixes #1074
Bug: http://b/229387566