### PR TITLE
Fix validation link in gh pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,7 @@ url: "https://gpuinspector.dev" # the base hostname & protocol for your site, e.
 project-url: "https://github.com/google/agi"
 releases-url: "https://github.com/google/agi/releases"
 docurl: "https://developer.android.com/agi"
+validation-url: "https://developer.android.com/agi/supported-devices"
 feedback-url: "https://github.com/google/agi/issues"
 markdown: kramdown
 sass:

--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ url: "https://gpuinspector.dev" # the base hostname & protocol for your site, e.
 project-url: "https://github.com/google/agi"
 releases-url: "https://github.com/google/agi/releases"
 docurl: "https://developer.android.com/agi"
-validation-url: "https://developer.android.com/agi/supported-devices"
+validation-url: "https://developer.android.com/agi/start#device-validation"
 feedback-url: "https://github.com/google/agi/issues"
 markdown: kramdown
 sass:

--- a/validation.md
+++ b/validation.md
@@ -5,4 +5,4 @@ title: Device Support Validation
 permalink: /validation
 ---
 
-The device support validation documentation has moved to [{{site.docurl}}]({{site.validation-url}}).
+The device support validation documentation has moved to [{{site.validation-url}}]({{site.validation-url}}).

--- a/validation.md
+++ b/validation.md
@@ -5,4 +5,4 @@ title: Device Support Validation
 permalink: /validation
 ---
 
-The device support validation documentation has moved to [{{site.docurl}}]({{https://developer.android.com/agi/start#device-validation}}).
+The device support validation documentation has moved to [{{site.docurl}}]({{site.validation-url}}).


### PR DESCRIPTION
https://gpuinspector.dev/validation somehow has a link that links to itself instead of the correct page. This hopefully will fix it.