### PR TITLE
[fuchsia] Move libgapii.so to fuchsia_package_resource()

### DIFF
--- a/gapii/fuchsia/BUILD.bazel
+++ b/gapii/fuchsia/BUILD.bazel
@@ -36,8 +36,13 @@ fuchsia_component(
     manifest = ":manifest",
     deps = [
         ":gapii_server",
-        "//gapii/cc:libgapii",
     ],
+)
+
+fuchsia_package_resource(
+    name = "libgapii",
+    src = "//gapii/cc:libgapii",
+    dest = "lib/libgapii.so",
 )
 
 fuchsia_package_resource(
@@ -51,5 +56,6 @@ fuchsia_package(
     deps = [
         ":gapii-server",
         ":graphics_spy_json",
+        ":libgapii",
     ],
 )


### PR DESCRIPTION
- Allows loader to load the layer in a more canonical way.