### PR TITLE
Update fuchsia_sdk.bzl

### DIFF
--- a/tools/build/fuchsia/enabled/fuchsia_sdk.bzl
+++ b/tools/build/fuchsia/enabled/fuchsia_sdk.bzl
@@ -22,11 +22,6 @@ def fuchsia_sdk_dependencies(locals = {}):
     fuchsia_sdk_repository,
     name = "fuchsia_sdk_dynamic",
     locals = locals,
-    cipd_tag = "version:7.20220228.3.1",
-    sha256 = {
-      "linux": "7f886893f5758272da4f51aced35448fa83805aa0f2b363f2e538db4cf936462",
-      "mac": "e18ea6c85b436146ce9f93f6abcea35baea2ba23f9544a87e7b6f5632ade374e",
-    },
   )
   native.register_toolchains("@fuchsia_sdk_dynamic//:fuchsia_toolchain_sdk")
 
@@ -34,10 +29,5 @@ def fuchsia_sdk_dependencies(locals = {}):
     fuchsia_clang_repository,
     name = "fuchsia_clang",
     locals = locals,
-    cipd_tag = "git_revision:c9e46219f38da5c3fbfe41012173dc893516826e",
     sdk_root_label = "@fuchsia_sdk_dynamic",
-    sha256 = {
-      "linux": "573ebb62fc5cd9d2357be630cc079fa97b028cd99e2e87132dcd8be31c425984",
-      "mac": "fb9e478d18f35d0a9bb186138a85cf7ef5f9078fbf432fc3ad8f0660b233b3b4",
-    },
   )


### PR DESCRIPTION
Remove cipd_tag and sha, so the versions of these repos are rolled automatically.