### PR TITLE
[fuchsia] Rename interposer layer.

### DIFF
--- a/gapii/fuchsia/BUILD.bazel
+++ b/gapii/fuchsia/BUILD.bazel
@@ -43,16 +43,16 @@ fuchsia_package_resource(
 )
 
 fuchsia_package_resource(
-    name = "graphics_spy_json",
+    name = "gpu_inspector_json",
     src = "//gapii/vulkan/vk_graphics_spy/fuchsia:fuchsia_json",
-    dest = "data/vulkan/explicit_layer.d/GraphicsSpyLayer.json",
+    dest = "data/vulkan/explicit_layer.d/GpuInspectorLayer.json",
 )
 
 fuchsia_package(
     name = "gapii",
     deps = [
         ":gapii-server",
-        ":graphics_spy_json",
+        ":gpu_inspector_json",
         ":libgapii",
     ],
 )

--- a/gapii/vulkan/vk_graphics_spy/fuchsia/BUILD.bazel
+++ b/gapii/vulkan/vk_graphics_spy/fuchsia/BUILD.bazel
@@ -14,6 +14,6 @@
 
 filegroup(
     name = "fuchsia_json",
-    srcs = ["GraphicsSpyLayerFuchsia.json"],
+    srcs = ["GpuInspectorFuchsia.json"],
     visibility = ["//visibility:public"],
 )

--- a/gapii/vulkan/vk_graphics_spy/fuchsia/GpuInspectorFuchsia.json
+++ b/gapii/vulkan/vk_graphics_spy/fuchsia/GpuInspectorFuchsia.json
@@ -1,12 +1,12 @@
 {
   "file_format_version" : "1.0.0",
   "layer": {
-    "name": "GraphicsSpy",
+    "name": "VK_LAYER_GOOGLE_gpu_inspector",
     "type": "GLOBAL",
     "library_path": "../../../lib/libgapii.so",
     "api_version" : "1.3.231",
     "implementation_version" : "1",
-    "description" : "Graphics Spy Layer",
+    "description" : "GPU Inspector Layer",
     "functions": {
       "vkGetDeviceProcAddr": "gapid_vkGetDeviceProcAddr",
       "vkGetInstanceProcAddr": "gapid_vkGetInstanceProcAddr"


### PR DESCRIPTION
- Current name "GraphicsSpy" doesn't conform to the loader's layer naming standard.