### PR TITLE
Fixes Vulkan application crash that occurs

### DIFF
--- a/gapis/api/vulkan/templates/vulkan_layer.tmpl
+++ b/gapis/api/vulkan/templates/vulkan_layer.tmpl
@@ -586,9 +586,15 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL
 vkGetDeviceProcAddr(VkDevice device, const char *pName);
 
+VKAPI_ATTR void VKAPI_CALL vkDestroyInstance(VkInstance instance, AllocationCallbacks pAllocator);
+
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(
     const VkInstance  instance,
     const char* pName) {
+
+    if (strcmp(pName, "vkDestroyInstance") == 0) {
+      return (PFN_vkVoidFunction)(internal::vkDestroyInstance);
+    }
     if (strcmp(pName, "vkCreateInstance") == 0) {
       return (PFN_vkVoidFunction)(internal::vkCreateInstance);
     }


### PR DESCRIPTION
when the application creates an vulkan instance, destroys & creates another instance with the
same handle ID. vulkan layer returns VK_ERROR_INITIALIZATION_FAILED as the original instance
still exists in the local map.