### PR TITLE
Fixed Power Rail Track Names

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/models/BatterySummaryTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/BatterySummaryTrack.java
@@ -63,6 +63,7 @@ public class BatterySummaryTrack
     List<CounterInfo> powerRails = counters.entries().stream()
         .filter(entry -> entry.getKey().startsWith("power.rails"))
         .map(Map.Entry::getValue)
+        .map(value -> trimPowerRailTrackName(value))
         .collect(Collectors.toList());
     if (((battCap == null) || (battCharge  == null) || (battCurrent  == null))
         && powerRails.size() == 0) {
@@ -95,6 +96,14 @@ public class BatterySummaryTrack
 
   private static CounterInfo onlyOne(ImmutableList<CounterInfo> counters) {
     return (counters.size() != 1) ? null : counters.get(0);
+  }
+
+  private static CounterInfo trimPowerRailTrackName(CounterInfo powerRailTrack) {
+    String powerRailTrackName = powerRailTrack.name.replace("power.rails.","").replace(".", "-");
+    CounterInfo trimmedPowerRailTrack = new CounterInfo(powerRailTrack.id, powerRailTrack.type, powerRailTrack.ref,
+    powerRailTrackName, powerRailTrack.description, powerRailTrack.unit,
+      powerRailTrack.interpolation, powerRailTrack.count, powerRailTrack.min, powerRailTrack.max, powerRailTrack.avg);
+    return trimmedPowerRailTrack;
   }
 
   @Override


### PR DESCRIPTION
This commit beautifies the way the names of power rail tracks get displayed. 

Before 

<img width="1728" alt="Screenshot 2022-07-25 at 4 16 41 pm" src="https://user-images.githubusercontent.com/24795489/180814595-47e53d35-41a2-40c8-bbf6-23953856aa22.png">

Now 

<img width="1626" alt="Screenshot 2022-07-25 at 4 18 01 pm" src="https://user-images.githubusercontent.com/24795489/180814675-bfb31243-c8e3-4a2a-9f8d-b44b9e744fe9.png">
