### PR TITLE
Add non codegen libraries to replay2 in advance of MemoryRemapper

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -445,6 +445,7 @@ test_suite(
         "//gapis/stringtable/minidown/scanner:go_default_test",
         "//gapis/stringtable/parser:go_default_test",
         "//gapis/vertex:go_default_test",
+        "//replay2/handle_remapper:handle_remapper_test",
         "//test/integration/replay:go_default_test",
         "//test/integration/service:go_default_test",
         "//vulkan_generator:lint",

--- a/replay2/core_utils/BUILD.bazel
+++ b/replay2/core_utils/BUILD.bazel
@@ -12,31 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//tools/build/rules:vulkan_generator.bzl", "basic_vulkan_generator")
-
-basic_vulkan_generator(
-    name = "handle_remapper_src",
-    target = "handle_remapper",
-)
-
 cc_library(
-    name = "handle_remapper",
-    srcs = glob(
-        [":handle_remapper_src"],
-        exclude = ["*_test.cpp"],
-    ),
+    name = "core_utils",
+    srcs = glob(["*.cc"]),
+    hdrs = glob(["*.h"]),
     visibility = ["//visibility:public"],
-    deps = [
-        "//replay2/core_utils",
-    ],
-)
-
-cc_test(
-    name = "handle_remapper_test",
-    srcs = [":handle_remapper_src"],
-    deps = [
-        "//replay2/core_utils",
-        "//replay2/vulkan_base",
-        "@com_google_googletest//:gtest_main",
-    ],
 )

--- a/replay2/core_utils/non_copyable.cc
+++ b/replay2/core_utils/non_copyable.cc
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "non_copyable.h"

--- a/replay2/core_utils/non_copyable.h
+++ b/replay2/core_utils/non_copyable.h
@@ -1,0 +1,26 @@
+// Copyright (C) 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace agi {
+namespace replay2 {
+
+class non_copyable {
+ public:
+  non_copyable(void){};
+  non_copyable(const non_copyable& rhs) = delete;
+  non_copyable& operator=(const non_copyable& rhs) = delete;
+};
+
+}  // namespace replay2
+}  // namespace agi

--- a/replay2/handle_remapper/BUILD.bazel
+++ b/replay2/handle_remapper/BUILD.bazel
@@ -12,20 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_python//python:defs.bzl", "py_library")
-load("//tools/build:rules.bzl", "py_lint")
+load("//tools/build/rules:vulkan_generator.bzl", "basic_vulkan_generator")
 
-py_library(
-    name = "handle_remapper",
-    srcs = glob(["*.py"]),
-    srcs_version = "PY3",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//vulkan_generator/codegen_utils",
-    ],
+basic_vulkan_generator(
+    name = "handle_remapper_src",
+    target = "handle_remapper",
 )
 
-py_lint(
-    name = "lint",
-    srcs = glob(["*.py"]),
+cc_library(
+    name = "handle_remapper",
+    srcs = glob(
+        [":handle_remapper_src"],
+        exclude = ["*_test.cpp"],
+    ),
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "handle_remapper_test",
+    srcs = [":handle_remapper_src"],
+    deps = [
+        "@com_google_googletest//:gtest_main",
+    ],
 )

--- a/replay2/memory_remapper/BUILD.bazel
+++ b/replay2/memory_remapper/BUILD.bazel
@@ -12,31 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//tools/build/rules:vulkan_generator.bzl", "basic_vulkan_generator")
-
-basic_vulkan_generator(
-    name = "handle_remapper_src",
-    target = "handle_remapper",
-)
-
 cc_library(
-    name = "handle_remapper",
-    srcs = glob(
-        [":handle_remapper_src"],
-        exclude = ["*_test.cpp"],
-    ),
+    name = "memory_remapper",
+    srcs = glob(["*.cc"]),
+    hdrs = glob(["*.h"]),
     visibility = ["//visibility:public"],
-    deps = [
-        "//replay2/core_utils",
-    ],
-)
-
-cc_test(
-    name = "handle_remapper_test",
-    srcs = [":handle_remapper_src"],
-    deps = [
-        "//replay2/core_utils",
-        "//replay2/vulkan_base",
-        "@com_google_googletest//:gtest_main",
-    ],
 )

--- a/replay2/memory_remapper/memory_remapper.cc
+++ b/replay2/memory_remapper/memory_remapper.cc
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "memory_remapper.h"
+
+void foo(int var) { return; }

--- a/replay2/memory_remapper/memory_remapper.h
+++ b/replay2/memory_remapper/memory_remapper.h
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+void foo(int var);

--- a/replay2/vulkan_base/BUILD.bazel
+++ b/replay2/vulkan_base/BUILD.bazel
@@ -12,31 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//tools/build/rules:vulkan_generator.bzl", "basic_vulkan_generator")
-
-basic_vulkan_generator(
-    name = "handle_remapper_src",
-    target = "handle_remapper",
-)
-
 cc_library(
-    name = "handle_remapper",
-    srcs = glob(
-        [":handle_remapper_src"],
-        exclude = ["*_test.cpp"],
-    ),
+    name = "vulkan_base",
+    srcs = glob(["*.cc"]),
+    hdrs = glob(["*.h"]),
     visibility = ["//visibility:public"],
-    deps = [
-        "//replay2/core_utils",
-    ],
-)
-
-cc_test(
-    name = "handle_remapper_test",
-    srcs = [":handle_remapper_src"],
-    deps = [
-        "//replay2/core_utils",
-        "//replay2/vulkan_base",
-        "@com_google_googletest//:gtest_main",
-    ],
 )

--- a/replay2/vulkan_base/vulkan_handle.cc
+++ b/replay2/vulkan_base/vulkan_handle.cc
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "vulkan_handle.h"

--- a/replay2/vulkan_base/vulkan_handle.h
+++ b/replay2/vulkan_base/vulkan_handle.h
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdint>
+
+namespace agi {
+namespace replay2 {
+
+// TODO: This is just a placeholder type for now. We want to do something more
+// typesafe.
+typedef uint64_t VulkanHandle;
+
+}  // namespace replay2
+}  // namespace agi

--- a/vulkan_generator/handle_remapper/generator.py
+++ b/vulkan_generator/handle_remapper/generator.py
@@ -144,19 +144,11 @@ def generate_handle_remapper_h(file_path : Path, vulkan_metadata : types.VulkanM
             #include <iostream>
             #include <map>
 
+            #include "replay2/core_utils/non_copyable.h"
+            #include "replay2/vulkan_base/vulkan_handle.h"
+
             namespace agi {
             namespace replay2 {
-
-            // TODO: This is just a placeholder type for now. This type will not be generated.
-            typedef uint64_t Handle;
-
-            // TODO: This is just a placeholder type for now. This type will not be generated.
-            class noncopyable {
-                public:
-                noncopyable() {};
-                noncopyable(const noncopyable& rhs) = delete;
-                noncopyable& operator=(const noncopyable& rhs) = delete;
-            };
 
         """))
 
@@ -173,25 +165,25 @@ def generate_handle_remapper_h(file_path : Path, vulkan_metadata : types.VulkanM
 
         for handle in vulkan_metadata.types.handles:
 
-            private_members.append(f"""std::map<Handle, Handle> {handle_map_name(handle)};""")
+            private_members.append(f"""std::map<VulkanHandle, VulkanHandle> {handle_map_name(handle)};""")
 
             if not vulkan_metadata.types.handles[handle].dispatchable:
-                private_members.append(f"""std::map<Handle, int> {handle_count_map_name(handle)};""")
+                private_members.append(f"""std::map<VulkanHandle, int> {handle_count_map_name(handle)};""")
 
             private_members.append("")
 
             public_functions.append(codegen.create_function_declaration(handle_add_name(handle),
-                                                                        arguments = {"captureHandle" : "Handle",
-                                                                                           "replayHandle" : "Handle"}))
+                                                                        arguments = {"captureHandle" : "VulkanHandle",
+                                                                                           "replayHandle" : "VulkanHandle"}))
             public_functions.append(codegen.create_function_declaration(handle_remove_name(handle),
-                                                                        arguments = {"captureHandle" : "Handle"}))
+                                                                        arguments = {"captureHandle" : "VulkanHandle"}))
             public_functions.append(codegen.create_function_declaration(handle_remap_name(handle),
-                                                                        return_type = "Handle",
-                                                                        arguments = {"captureHandle" : "Handle"}))
+                                                                        return_type = "VulkanHandle",
+                                                                        arguments = {"captureHandle" : "VulkanHandle"}))
             public_functions.append("")
 
         remapper_class_def = codegen.create_class_definition("VulkanHandleRemapper",
-                                                             public_inheritance = ["noncopyable"],
+                                                             public_inheritance = ["non_copyable"],
                                                              public_functions = public_functions,
                                                              public_members = public_members,
                                                              private_members = private_members)
@@ -227,19 +219,19 @@ def generate_handle_remapper_cpp(file_path : Path, vulkan_metadata : types.Vulka
 
             add_definition = codegen.create_function_definition(
                                 f"""VulkanHandleRemapper::{handle_add_name(handle)}""",
-                                arguments = {"captureHandle" : "Handle",
-                                           "replayHandle" : "Handle"},
+                                arguments = {"captureHandle" : "VulkanHandle",
+                                           "replayHandle" : "VulkanHandle"},
                                 code = implgenerator.handle_add_code(handle))
 
             remove_definition = codegen.create_function_definition(
                                     f"""VulkanHandleRemapper::{handle_remove_name(handle)}""",
-                                    arguments = {"captureHandle" : "Handle"},
+                                    arguments = {"captureHandle" : "VulkanHandle"},
                                     code = implgenerator.handle_remove_code(handle))
 
             remap_definition = codegen.create_function_definition(
                                     f"""VulkanHandleRemapper::{handle_remap_name(handle)}""",
-                                    arguments = {"captureHandle" : "Handle"},
-                                    return_type = "Handle",
+                                    arguments = {"captureHandle" : "VulkanHandle"},
+                                    return_type = "VulkanHandle",
                                     code = implgenerator.handle_remap_code(handle))
 
             remapper_cpp.write(codegen.comment_code(code = add_definition,


### PR DESCRIPTION
Before this PR we only had codegen'd code in replay2 and some of the types inside the HandleRemapper were stubs to cover for the lack of basic infrastructure. This adds the following non codegen'd libraries to replay2:

replay2/core_utils: for any basic core classes.
    - I've moved non_copyable here for now, but expect other common utility code to go here in future.
replay2/vulkan_base: for basic hand written vulkan code
    - I've moved the vulkan handle typedef here for now and renamed it to VulkanHandle to be more explicit. We're going to codegen a lot of the vulkan code in the end, but there will still be some parts of the vulkan which will be hand written. This library exists for the handwritten stuff.
replay2/memory_remapper: for the memory remapper
    - The memory remapper is not included in this PR, but this is where it will go.