### PR TITLE
Frame boundary option change for the tracing UI

### DIFF
--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -336,7 +336,7 @@ public class TracerDialog {
       private final Spinner duration;
       private final Label durationUnit;
       private final Label startUnit;
-      private final Button ignoreAndroidFrameBoundary;
+      private final Button useAndroidFrameBoundaryExtension;
       private final Button withoutBuffering;
       private final Button includeUnsupportedExtensions;
       private final Button loadValidationLayer;
@@ -490,8 +490,9 @@ public class TracerDialog {
         duration.setVisible(DURATION_FRAMES_MAX > 1);
         durationUnit = createLabel(durGroup, DURATION_FRAMES_UNIT);
         durationUnit.setVisible(DURATION_FRAMES_MAX > 1);
-        ignoreAndroidFrameBoundary = createCheckbox(durGroup, "Ignore ANDROID_frame_boundary extension", true);
-        ignoreAndroidFrameBoundary.setEnabled(true);
+        useAndroidFrameBoundaryExtension = createCheckbox(durGroup, "Use ANDROID_frame_boundary extension", false,
+         "Enables using ANDROID_frame_boundary extension to define the frame boundaries. Otherwise, the present calls are used.");
+        useAndroidFrameBoundaryExtension.setEnabled(true);
 
         Group optGroup  = withLayoutData(
             createGroup(this, "Trace Options", new GridLayout(2, false)),
@@ -1031,7 +1032,7 @@ public class TracerDialog {
             .setUri(traceTarget.getText())
             .setAdditionalCommandLineArgs(arguments.getText())
             .setFramesToCapture(duration.getSelection())
-            .setIgnoreFrameBoundaryDelimiters(ignoreAndroidFrameBoundary.getSelection())
+            .setIgnoreFrameBoundaryDelimiters(!useAndroidFrameBoundaryExtension.getSelection())
             .setNoBuffer(withoutBuffering.getSelection())
             .setHideUnknownExtensions(!includeUnsupportedExtensions.getSelection())
             .setServerLocalSavePath(output.getAbsolutePath())

--- a/gapic/src/main/com/google/gapid/widgets/Widgets.java
+++ b/gapic/src/main/com/google/gapid/widgets/Widgets.java
@@ -380,6 +380,15 @@ public class Widgets {
     return button;
   }
 
+  public static Button createCheckbox(Composite parent, String label, boolean checked, String tooltipText) {
+    // Workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=561592 - set label first.
+    Button button = new Button(parent, SWT.CHECK);
+    button.setText(label);
+    button.setSelection(checked);
+    button.setToolTipText(tooltipText);
+    return button;
+  }
+
   public static Button createCheckbox(
       Composite parent, String label, boolean checked, Listener listener) {
     // Workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=561592 - set label first.


### PR DESCRIPTION
Changes to reflect the decision on making the option one-or-the-other way for setting up frame delimiters. Also added a tooltip on the checkbox to make it more understandable. 