### PR TITLE
Disable Fuchsia device scan when SDK is not found

### DIFF
--- a/cmd/gapis/main.go
+++ b/cmd/gapis/main.go
@@ -97,6 +97,16 @@ func run(ctx context.Context) error {
 		adb.ADB = file.Abs(*adbPath)
 	}
 
+	// Check if FFX SDK path is set, which is necessary to scan Fuchsia devices
+	if *scanFuchsiaDevs {
+		_, ffxFound := os.LookupEnv("FUCHSIA_FFX_PATH")
+		if !ffxFound {
+			// Disable Fuchsia device scanning when there is no SDK, to avoid runtime errors
+			log.W(ctx, "FUCHSIA_FFX_PATH is not set, disabling Fuchsia device monitoring.")
+			*scanFuchsiaDevs = false
+		}
+	}
+
 	r := bind.NewRegistry()
 	ctx = bind.PutRegistry(ctx, r)
 	m := replay.New(ctx)

--- a/core/os/android/adb/device.go
+++ b/core/os/android/adb/device.go
@@ -103,7 +103,7 @@ func Monitor(ctx context.Context, r *bind.Registry, interval time.Duration) erro
 	for {
 		if err := scanDevices(ctx); err != nil {
 			if time.Since(lastErrorPrinted).Seconds() > printScanErrorsEveryNSeconds {
-				log.E(ctx, "Couldn't scan devices: %v", err)
+				log.E(ctx, "Couldn't scan Android devices: %v", err)
 				lastErrorPrinted = time.Now()
 			}
 		} else {

--- a/core/os/fuchsia/ffx/device.go
+++ b/core/os/fuchsia/ffx/device.go
@@ -87,7 +87,7 @@ func Monitor(ctx context.Context, r *bind.Registry, interval time.Duration) erro
 		err := scanDevices(ctx)
 		if err != nil {
 			if time.Since(lastErrorPrinted).Seconds() > printScanErrorsEveryNSeconds {
-				log.E(ctx, "Couldn't scan devices: %v", err)
+				log.E(ctx, "Couldn't scan Fuchsia devices: %v", err)
 				lastErrorPrinted = time.Now()
 			}
 		} else {


### PR DESCRIPTION
Rather than reporting many Fuchsia SDK errors at runtime, this CL makes sure a single warning is given at the startup for gapis and disables monitoring of Fuchsia devices. 
(b/240447828)