### PR TITLE
Reorder gpu slice validation

### DIFF
--- a/gapis/trace/android/adreno/validate.go
+++ b/gapis/trace/android/adreno/validate.go
@@ -47,9 +47,6 @@ func (v *AdrenoValidator) Validate(ctx context.Context, processor *perfetto.Proc
 	if err := validate.ValidateGpuSlices(ctx, processor); err != nil {
 		return err
 	}
-	if err := validate.ValidateVulkanEvents(ctx, processor); err != nil {
-		return err
-	}
 
 	return nil
 }

--- a/gapis/trace/android/generic/validate.go
+++ b/gapis/trace/android/generic/validate.go
@@ -54,9 +54,6 @@ func (v *GenericValidator) Validate(ctx context.Context, processor *perfetto.Pro
 	if err := validate.ValidateGpuSlices(ctx, processor); err != nil {
 		return err
 	}
-	if err := validate.ValidateVulkanEvents(ctx, processor); err != nil {
-		return err
-	}
 
 	return nil
 }

--- a/gapis/trace/android/mali/validate.go
+++ b/gapis/trace/android/mali/validate.go
@@ -76,9 +76,6 @@ func (v *MaliValidator) Validate(ctx context.Context, processor *perfetto.Proces
 	if err := validate.ValidateGpuSlices(ctx, processor); err != nil {
 		return err
 	}
-	if err := validate.ValidateVulkanEvents(ctx, processor); err != nil {
-		return err
-	}
 
 	return nil
 }

--- a/gapis/trace/android/validate/validate.go
+++ b/gapis/trace/android/validate/validate.go
@@ -262,7 +262,7 @@ func GetTrackIDs(ctx context.Context, s Scope, processor *perfetto.Processor) ([
 	return result, nil
 }
 
-// ValidateGpuSlices validates vulkan events and its associated render stage events, then 
+// ValidateGpuSlices validates vulkan events and its associated render stage events, then
 // returns nil if all validation passes.
 func ValidateGpuSlices(ctx context.Context, processor *perfetto.Processor) error {
 	tIds, err := GetTrackIDs(ctx, vulkanEventsTrackScope, processor)

--- a/gapis/trace/android/validate/validate.go
+++ b/gapis/trace/android/validate/validate.go
@@ -262,7 +262,8 @@ func GetTrackIDs(ctx context.Context, s Scope, processor *perfetto.Processor) ([
 	return result, nil
 }
 
-// ValidateGpuSlices validates vulkan events & gpu slices, returns nil if all validation passes.
+// ValidateGpuSlices validates vulkan events and its associated render stage events, then 
+// returns nil if all validation passes.
 func ValidateGpuSlices(ctx context.Context, processor *perfetto.Processor) error {
 	tIds, err := GetTrackIDs(ctx, vulkanEventsTrackScope, processor)
 	if err != nil {


### PR DESCRIPTION
- Validate vulkan events first and track the submission IDs
- Only validate render stage events that have an associated submission ID with a vulkan event