### PR TITLE
handle missing energy tracks case

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/models/PowerSummaryTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/PowerSummaryTrack.java
@@ -104,20 +104,23 @@ public class PowerSummaryTrack extends Track.WithQueryEngine<PowerSummaryTrack.D
             .map(Map.Entry::getValue)
             .collect(Collectors.toList());
 
-    String energyBreakdownGroup = "energy_breakdown_group";
-    data.tracks.addLabelGroup(
-        null,
-        energyBreakdownGroup,
-        "Energy Breakdown",
-        group(state -> new TitlePanel("Energy Breakdown"), true));
-    for (CounterInfo energy : energyTracks) {
-      EnergyBreakdownTrack energyTrack = new EnergyBreakdownTrack(data.qe, energy);
-      data.tracks.addTrack(
+    if(energyTracks.size() > 0) { //TODO: handle in a better way
+      String energyBreakdownGroup = "energy_breakdown_group";
+      data.tracks.addLabelGroup(
+          null,
           energyBreakdownGroup,
-          energyTrack.getId(),
-          energy.name,
-          single(state -> new EnergyBreakdownPanel(state, energyTrack, 50), true, true));
+          "Energy Breakdown",
+          group(state -> new TitlePanel("Energy Breakdown"), true));
+      for (CounterInfo energy : energyTracks) {
+        EnergyBreakdownTrack energyTrack = new EnergyBreakdownTrack(data.qe, energy);
+        data.tracks.addTrack(
+            energyBreakdownGroup,
+            energyTrack.getId(),
+            energy.name,
+            single(state -> new EnergyBreakdownPanel(state, energyTrack, 50), true, true));
+      }
     }
+    
     return data;
   }
 


### PR DESCRIPTION
System profiler is not working correctly since we didn't test the dependency update branch with the code submitted earlier. It crashes when a perfetto file is loaded without any energy tracks, or a new trace is performed. This CL adds a size check for energy tracks to get things running again. a better fix and UI can be added later. 

<img width="420" alt="Screen Shot 2022-09-15 at 22 37 52" src="https://user-images.githubusercontent.com/104000734/190519177-5e3b7f37-aa49-40b5-ac61-18f87b16e461.png">
