### PR TITLE
Corrected the Power Rail Tracks Graph

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
@@ -95,7 +95,10 @@ public class CounterPanel extends TrackPanel<CounterPanel> implements Selectable
       }
 
       CounterInfo counter = track.getCounter();
-      double min = counter.range.min, range = counter.range.range();
+
+      //TODO: Move all the calculations below in the backend
+      double min = counter.min;
+      double range = counter.range.range() - min;
 
       Selection<?> selected = state.getSelection(Selection.Kind.Counter);
       List<Integer> visibleSelected = Lists.newArrayList();
@@ -315,7 +318,6 @@ public class CounterPanel extends TrackPanel<CounterPanel> implements Selectable
       this.minLabel = isTotal ? "Trace Min:" : "Range Min:";
       this.maxLabel = isTotal ? "Trace Max:" : "Range Max:";
       this.avgLabel = isTotal ? "Trace Avg:" : "Range Avg:";
-
 
       Size valueSize = tm.measure(Fonts.Style.Normal, label);
       Size minSize = tm.measure(Fonts.Style.Normal, min);


### PR DESCRIPTION
The power rail tracks initially were unaffected by the values as a wrong `min` variable was used to calculate the next Y coordinate required in plotting. 

Before:

![Screenshot from 2022-08-02 12-35-21](https://user-images.githubusercontent.com/24795489/182365249-505284cd-eeb1-4ead-83b3-f1f9991374a9.png)

After: 

![Screenshot from 2022-08-02 12-44-48](https://user-images.githubusercontent.com/24795489/182366699-f92ea277-1040-4fe0-baa9-89f3e985bc0f.png)
