### PR TITLE
Adjust ranges to the max for all gpufreq tracks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 *ycm_extra_conf.py*
 gapir.log
 gapis.log
+hs_err_pid*.log
 
 # MacOS
 .DS_Store


### PR DESCRIPTION
This CL is to visualize GPU frequencies from different counters with a shared maximum range value. 
Also adds hs_err_pid* log java runtime files to the ignore list which can be generated when you debug gapic through eclipse. 