### PR TITLE
Set minimum height for queue panel

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/views/GpuQueuePanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/GpuQueuePanel.java
@@ -76,7 +76,7 @@ public class GpuQueuePanel extends TrackPanel<GpuQueuePanel> implements Selectab
 
   @Override
   public double getHeight() {
-    return queue.maxDepth * SLICE_HEIGHT;
+    return Math.max(SLICE_HEIGHT, queue.maxDepth * SLICE_HEIGHT);
   }
 
   @Override


### PR DESCRIPTION
Empty queues will show their text instead of being scrunched up.
Now:
![Screenshot 2023-01-10 at 5 49 43 PM](https://user-images.githubusercontent.com/14023901/211664582-9101d2c2-7109-490b-9d91-47e5fc016bef.png)

Previous:
![Empty queues showing up wrongly](https://user-images.githubusercontent.com/109323095/209026173-ab0f996c-e6c3-47b5-ad2a-ba856e32b0e0.png)

Fixes: https://github.com/google/agi/issues/1255