### PR TITLE
Add missing functionality for Vulkan parser

### DIFF
--- a/vulkan_generator/tests/test_union_parsing.py
+++ b/vulkan_generator/tests/test_union_parsing.py
@@ -141,6 +141,18 @@ def test_vulkan_union_with_array() -> None:
     typ = union_parser.parse(ET.fromstring(xml))
 
     assert isinstance(typ, internal_types.VulkanUnion)
-    assert typ.members["float32"].array_length == 4
-    assert typ.members["int32"].array_length == 4
-    assert typ.members["uint32"].array_length == 4
+
+    size_float32 = typ.members["float32"].size
+    assert size_float32
+    assert len(size_float32) == 1
+    assert size_float32[0] == "4"
+
+    size_int32 = typ.members["int32"].size
+    assert size_int32
+    assert len(size_int32) == 1
+    assert size_int32[0] == "4"
+
+    size_uint32 = typ.members["float32"].size
+    assert size_uint32
+    assert len(size_uint32) == 1
+    assert size_uint32[0] == "4"

--- a/vulkan_generator/vulkan_parser/api/types.py
+++ b/vulkan_generator/vulkan_parser/api/types.py
@@ -203,6 +203,9 @@ class VulkanFunctionArgument:
     type: VulkanType
     name: str
 
+    # Full typename of the function argument. This would include modifiers e.g. const and *
+    full_typename: str
+
 
 @dataclass
 class VulkanFunctionPtr(VulkanType):
@@ -224,6 +227,9 @@ class VulkanStructMember:
     # Full typename of the member. This would include modifiers e.g. const and *
     full_typename: str
 
+    # Full field name of the member. This would include modifiers e.g. arrays
+    full_member_name: str
+
     # Some members have this property which states if that particular
     # member has to be valid if they are not null
     no_auto_validity: Optional[bool]
@@ -232,11 +238,14 @@ class VulkanStructMember:
     expected_value: Optional[VulkanEnumField]
 
     # Some member variables are static arrays with a default size
-    size: Optional[Union[VulkanDefine, VulkanStructMember]]
+    size: Optional[Union[VulkanDefine, VulkanStructMember, List[int]]]
 
     # Sometimes size is a calculation based on another member or a define
     # in that case we need the calculation text as well
     size_calculation: Optional[str]
+
+    # If the field is a C sytle bitfield, this will be the size of it
+    c_bitfield_size: Optional[int]
 
     # Is this field has to be set and/or not-null
     optional: Optional[bool]
@@ -300,6 +309,10 @@ class VulkanUnionMember:
     type: VulkanType
     name: str
 
+    # Full member name of the member required for declaration.
+    # This would include modifiers e.g. arrays
+    full_member_name: str
+
     # Some members have this property which states if that particular
     # member has to be valid if they are not null
     no_auto_validity: Optional[bool]
@@ -309,7 +322,7 @@ class VulkanUnionMember:
     selection: Optional[str]
 
     # If this member is a static array, what is the length
-    array_length: Optional[int]
+    size: Optional[List[int]]
 
 
 @dataclass

--- a/vulkan_generator/vulkan_parser/internal/internal_types.py
+++ b/vulkan_generator/vulkan_parser/internal/internal_types.py
@@ -109,7 +109,12 @@ class VulkanStructMember:
 
     # If the member is an array, it's size is defined by another
     # member in the struct or a define if it's a static array
-    size: Optional[str]
+    # If the array is multidimensional, sizes of each dimention will be
+    # listed in order.
+    size: Optional[List[str]]
+
+    # Some structs uses C bitfield sizes
+    c_bitfield_size: Optional[int]
 
     # Is this field has to be set and/or not-null
     optional: Optional[bool]
@@ -149,7 +154,7 @@ class VulkanUnionMember:
     selection: Optional[str]
 
     # If this member is a static array, what is the length
-    array_length: Optional[int]
+    size: Optional[List[str]]
 
 
 @dataclass

--- a/vulkan_generator/vulkan_parser/internal/union_parser.py
+++ b/vulkan_generator/vulkan_parser/internal/union_parser.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2022 Google Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License, Verlon 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
@@ -23,27 +23,22 @@ from vulkan_generator.vulkan_parser.internal import parser_utils
 from vulkan_generator.vulkan_parser.internal import internal_types
 
 
-def parse_member(member_element) -> internal_types.VulkanUnionMember:
+def parse_member(member_element: ET.Element) -> internal_types.VulkanUnionMember:
     """Parses a Vulkan Union Member"""
     typ = parser_utils.get_text_from_tag_in_children(member_element, "type")
     name = parser_utils.get_text_from_tag_in_children(member_element, "name")
 
     # Currently if this attribute exists, it's always true
     no_auto_validity = member_element.get("noautovalidity") == "true"
-
     selection = member_element.get("selection")
-
-    length_str = parser_utils.try_get_tail_from_tag_in_children(member_element, "name")
-    if length_str:
-        length_str = length_str.replace("[", "").replace("]", "")
-    length = int(length_str) if length_str else None
+    size = parser_utils.parse_member_sizes(member_element)
 
     return internal_types.VulkanUnionMember(
         member_type=typ,
         member_name=name,
         no_auto_validity=no_auto_validity,
         selection=selection,
-        array_length=length
+        size=size,
     )
 
 


### PR DESCRIPTION
Fixes a few missing thing from the parser

- Full typename for function pointers
- Missing implementation for multi dimensional arrays
- Missing implementation for C style bitfields
- Full variable name for C style bitfields and static arrays