### PR TITLE
create separate vulkan generator test target

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -347,6 +347,20 @@ test_suite(
 )
 
 test_suite(
+    name = "tests-vulkan-generator",
+    tests = [
+        # Linting
+        "//vulkan_generator:lint",
+        "//vulkan_generator/tests:lint",
+        "//vulkan_generator/vulkan_parser:lint",
+        "//vulkan_generator/vulkan_utils:lint",
+
+        # Tests
+        "//vulkan_generator/tests:test_vulkan_parsing",
+    ],
+)
+
+test_suite(
     name = "tests",
     tests = [
         # __BEGIN_TESTS

--- a/kokoro/linux-test/test.sh
+++ b/kokoro/linux-test/test.sh
@@ -74,3 +74,4 @@ test tests-gapis-other
 test tests-gapir
 test tests-gapil
 test tests-general
+test tests-vulkan-generator


### PR DESCRIPTION
To be able to test vulkan generator only, without triggering the entire AGI test