### PR TITLE
Handle vkGetPhysicalDeviceSurfaceFormats2KHR in the virtual swapchain.

### DIFF
--- a/core/vulkan/vk_virtual_swapchain/cc/layer.cpp
+++ b/core/vulkan/vk_virtual_swapchain/cc/layer.cpp
@@ -516,6 +516,7 @@ vkGetInstanceProcAddr(VkInstance instance, const char* funcName) {
 
   INTERCEPT(vkGetPhysicalDeviceSurfaceSupportKHR);
   INTERCEPT(vkGetPhysicalDeviceSurfaceFormatsKHR);
+  INTERCEPT(vkGetPhysicalDeviceSurfaceFormats2KHR);
   INTERCEPT(vkGetPhysicalDeviceSurfaceCapabilitiesKHR);
   INTERCEPT(vkGetPhysicalDeviceSurfaceCapabilities2KHR);
   INTERCEPT(vkGetPhysicalDeviceSurfacePresentModesKHR);

--- a/core/vulkan/vk_virtual_swapchain/cc/swapchain.cpp
+++ b/core/vulkan/vk_virtual_swapchain/cc/swapchain.cpp
@@ -213,6 +213,15 @@ VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfaceFormatsKHR(
   return VK_SUCCESS;
 }
 
+VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfaceFormats2KHR(
+    VkPhysicalDevice physicalDevice,
+    const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
+    uint32_t* pSurfaceFormatCount, VkSurfaceFormatKHR* pSurfaceFormats) {
+  return swapchain::vkGetPhysicalDeviceSurfaceFormatsKHR(
+      physicalDevice, pSurfaceInfo->surface, pSurfaceFormatCount,
+      pSurfaceFormats);
+}
+
 VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfacePresentModesKHR(
     VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
     uint32_t* pPresentModeCount, VkPresentModeKHR* pPresentModes) {

--- a/core/vulkan/vk_virtual_swapchain/cc/swapchain.h
+++ b/core/vulkan/vk_virtual_swapchain/cc/swapchain.h
@@ -55,6 +55,11 @@ VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfaceFormatsKHR(
     VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
     uint32_t* pSurfaceFormatCount, VkSurfaceFormatKHR* pSurfaceFormats);
 
+VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfaceFormats2KHR(
+    VkPhysicalDevice physicalDevice,
+    const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
+    uint32_t* pSurfaceFormatCount, VkSurfaceFormatKHR* pSurfaceFormats);
+
 VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfacePresentModesKHR(
     VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
     uint32_t* pPresentModeCount, VkPresentModeKHR* pPresentModes);


### PR DESCRIPTION
Fixes #1069 