### PR TITLE
Ignore .DS_Store also from the subfolders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Directories
-/.DS_Store
 /.idea
 /.vscode
 /bazel-*
@@ -19,6 +18,9 @@
 *ycm_extra_conf.py*
 gapir.log
 gapis.log
+
+# MacOS
+.DS_Store
 
 # Vim
 [._]*.s[a-w][a-z]


### PR DESCRIPTION
Small change to avoid adding automatically generated .DS_Store files into the source control.