### PR TITLE
Modify Power Rail Names in the UI instead of backend

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/models/BatterySummaryTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/BatterySummaryTrack.java
@@ -63,7 +63,6 @@ public class BatterySummaryTrack
     List<CounterInfo> powerRails = counters.entries().stream()
         .filter(entry -> entry.getKey().startsWith("power.rails"))
         .map(Map.Entry::getValue)
-        .map(value -> trimPowerRailTrackName(value))
         .collect(Collectors.toList());
     if (((battCap == null) || (battCharge  == null) || (battCurrent  == null))
         && powerRails.size() == 0) {
@@ -96,14 +95,6 @@ public class BatterySummaryTrack
 
   private static CounterInfo onlyOne(ImmutableList<CounterInfo> counters) {
     return (counters.size() != 1) ? null : counters.get(0);
-  }
-
-  private static CounterInfo trimPowerRailTrackName(CounterInfo powerRailTrack) {
-    String powerRailTrackName = powerRailTrack.name.replace("power.rails.","").replace(".", "-");
-    CounterInfo trimmedPowerRailTrack = new CounterInfo(powerRailTrack.id, powerRailTrack.type, powerRailTrack.ref,
-    powerRailTrackName, powerRailTrack.description, powerRailTrack.unit,
-      powerRailTrack.interpolation, powerRailTrack.count, powerRailTrack.min, powerRailTrack.max, powerRailTrack.avg);
-    return trimmedPowerRailTrack;
   }
 
   @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
@@ -63,7 +63,9 @@ public class CounterPanel extends TrackPanel<CounterPanel> implements Selectable
   @Override
   public String getTitle() {
     CounterInfo info = track.getCounter();
-    if (info.type == CounterInfo.Type.Gpu && "gpufreq".equals(info.name)) {
+    if (info.name.startsWith("power.rails")) {
+      return info.name.replace("power.rails.","").replace(".", "-");
+    } else if (info.type == CounterInfo.Type.Gpu && "gpufreq".equals(info.name)) {
       return "GPU " + info.ref + " Frequency";
     }
     return track.getCounter().name;


### PR DESCRIPTION
This change moves the modification of Power Rail Track names done in #1160  from backend to the UI to avoid unnecessary creation of `CounterInfo` object.