### PR TITLE
Bumping the version number to 3.2.0

### DIFF
--- a/version.bzl
+++ b/version.bzl
@@ -15,7 +15,7 @@
 # True source of AGI versions.
 # Increment these numbers immediately after releasing a new version.
 AGI_VERSION_MAJOR="3"
-AGI_VERSION_MINOR="1"
+AGI_VERSION_MINOR="2"
 AGI_VERSION_POINT="0"
 
 # See bazel.rc. Can be overriden on the command line with:


### PR DESCRIPTION
Bumping the version number as the default behaviour changed for frame boundary selection.