### PR TITLE
Change gapis log message timestamps to system local;

### DIFF
--- a/core/log/log.go
+++ b/core/log/log.go
@@ -150,7 +150,7 @@ func (l *Logger) Message(s Severity, stopProcess bool, text string) *Message {
 
 	m := &Message{
 		Text:        text,
-		Time:        t.In(time.UTC),
+		Time:        t.In(time.Local),
 		Severity:    s,
 		StopProcess: stopProcess,
 		Tag:         l.tag,


### PR DESCRIPTION
Most of the users of AGI runs the server locally, so it's better to provide system local timestamps for readability and comparison with other logs. 