### PR TITLE
Added Power Usage Summary Track and corresponding graph

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/models/BatterySummaryTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/BatterySummaryTrack.java
@@ -60,12 +60,8 @@ public class BatterySummaryTrack
     CounterInfo battCap = onlyOne(counters.get("batt.capacity_pct"));
     CounterInfo battCharge = onlyOne(counters.get("batt.charge_uah"));
     CounterInfo battCurrent = onlyOne(counters.get("batt.current_ua"));
-    List<CounterInfo> powerRails = counters.entries().stream()
-        .filter(entry -> entry.getKey().startsWith("power.rails"))
-        .map(Map.Entry::getValue)
-        .collect(Collectors.toList());
-    if (((battCap == null) || (battCharge  == null) || (battCurrent  == null))
-        && powerRails.size() == 0) {
+
+    if ((battCap == null) || (battCharge  == null) || (battCurrent  == null)){
       return data;
     }
     // Battery Group
@@ -78,18 +74,7 @@ public class BatterySummaryTrack
       data.tracks.addTrack(batteryGroup, track.getId(), "Battery Usage",
           single(state -> new BatterySummaryPanel(state, track), true, false));
     }
-    // Power Rails tracks.
-    if (powerRails.size() > 0) {
-      String powerRailsGroup = "power_rails_group";
-      data.tracks.addLabelGroup(batteryGroup, powerRailsGroup, "Power Rails",
-          group(state -> new TitlePanel("Power Rails"), false));
-      for (CounterInfo powerRail : powerRails) {
-        CounterTrack powerRailTrack = new CounterTrack(data.qe, powerRail);
-        data.tracks.addTrack(powerRailsGroup, powerRailTrack.getId(), powerRail.name,
-            single(state -> new CounterPanel(state, powerRailTrack, POWER_RAIL_COUNTER_TRACK_HEIGHT),
-                true, true));
-      }
-    }
+
     return data;
   }
 

--- a/gapic/src/main/com/google/gapid/perfetto/models/PowerSummaryTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/PowerSummaryTrack.java
@@ -1,0 +1,170 @@
+package com.google.gapid.perfetto.models;
+
+import static com.google.gapid.perfetto.models.QueryEngine.createSpan;
+import static com.google.gapid.perfetto.models.QueryEngine.createView;
+import static com.google.gapid.perfetto.models.QueryEngine.createWindow;
+import static com.google.gapid.perfetto.models.QueryEngine.dropTable;
+import static com.google.gapid.perfetto.models.QueryEngine.dropView;
+import static com.google.gapid.perfetto.views.StyleConstants.POWER_RAIL_COUNTER_TRACK_HEIGHT;
+import static com.google.gapid.perfetto.views.TrackContainer.group;
+import static com.google.gapid.perfetto.views.TrackContainer.single;
+import static com.google.gapid.util.MoreFutures.transform;
+import static com.google.gapid.util.MoreFutures.transformAsync;
+import static java.lang.String.format;
+
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.gapid.models.Perfetto;
+import com.google.gapid.perfetto.Unit;
+import com.google.gapid.perfetto.models.TrackConfig.Group;
+import com.google.gapid.perfetto.views.CounterPanel;
+import com.google.gapid.perfetto.views.PowerSummaryPanel;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** {@link Track} summarizing the total Power usage. */
+public class PowerSummaryTrack extends Track.WithQueryEngine<PowerSummaryTrack.Data> {
+  private static String viewSql;
+  private static int numPowerRailTracks;
+  public static Unit unit;
+  public static Double minValue;
+  public static Double maxValue;
+
+  private static final String VIEW_SQL_MONOTONIC =
+      "select ts + 1 ts, lead(ts) over win - ts dur, lead(value) over win - value value, lead(id)"
+          + " over win id from counter where track_id = ";
+
+  public PowerSummaryTrack(QueryEngine qe, int numTracks) {
+    super(qe, "power_sum");
+    this.numPowerRailTracks = numTracks;
+  }
+
+  public int getNumPowerRailTracks() {
+    return numPowerRailTracks;
+  }
+
+  public static Perfetto.Data.Builder enumerate(Perfetto.Data.Builder data) {
+    ImmutableListMultimap<String, CounterInfo> counters = data.getCounters(CounterInfo.Type.Global);
+    List<CounterInfo> powerRails =
+        counters.entries().stream()
+            .filter(entry -> entry.getKey().startsWith("power.rails"))
+            .map(Map.Entry::getValue)
+            .collect(Collectors.toList());
+
+    if (powerRails.size() == 0) {
+      return data;
+    }
+
+    // Power Group
+    viewSql = buildViewSql(powerRails);
+    PowerSummaryTrack powerSummaryTrack = new PowerSummaryTrack(data.qe, powerRails.size());
+
+    // Power Rails tracks.
+    for (CounterInfo powerRail : powerRails) {
+      unit = powerRail.unit;
+      CounterTrack powerRailTrack = new CounterTrack(data.qe, powerRail);
+      data.tracks.addTrack(
+          powerSummaryTrack.getId(),
+          powerRailTrack.getId(),
+          powerRail.name,
+          single(
+              state -> new CounterPanel(state, powerRailTrack, POWER_RAIL_COUNTER_TRACK_HEIGHT),
+              true,
+              true));
+    }
+
+    Group.UiFactory ui =
+        group(
+            state ->
+                new PowerSummaryPanel(state, powerSummaryTrack, POWER_RAIL_COUNTER_TRACK_HEIGHT),
+            false);
+    data.tracks.addLabelGroup(null, powerSummaryTrack.getId(), "Power Usage", ui);
+    return data;
+  }
+
+  private static String buildViewSql(List<CounterInfo> powerRails) {
+    minValue = powerRails.get(0).min;
+    maxValue = powerRails.get(0).max;
+    StringBuilder sb =
+        new StringBuilder()
+            .append("select aggregateTable.ts ts, sum(aggregateTable.value) totalValue from")
+            .append(" (")
+            .append(VIEW_SQL_MONOTONIC)
+            .append(powerRails.get(0).id)
+            .append(" window win as (order by ts) ")
+            .append(") as aggregateTable");
+    for (int i = 1; i < numPowerRailTracks; i++) {
+      sb.append("left join (")
+          .append(VIEW_SQL_MONOTONIC)
+          .append(powerRails.get(i).id)
+          .append(" window win as (order by ts) ")
+          .append(") ");
+      minValue = Math.min(minValue, powerRails.get(i).min);
+      maxValue = Math.max(maxValue, powerRails.get(i).max);
+    }
+    sb.append(" group by ts");
+    minValue = Math.min(0, minValue);
+    return sb.toString();
+  }
+
+  @Override
+  protected ListenableFuture<?> initialize() {
+    String vals = tableName("vals");
+    String span = tableName("span");
+    String window = tableName("window");
+    return qe.queries(
+        dropTable(span),
+        dropTable(window),
+        dropView(vals),
+        createView(vals, viewSql),
+        createWindow(window),
+        createSpan(span, vals + ", " + window));
+  }
+
+  @Override
+  protected ListenableFuture<Data> computeData(DataRequest req) {
+    Window win = Window.quantized(req, 5);
+    return transformAsync(win.update(qe, tableName("window")), $ -> computeData(req, win));
+  }
+
+  private ListenableFuture<Data> computeData(DataRequest req, Window win) {
+    return transform(
+        qe.query(sql()),
+        res -> {
+          int rows = res.getNumRows();
+          if (rows == 0) {
+            return Data.empty(req);
+          }
+
+          Data data = new Data(req, new long[rows + 1], new double[rows + 1]);
+          res.forEachRow(
+              (i, r) -> {
+                data.ts[i] = r.getLong(0);
+                data.values[i] = r.getDouble(1);
+              });
+          data.ts[rows] = res.getLong(rows - 1, 1, 0);
+          data.values[rows] = data.values[rows - 1];
+          return data;
+        });
+  }
+
+  private String sql() {
+    return format(viewSql, tableName("span"));
+  }
+
+  public static class Data extends Track.Data {
+    public final long[] ts;
+    public final double[] values;
+
+    public Data(DataRequest request, long[] ts, double[] values) {
+      super(request);
+      this.ts = ts;
+      this.values = values;
+    }
+
+    public static Data empty(DataRequest req) {
+      return new Data(req, new long[0], new double[0]);
+    }
+  }
+}

--- a/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
@@ -130,6 +130,7 @@ public class Tracks {
   public static Perfetto.Data.Builder enumerateCounters(Perfetto.Data.Builder data) {
     MemorySummaryTrack.enumerate(data);
     BatterySummaryTrack.enumerate(data);
+    PowerSummaryTrack.enumerate(data);
     return data;
   }
 

--- a/gapic/src/main/com/google/gapid/perfetto/views/PowerSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/PowerSummaryPanel.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.perfetto.views;
+
+import static com.google.gapid.perfetto.views.Loading.drawLoading;
+import static com.google.gapid.perfetto.views.StyleConstants.TRACK_MARGIN;
+import static com.google.gapid.perfetto.views.StyleConstants.colors;
+import static com.google.gapid.perfetto.views.StyleConstants.mainGradient;
+
+import com.google.gapid.perfetto.Unit;
+import com.google.gapid.perfetto.canvas.Area;
+import com.google.gapid.perfetto.canvas.Fonts;
+import com.google.gapid.perfetto.canvas.RenderContext;
+import com.google.gapid.perfetto.canvas.Size;
+import com.google.gapid.perfetto.models.PowerSummaryTrack;
+import com.google.gapid.perfetto.models.Selection;
+
+public class PowerSummaryPanel extends TrackPanel<PowerSummaryPanel> {
+  private static final double HOVER_MARGIN = 10;
+  private static final double HOVER_PADDING = 4;
+  private static final double CURSOR_SIZE = 5;
+  private static Unit unit;
+
+  protected final PowerSummaryTrack track;
+  protected final double trackHeight;
+  protected HoverCard hovered = null;
+
+  public PowerSummaryPanel(State state, PowerSummaryTrack track, double trackHeight) {
+    super(state);
+    this.track = track;
+    this.trackHeight = trackHeight;
+    this.unit = track.unit;
+  }
+
+  @Override
+  public PowerSummaryPanel copy() {
+    return new PowerSummaryPanel(state, track, trackHeight);
+  }
+
+  @Override
+  public String getTitle() {
+    return "Power Usage";
+  }
+
+  @Override
+  public double getHeight() {
+    return trackHeight;
+  }
+
+  @Override
+  protected void renderTrack(RenderContext ctx, Repainter repainter, double w, double h) {
+    ctx.trace(
+        "PowerSummary",
+        () -> {
+          PowerSummaryTrack.Data data = track.getData(state.toRequest(), onUiThread(repainter));
+          drawLoading(ctx, data, state, h);
+
+          if (data == null || data.ts.length == 0) {
+            return;
+          }
+
+          Selection<?> selected = state.getSelection(Selection.Kind.Counter);
+          mainGradient().applyBaseAndBorder(ctx);
+          ctx.path(
+              path -> {
+                double lastX = state.timeToPx(data.ts[0]), lastY = h;
+                path.moveTo(lastX, lastY);
+                for (int i = 0; i < data.ts.length; i++) {
+                  double range =
+                      (track.minValue == track.maxValue && track.minValue == 0)
+                          ? 1
+                          : (track.maxValue - track.minValue);
+                  double nextX = state.timeToPx(data.ts[i]);
+                  double nextY =
+                      (trackHeight - 1) * (1 - (data.values[i] - track.minValue) / range);
+                  path.lineTo(nextX, lastY);
+                  path.lineTo(nextX, nextY);
+                  lastX = nextX;
+                  lastY = nextY;
+                }
+
+                path.lineTo(lastX, h);
+                ctx.fillPath(path);
+                ctx.drawPath(path);
+              });
+
+          if (hovered != null) {
+            double y =
+                (trackHeight - 1)
+                    * (1
+                        - (hovered.value - hovered.minValue)
+                            / (hovered.maxValue - hovered.minValue));
+            ctx.setBackgroundColor(mainGradient().highlight);
+            ctx.fillRect(hovered.startX, y - 1, hovered.endX - hovered.startX, trackHeight - y + 1);
+            ctx.setForegroundColor(colors().textMain);
+            ctx.drawCircle(hovered.mouseX, y, CURSOR_SIZE / 2);
+
+            ctx.setBackgroundColor(colors().hoverBackground);
+            double bgH = Math.max(hovered.size.h, trackHeight);
+            // The left x-axis coordinate of HoverCard.
+            double hx = hovered.mouseX + CURSOR_SIZE / 2 + HOVER_MARGIN;
+            if (hx >= w - (2 * HOVER_PADDING + hovered.size.w)) {
+              hx =
+                  hovered.mouseX
+                      - CURSOR_SIZE / 2
+                      - HOVER_MARGIN
+                      - 2 * HOVER_PADDING
+                      - hovered.size.w;
+            }
+            ctx.fillRect(
+                hx, Math.min((trackHeight - bgH) / 2, 0), 2 * HOVER_PADDING + hovered.size.w, bgH);
+            ctx.setForegroundColor(colors().textMain);
+            // The left x-axis coordinate of the left labels.
+            double x = hx + HOVER_PADDING;
+            y = (trackHeight - hovered.size.h) / 2;
+            // The difference between the x-axis coordinate of the left labels and the right labels.
+            double dx = hovered.leftWidth + HOVER_PADDING, dy = hovered.size.h / 2;
+            ctx.drawText(Fonts.Style.Normal, "Value:", x, y);
+            ctx.drawText(Fonts.Style.Normal, hovered.minLabel, x + dx, y);
+            ctx.drawText(Fonts.Style.Normal, hovered.maxLabel, x + dx, y + dy);
+
+            x = hx + HOVER_PADDING + hovered.leftWidth;
+            ctx.drawTextRightJustified(Fonts.Style.Normal, hovered.valueLabel, x, y, dy);
+
+            x = hx + HOVER_PADDING + hovered.size.w;
+            ctx.drawTextRightJustified(Fonts.Style.Normal, hovered.min, x, y, dy);
+            ctx.drawTextRightJustified(Fonts.Style.Normal, hovered.max, x, y + dy, dy);
+          }
+        });
+  }
+
+  @Override
+  protected Hover onTrackMouseMove(
+      Fonts.TextMeasurer m, Repainter repainter, double x, double y, int mods) {
+    PowerSummaryTrack.Data data = track.getData(state.toRequest(), onUiThread(repainter));
+    if (data == null || data.ts.length == 0) {
+      return Hover.NONE;
+    }
+
+    long time = state.pxToTime(x);
+    if (time < data.ts[0] || time > data.ts[data.ts.length - 1]) {
+      return Hover.NONE;
+    }
+
+    int idx = 0;
+    for (; idx < data.ts.length - 1; idx++) {
+      if (data.ts[idx + 1] > time) {
+        break;
+      }
+    }
+
+    if (idx >= data.ts.length) {
+      return Hover.NONE;
+    }
+
+    double startX = state.timeToPx(data.ts[idx]);
+    double endX = (idx >= data.ts.length - 1) ? startX : state.timeToPx(data.ts[idx + 1]);
+    hovered = new HoverCard(m, track.minValue, track.maxValue, data.values[idx], startX, endX, x);
+
+    return new Hover() {
+      @Override
+      public Area getRedraw() {
+        // The area of the sample can be larger than the hover card. Hence the redraw area needs to
+        // at least cover the whole sample because when we move between samples, the highlight of
+        // the previous sample needs to be redrawn without highlight. If the redraw area only
+        // covers the hover card then the area that is not intersected with the hover card will
+        // not be redrawn, and hence the highlight remains in that area.
+
+        // First, calculate the default left boundary x-axis coordinate and width of the
+        // redrawn area.
+        final double defaultX = hovered.mouseX - CURSOR_SIZE / 2;
+        final double defaultW =
+            CURSOR_SIZE + HOVER_MARGIN + HOVER_PADDING + hovered.size.w + HOVER_PADDING;
+
+        // Assuming the hover card is drawn on the right of the hover point.
+
+        // Determine the x-axis coordinate of the left boundary of the redrawn area.
+        double redrawLx = Math.min(defaultX, startX);
+
+        // Determine the x-axis coordinate of the right boundary of the redrawn area by comparing
+        // the right end of the sample with the right boundary of the default redrawn area.
+        double redrawRx = Math.max(defaultX + defaultW, endX);
+
+        // Calculate the real redrawn width.
+        double redrawW = redrawRx - redrawLx;
+
+        if (defaultX >= state.getWidth() - defaultW) {
+
+          // re-calculate the left boundary of the redrawn area by comparing the start end of the
+          // sample with the left boundary of the default redrawn area when the hover card is drawn
+          // on the left side of the hover point.
+          redrawLx = Math.min(startX, hovered.mouseX + CURSOR_SIZE / 2 - defaultW);
+
+          // re-calculate the right boundary of the redrawn area by comparing the end of the sample
+          // with the right boundary of the default redrawn area when the hover card is drawn on
+          // the left side of the hover point.
+          redrawRx = Math.max(hovered.mouseX + CURSOR_SIZE / 2, endX);
+
+          // Finally, re-calculate the redrawn width, plus radius of the cursor to avoid the
+          // precision issue at the right edge of the cursor.
+          redrawW = redrawRx - redrawLx + CURSOR_SIZE / 2;
+        }
+
+        return new Area(redrawLx, -TRACK_MARGIN, redrawW, trackHeight + 2 * TRACK_MARGIN);
+      }
+
+      @Override
+      public void stop() {
+        hovered = null;
+      }
+    };
+  }
+
+  private static class HoverCard {
+    public final double value;
+    public final double minValue;
+    public final double maxValue;
+    public final double startX, endX;
+    public final double mouseX;
+    public final String valueLabel;
+    public final String min, max;
+    public final String minLabel, maxLabel;
+    public final double leftWidth;
+    public final Size size;
+
+    public HoverCard(
+        Fonts.TextMeasurer tm,
+        Double minValue,
+        Double maxValue,
+        double value,
+        double startX,
+        double endX,
+        double mouseX) {
+      this.value = value;
+      this.startX = startX;
+      this.endX = endX;
+      this.mouseX = mouseX;
+      this.minValue = Math.min(minValue, 0);
+      this.maxValue = maxValue;
+      this.valueLabel = unit.format(value);
+
+      // TODO: figure out how to use unit
+      this.min = unit.format(minValue);
+      this.max = unit.format(maxValue);
+
+      this.minLabel = "Trace Min:";
+      this.maxLabel = "Trace Max:";
+
+      Size valueSize = tm.measure(Fonts.Style.Normal, valueLabel);
+      Size minSize = tm.measure(Fonts.Style.Normal, min);
+      Size maxSize = tm.measure(Fonts.Style.Normal, max);
+
+      double leftLabel = tm.measure(Fonts.Style.Normal, "Value:").w;
+      double rightLabel =
+          Math.max(
+                  tm.measure(Fonts.Style.Normal, minLabel).w,
+                  tm.measure(Fonts.Style.Normal, maxLabel).w)
+              + HOVER_PADDING;
+      this.leftWidth = leftLabel + valueSize.w;
+      this.size =
+          new Size(
+              leftWidth + HOVER_PADDING + rightLabel + Math.max(minSize.w, maxSize.w),
+              Math.max(valueSize.h, minSize.h + maxSize.h) + HOVER_PADDING);
+    }
+  }
+}


### PR DESCRIPTION
Currently, System Profiler displays the raw power utilized by different power rail tracks individually. This change introduces a new power summary track, which depicts the combined power used by all the tracks in that trace. It also displays a graph based on the aggregated values.

![Power Summary Graph](https://user-images.githubusercontent.com/24795489/183929141-a86afd0f-6f8f-4003-9ecd-f58b462cda72.png)
