### PR TITLE
Fix bazel using "python" rather than "python3". 

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,3 +48,11 @@ load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 grpc_deps()
 load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 grpc_extra_deps()
+
+# Python setup.
+load("@rules_python//python:repositories.bzl", "python_register_toolchains")
+
+python_register_toolchains(
+    name = "python3_9",
+    python_version = "3.9",
+)

--- a/tools/build/third_party/rules_python.patch
+++ b/tools/build/third_party/rules_python.patch
@@ -1,0 +1,11 @@
+diff --git a/python/repositories.bzl b/python/repositories.bzl
+--- a/python/repositories.bzl
++++ b/python/repositories.bzl
+@@ -152,6 +152,7 @@ py_runtime(
+     files = [":files"],
+     interpreter = "{python_path}",
+     python_version = "PY3",
++    stub_shebang = "#!/usr/bin/env python3",
+ )
+
+ py_runtime_pair(

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -50,6 +50,10 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
         project = "rules_python",
         commit = "ae7a2677b3003b13d45bc9bfc25f1425bed5b407",  # 0.8.1
         sha256 = "f1c3069679395ac1c1104f28a166f06167d30d41bdb1797d154d80b511780d2e",
+        patches = [
+            # Fix the problem with trying to use /usr/bin/python rather than a versioned python.
+            "@gapid//tools/build/third_party:rules_python.patch",
+        ],
     )
 
     maybe_repository(

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -44,6 +44,16 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
 
     maybe_repository(
         github_repository,
+        name = "rules_python",
+        locals = locals,
+        organization = "bazelbuild",
+        project = "rules_python",
+        commit = "ae7a2677b3003b13d45bc9bfc25f1425bed5b407",  # 0.8.1
+        sha256 = "f1c3069679395ac1c1104f28a166f06167d30d41bdb1797d154d80b511780d2e",
+    )
+
+    maybe_repository(
+        github_repository,
         name = "bazel_gazelle",
         locals = locals,
         organization = "bazelbuild",


### PR DESCRIPTION
This changes bazel's default shebang from `#!/usr/bin/env python` to `#!/user/bin/env python3`. This only affects genrule scripts, which, however, includes the wrapper script used for py_binaries. Newer versions of bazel have changed to this new default already.
