### PR TITLE
Clarity in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,14 @@ developers. See also the README files under some source directories.
 
 *Unstable* developer releases are [here](https://github.com/google/agi-dev-releases/releases).
 
-> Dependencies for Linux builds in zip archives: AGI depends on openjdk-11-jre,
-> libgtk-3-0, and libwebkit2gtk. These are marked as dependencies in the deb
-> package. If you install AGI via a zip archive, make sure to install these
-> dependencies as well.
+Dependencies for Linux builds in zip archives:
+- openjdk-11-jre 
+- libgtk-3-0
+- libwebkit2gtk
+
+These are marked as dependencies in the .deb package. 
+
+If you install AGI via a zip archive, make sure to install these dependencies as well.
 
 ## Building
 


### PR DESCRIPTION
The original README.md in this repository was unclear with showing the dependencies of zipped linux builds. 
> Dependencies for Linux builds in zip archives: AGI depends on openjdk-11-jre,
> libgtk-3-0, and libwebkit2gtk. These are marked as dependencies in the deb
> package. If you install AGI via a zip archive, make sure to install these
> dependencies as well.

The new one in this PR makes it easier to understand as the dependencies are now listed instead of being contained within a text quote.