### PR TITLE
This is a small maintaince PR that changes some of the decision

### DIFF
--- a/tools/build/python/pylintrc
+++ b/tools/build/python/pylintrc
@@ -21,7 +21,6 @@
 #   https://google.github.io/styleguide/pylintrc
 
 [MASTER]
-
 # Files or directories to be skipped. They should be base names, not paths.
 ignore=third_party
 
@@ -279,9 +278,9 @@ generated-members=
 
 [FORMAT]
 
-# Melih : We deviate from Google Standard here and using line-lenght 100 instead of 80
+# Melih : We deviate from Google Standard here and using line-lenght 120 instead of 80
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=120
 
 # TODO(https://github.com/PyCQA/pylint/issues/3352): Direct pylint to exempt
 # lines made too long by directives to pytype.

--- a/vulkan_generator/generator.py
+++ b/vulkan_generator/generator.py
@@ -17,11 +17,11 @@
 from pathlib import Path
 import pprint
 
-from vulkan_parser import parser as vulkan_parser
-from vulkan_parser import type_parser
+from vulkan_generator.vulkan_parser import parser as vulkan_parser
+from vulkan_generator.vulkan_parser import types
 
 
-def print_vulkan_metaadata(vulkan_metadata: type_parser.AllVulkanTypes) -> None:
+def print_vulkan_metaadata(vulkan_metadata: types.AllVulkanTypes) -> None:
     """Prints all the vulkan information that is extracted"""
 
     pretty_printer = pprint.PrettyPrinter(depth=4)

--- a/vulkan_generator/tests/test_funcptr_parsing.py
+++ b/vulkan_generator/tests/test_funcptr_parsing.py
@@ -44,17 +44,17 @@ def test_vulkan_func_pointer() -> None:
     assert funcptr.return_type == "void"
     assert len(funcptr.arguments) == 4
 
-    assert funcptr.arguments[0].typename == "void*"
-    assert funcptr.arguments[0].argument_name == "pUserData"
+    assert funcptr.argument_order[0] == "pUserData"
+    assert funcptr.arguments["pUserData"].argument_type == "void*"
 
-    assert funcptr.arguments[1].typename == "size_t"
-    assert funcptr.arguments[1].argument_name == "size"
+    assert funcptr.argument_order[1] == "size"
+    assert funcptr.arguments["size"].argument_type == "size_t"
 
-    assert funcptr.arguments[2].typename == "VkInternalAllocationType"
-    assert funcptr.arguments[2].argument_name == "allocationType"
+    assert funcptr.argument_order[2] == "allocationType"
+    assert funcptr.arguments["allocationType"].argument_type == "VkInternalAllocationType"
 
-    assert funcptr.arguments[3].typename == "VkSystemAllocationScope"
-    assert funcptr.arguments[3].argument_name == "allocationScope"
+    assert funcptr.argument_order[3] == "allocationScope"
+    assert funcptr.arguments["allocationScope"].argument_type == "VkSystemAllocationScope"
 
 
 def test_vulkan_func_pointer_with_pointer_return_value() -> None:
@@ -92,6 +92,5 @@ def test_vulkan_func_pointer_with_const_member() -> None:
     """
 
     funcptr = funcptr_parser.parse(ET.fromstring(xml))
-
-    assert funcptr.arguments[4].argument_name == "messageCode"
-    assert funcptr.arguments[5].typename == "const char*"
+    assert funcptr.argument_order[4] == "messageCode"
+    assert funcptr.arguments["pLayerPrefix"].argument_type == "const char*"

--- a/vulkan_generator/tests/test_handle_parsing.py
+++ b/vulkan_generator/tests/test_handle_parsing.py
@@ -32,7 +32,7 @@ def test_vulkan_handle_by_tag() -> None:
     <type category="handle" parent="VkDevice" objtypeenum="VK_OBJECT_TYPE_QUEUE">
     <type>VK_DEFINE_HANDLE</type>(<name>VkQueue</name>)</type>"""
 
-    handle = handle_parser.parse_handle_by_tag(ET.fromstring(xml))
+    handle = handle_parser.parse(ET.fromstring(xml))
 
     assert isinstance(handle, types.VulkanHandle)
     assert handle.typename == "VkQueue"
@@ -46,7 +46,7 @@ def test_vulkan_handle_by_attribute() -> None:
         alias="VkDescriptorUpdateTemplate"/>
     """
 
-    handle = handle_parser.parse_handle_by_attribute(ET.fromstring(xml))
+    handle = handle_parser.parse(ET.fromstring(xml))
 
     assert isinstance(handle, types.VulkanHandleAlias)
     assert handle.typename == "VkDescriptorUpdateTemplateKHR"

--- a/vulkan_generator/tests/test_struct_parsing.py
+++ b/vulkan_generator/tests/test_struct_parsing.py
@@ -46,14 +46,14 @@ def test_vulkan_struct_with_members() -> None:
     assert typ.typename == "VkDevicePrivateDataCreateInfo"
 
     assert len(typ.members) == 3
-    assert "sType" in typ.members
-    assert typ.members["sType"].typename == "VkStructureType"
+    assert typ.member_order[0] == "sType"
+    assert typ.members["sType"].variable_type == "VkStructureType"
 
-    assert "pNext" in typ.members
-    assert typ.members["pNext"].typename == "const void*"
+    assert typ.member_order[1] == "pNext"
+    assert typ.members["pNext"].variable_type == "const void*"
 
-    assert "privateDataSlotRequestCount" in typ.members
-    assert typ.members["privateDataSlotRequestCount"].typename == "uint32_t"
+    assert typ.member_order[2] == "privateDataSlotRequestCount"
+    assert typ.members["privateDataSlotRequestCount"].variable_type == "uint32_t"
 
 
 def test_vulkan_struct_with_const_and_pointer() -> None:
@@ -83,8 +83,7 @@ def test_vulkan_struct_with_const_and_pointer() -> None:
     assert isinstance(typ, types.VulkanStruct)
     assert typ.typename == "VkInstanceCreateInfo"
 
-    assert "ppEnabledLayerNames" in typ.members
-    assert typ.members["ppEnabledLayerNames"].typename == "const char* const*"
+    assert typ.members["ppEnabledLayerNames"].variable_type == "const char* const*"
 
 
 def test_vulkan_struct_with_expected_value() -> None:
@@ -103,6 +102,7 @@ def test_vulkan_struct_with_expected_value() -> None:
 
     typ = struct_parser.parse(ET.fromstring(xml))
     assert isinstance(typ, types.VulkanStruct)
+
     expected_value = "VK_STRUCTURE_TYPE_DEVICE_PRIVATE_DATA_CREATE_INFO"
     assert typ.members["sType"].expected_value == expected_value
 
@@ -160,7 +160,9 @@ def test_vulkan_struct_with_dynamic_array() -> None:
     assert isinstance(typ, types.VulkanStruct)
 
     reference = typ.members["pBinds"].array_reference
+
     assert reference in typ.members
+    assert reference == typ.member_order[1]
 
 
 def test_vulkan_struct_with_static_array() -> None:
@@ -191,7 +193,6 @@ def test_vulkan_struct_with_static_array() -> None:
     typ = struct_parser.parse(ET.fromstring(xml))
     assert isinstance(typ, types.VulkanStruct)
 
-    assert "deviceName" in typ.members
     assert typ.members["deviceName"].variable_size == "VK_MAX_PHYSICAL_DEVICE_NAME_SIZE"
 
 

--- a/vulkan_generator/vulkan_parser/handle_parser.py
+++ b/vulkan_generator/vulkan_parser/handle_parser.py
@@ -31,8 +31,7 @@ def parse_handle_by_attribute(root: ET.Element) -> types.VulkanHandleAlias:
     """
     name = root.attrib["name"]
     alias = root.attrib["alias"]
-    vulkan_handle = types.VulkanHandleAlias(
-        typename=name, aliased_typename=alias)
+    vulkan_handle = types.VulkanHandleAlias(typename=name, aliased_typename=alias)
     return vulkan_handle
 
 
@@ -44,7 +43,7 @@ def parse_handle_by_tag(root: ET.Element) -> types.VulkanHandle:
     <type>VK_DEFINE_HANDLE</type>(<name>VkQueue</name>)</type>
     """
 
-    name = parsing_utils.get_text_from_tag(root, "name")
+    name = parsing_utils.get_text_from_tag_in_children(root, "name")
     vulkan_handle = types.VulkanHandle(typename=name)
     return vulkan_handle
 

--- a/vulkan_generator/vulkan_parser/parser.py
+++ b/vulkan_generator/vulkan_parser/parser.py
@@ -17,13 +17,14 @@
 from pathlib import Path
 import xml.etree.ElementTree as ET
 
+from vulkan_generator.vulkan_parser import types
 from vulkan_generator.vulkan_parser import type_parser
 
 
-def parse(filename: Path) -> type_parser.AllVulkanTypes:
+def parse(filename: Path) -> types.AllVulkanTypes:
     """ Parse the Vulkan XML to extract every information that is needed for code generation"""
     tree = ET.parse(filename)
-    all_types = type_parser.AllVulkanTypes()
+    all_types = types.AllVulkanTypes()
 
     for child in tree.iter():
         if child.tag == "types":

--- a/vulkan_generator/vulkan_parser/type_parser.py
+++ b/vulkan_generator/vulkan_parser/type_parser.py
@@ -17,74 +17,51 @@
 
 import xml.etree.ElementTree as ET
 
-from dataclasses import dataclass
-from dataclasses import field
-from typing import Dict
-
 from vulkan_generator.vulkan_parser import handle_parser
 from vulkan_generator.vulkan_parser import struct_parser
 from vulkan_generator.vulkan_parser import funcptr_parser
 from vulkan_generator.vulkan_parser import types
 
 
-@dataclass
-class AllVulkanTypes:
-    """
-    This class holds the information parsed from Vulkan XML
-    This class should have all the information needed to generate code
-    """
-    # This class holds every Vulkan Type as [typename -> type]
-    handles: Dict[str, types.VulkanHandle] = field(
-        default_factory=dict)
-
-    # Melih TODO: We probably need the map in two ways while generating code
-    # both type -> alias and alias -> type
-    # For now, lets store as the other types but when we do code generation,
-    # We may have an extra step to convert the map to other direction.
-    handle_aliases: Dict[str, types.VulkanHandleAlias] = field(
-        default_factory=dict)
-
-    structs: Dict[str, types.VulkanStruct] = field(
-        default_factory=dict)
-
-    struct_aliases: Dict[str, types.VulkanStructAlias] = field(
-        default_factory=dict)
-
-    funcpointers: Dict[str, types.VulkanFunctionPtr] = field(
-        default_factory=dict)
-
-
-def process_handle(vulkan_types: AllVulkanTypes, handle_element: ET.Element) -> None:
+def process_handle(vulkan_types: types.AllVulkanTypes, handle_element: ET.Element) -> None:
     """ Parse the Vulkan type "Handle". This can be an handle or an alias to another handle"""
     handle = handle_parser.parse(handle_element)
 
     if isinstance(handle, types.VulkanHandle):
         vulkan_types.handles[handle.typename] = handle
-    elif isinstance(handle, types.VulkanHandleAlias):
+        return
+
+    if isinstance(handle, types.VulkanHandleAlias):
         vulkan_types.handle_aliases[handle.typename] = handle
+        return
+
+    raise SyntaxError(f"Unknown VulkanType {handle}")
 
 
-def process_struct(vulkan_types: AllVulkanTypes, struct_element: ET.Element) -> None:
+def process_struct(vulkan_types: types.AllVulkanTypes, struct_element: ET.Element) -> None:
     """ Parse the Vulkan type "Struct". This can be a struct or an alias to another struct"""
     vulkan_struct = struct_parser.parse(struct_element)
 
     if isinstance(vulkan_struct, types.VulkanStruct):
         vulkan_types.structs[vulkan_struct.typename] = vulkan_struct
-    elif isinstance(vulkan_struct, types.VulkanStructAlias):
+        return
+
+    if isinstance(vulkan_struct, types.VulkanStructAlias):
         vulkan_types.struct_aliases[vulkan_struct.typename] = vulkan_struct
+        return
+
+    raise SyntaxError(f"Unknown VulkanType {vulkan_struct}")
 
 
-def process_funcpointer(vulkan_types: AllVulkanTypes, func_ptr_element: ET.Element) -> None:
+def process_funcpointer(vulkan_types: types.AllVulkanTypes, func_ptr_element: ET.Element) -> None:
     """ Parse the Vulkan type "Funcpointer"""
     vulkan_func_ptr = funcptr_parser.parse(func_ptr_element)
-
-    if isinstance(vulkan_func_ptr, types.VulkanFunctionPtr):
-        vulkan_types.funcpointers[vulkan_func_ptr.typename] = vulkan_func_ptr
+    vulkan_types.funcpointers[vulkan_func_ptr.typename] = vulkan_func_ptr
 
 
-def parse(types_root: ET.Element) -> AllVulkanTypes:
+def parse(types_root: ET.Element) -> types.AllVulkanTypes:
     """ Parses all the Vulkan types and returns them in an object with dictionaries to each type """
-    vulkan_types = AllVulkanTypes()
+    vulkan_types = types.AllVulkanTypes()
 
     for type_element in types_root.iter():
         if "category" in type_element.attrib:

--- a/vulkan_generator/vulkan_parser/types.py
+++ b/vulkan_generator/vulkan_parser/types.py
@@ -43,8 +43,9 @@ class VulkanHandleAlias(VulkanType):
 
 
 @dataclass
-class VulkanStructMember(VulkanType):
+class VulkanStructMember:
     """The meta data defines a Vulkan Handle"""
+    variable_type: str
     variable_name: str
 
     # Some member variables are static arrays with a default size
@@ -73,20 +74,23 @@ class VulkanStructMember(VulkanType):
 
 @dataclass
 class VulkanStruct(VulkanType):
-    """The meta data defines a Vulkan Handle"""
-    members: Dict[str, VulkanStructMember] = field(
-        default_factory=dict)
+    """The meta data defines a Vulkan Struct"""
+
+    # These give us both what are the members are and their order
+    member_order: List[str] = field(default_factory=list)
+    members: Dict[str, VulkanStructMember] = field(default_factory=dict)
 
 
 @dataclass
 class VulkanStructAlias(VulkanType):
-    """The meta data defines a Vulkan Handle alias"""
+    """The meta data defines a Vulkan Struct alias"""
     aliased_typename: str
 
 
 @dataclass
-class VulkanFunctionArgument(VulkanType):
+class VulkanFunctionArgument:
     """The meta data defines a Function argument"""
+    argument_type: str
     argument_name: str
 
 
@@ -94,5 +98,28 @@ class VulkanFunctionArgument(VulkanType):
 class VulkanFunctionPtr(VulkanType):
     """The meta data defines a Function Pointer"""
     return_type: str
-    arguments: List[VulkanFunctionArgument] = field(
-        default_factory=list)
+
+    # These give us both what are the arguments are and their order
+    argument_order: List[str] = field(default_factory=list)
+    arguments: Dict[str, VulkanFunctionArgument] = field(default_factory=dict)
+
+@dataclass
+class AllVulkanTypes:
+    """
+    This class holds the information parsed from Vulkan XML
+    This class should have all the information needed to generate code
+    """
+    # This class holds every Vulkan Type as [typename -> type]
+
+    # Melih TODO: We probably need the map in two ways while generating code
+    # both type -> alias and alias -> type
+    # For now, lets store as the other types but when we do code generation,
+    # We may have an extra step to convert the map to other direction.
+
+    handles: Dict[str, VulkanHandle] = field(default_factory=dict)
+    handle_aliases: Dict[str, VulkanHandleAlias] = field(default_factory=dict)
+
+    structs: Dict[str, VulkanStruct] = field(default_factory=dict)
+    struct_aliases: Dict[str, VulkanStructAlias] = field(default_factory=dict)
+
+    funcpointers: Dict[str, VulkanFunctionPtr] = field(default_factory=dict)

--- a/vulkan_generator/vulkan_utils/parsing_utils.py
+++ b/vulkan_generator/vulkan_utils/parsing_utils.py
@@ -19,9 +19,17 @@ from typing import Optional
 import os
 
 
-def get_text_from_tag(elem: ET.Element, tag: str) -> str:
-    """Gets the text of the element with the given tag"""
-    value = try_get_text_from_tag(elem, tag)
+def get_text_from_tag_in_children(elem: ET.Element, tag: str, recursive: bool = False) -> str:
+    """Gets the text of the element with the given tag in element
+
+    Args:
+        recursive(bool):
+            If True:
+                The function will search the entire subtree recursively including the root node
+            If False:
+                The function will search only the first level children.
+    """
+    value = try_get_text_from_tag_in_children(elem, tag, recursive)
 
     if value is None:
         # This should not happen
@@ -30,19 +38,38 @@ def get_text_from_tag(elem: ET.Element, tag: str) -> str:
     return value
 
 
-def try_get_text_from_tag(elem: ET.Element, tag: str) -> Optional[str]:
+def try_get_text_from_tag_in_children(elem: ET.Element, tag: str, recursive: bool = False) -> Optional[str]:
     """Tries to Gets the text of the element with the given tag
-    and returns None if the tag does not exits"""
-    for child in elem.iter():
+    and returns None if the tag does not exits
+
+    Args:
+        recursive(bool):
+            If True:
+                The function will search the entire subtree recursively including the root node
+            If False:
+                The function will search only the first level children.
+    """
+
+    search_base = elem.iter() if recursive else elem
+
+    for child in search_base:
         if tag == child.tag:
             return child.text
 
     return None
 
 
-def get_tail_from_tag(elem: ET.Element, tag: str) -> str:
-    """Gets the tail of the element with the given tag"""
-    value = try_get_tail_from_tag(elem, tag)
+def get_tail_from_tag_in_children(elem: ET.Element, tag: str, recursive: bool = False) -> str:
+    """Gets the tail of the element with the given tag recursively
+
+    Args:
+        recursive(bool):
+            If True:
+                The function will search the entire subtree recursively including the root node
+            If False:
+                The function will search only the first level children.
+    """
+    value = try_get_tail_from_tag_in_children(elem, tag, recursive)
 
     if value is None:
         # This should not happen
@@ -51,10 +78,20 @@ def get_tail_from_tag(elem: ET.Element, tag: str) -> str:
     return value
 
 
-def try_get_tail_from_tag(elem: ET.Element, tag: str) -> Optional[str]:
+def try_get_tail_from_tag_in_children(elem: ET.Element, tag: str, recursive: bool = False) -> Optional[str]:
     """Tries to Gets the text of the element with the given tag
-    and returns None if the tag does not exits"""
-    for child in elem.iter():
+    and returns None if the tag does not exits
+
+    Args:
+        recursive(bool):
+            If True:
+                The function will search the entire subtree recursively including the root node
+            If False:
+                The function will search only the first level children.
+    """
+    search_base = elem.iter() if recursive else elem
+
+    for child in search_base:
         if tag == child.tag:
             return child.tail
 


### PR DESCRIPTION
I made earlier in implementation
  - Moves AllVulkanTypes dictionary under the types
  - VulkanStructMembers and VulkanFunctionArguments are no more a VulkanType
    as they don't define a type
  - Change how we store the arguments and members
  - Remove some printfs
  - Linting issues