### PR TITLE
Remove set debug label calls that were causing segfaults

### DIFF
--- a/cmd/vulkan_sample/main.cpp
+++ b/cmd/vulkan_sample/main.cpp
@@ -881,15 +881,6 @@ int main(int argc, const char** argv) {
     }                                                         \
   } while (false)
 
-  // Set debug labels of objects created before the device.
-  SET_DEBUG_LABEL(instance, VK_OBJECT_TYPE_INSTANCE, "KubieInstance");
-  SET_DEBUG_LABEL(physical_device, VK_OBJECT_TYPE_PHYSICAL_DEVICE,
-                  "KubiePhysDevice");
-  SET_DEBUG_LABEL(device, VK_OBJECT_TYPE_DEVICE, "KubieDevice");
-  SET_DEBUG_LABEL(queue, VK_OBJECT_TYPE_QUEUE, "KubieQueue");
-  SET_DEBUG_LABEL(surface, VK_OBJECT_TYPE_SURFACE_KHR, "KubieSurface");
-  SET_DEBUG_LABEL(swapchain, VK_OBJECT_TYPE_SWAPCHAIN_KHR, "KubieSwapchain");
-
   // Immutable Data
   VkBuffer vertex_buffer;
   VkDeviceMemory vertex_buffer_memory;


### PR DESCRIPTION
Segfault from `strlen` that happens when doing repeated calls of set debug labels

```
05-18 14:20:38.260 16681 16681 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
05-18 14:20:38.260 16681 16681 F DEBUG   : Build fingerprint: 'Xiaomi/ishtar_eea/ishtar:13/TKQ1.221114.001/V14.0.0.2.TMAEUXM:user/release-keys'
05-18 14:20:38.260 16681 16681 F DEBUG   : Revision: '0'
05-18 14:20:38.260 16681 16681 F DEBUG   : ABI: 'arm64'
05-18 14:20:38.260 16681 16681 F DEBUG   : Timestamp: 2023-05-18 14:20:38.134186194+0100
05-18 14:20:38.260 16681 16681 F DEBUG   : Process uptime: 1s
05-18 14:20:38.260 16681 16681 F DEBUG   : Cmdline: com.google.android.gapid.arm64v8a
05-18 14:20:38.260 16681 16681 F DEBUG   : pid: 16635, tid: 16672, name: .gapid.arm64v8a  >>> com.google.android.gapid.arm64v8a <<<
05-18 14:20:38.260 16681 16681 F DEBUG   : uid: 10306
05-18 14:20:38.260 16681 16681 F DEBUG   : tagged_addr_ctrl: 0000000000000001 (PR_TAGGED_ADDR_ENABLE)
05-18 14:20:38.260 16681 16681 F DEBUG   : pac_enabled_keys: 000000000000000f (PR_PAC_APIAKEY, PR_PAC_APIBKEY, PR_PAC_APDAKEY, PR_PAC_APDBKEY)
05-18 14:20:38.260 16681 16681 F DEBUG   : signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0000000100000001
05-18 14:20:38.260 16681 16681 F DEBUG   :     x0  0000000100000001  x1  0000007afae82e70  x2  727553656962754b  x3  62754b0065636166
05-18 14:20:38.260 16681 16681 F DEBUG   :     x4  0000000000000001  x5  0000008000000000  x6  617449ff64626065  x7  7f7f7f7f7f7f7f7f
05-18 14:20:38.260 16681 16681 F DEBUG   :     x8  0101010101010101  x9  000000003b9aca00  x10 000000003b9cbdff  x11 000000003b9aca00
05-18 14:20:38.260 16681 16681 F DEBUG   :     x12 0000007b2bfa31ec  x13 000000000000005e  x14 0000000000000000  x15 0000000000000000
05-18 14:20:38.260 16681 16681 F DEBUG   :     x16 0000007a9fd91478  x17 0000007bac8f1a80  x18 a8f49a4aea8aa897  x19 0000007aa14a0d25
05-18 14:20:38.260 16681 16681 F DEBUG   :     x20 000000000000000c  x21 0000000100000001  x22 0000007afe705e40  x23 00000000000040fb
05-18 14:20:38.260 16681 16681 F DEBUG   :     x24 0000007afae83cb0  x25 0000007afae83cb0  x26 0000007afae83ff8  x27 00000000000fc000
05-18 14:20:38.260 16681 16681 F DEBUG   :     x28 00000000000fe000  x29 0000007afae800d0
05-18 14:20:38.260 16681 16681 F DEBUG   :     lr  0000007a9fbcfb9c  sp  0000007afae800d0  pc  0000007bac8f1a90  pst 0000000080001000
05-18 14:20:38.260 16681 16681 F DEBUG   : backtrace:
05-18 14:20:38.260 16681 16681 F DEBUG   :       #00 pc 0000000000086a90  /apex/com.android.runtime/lib64/bionic/libc.so (__strlen_aarch64+16) (BuildId: 449f781894033dce6346794a1ee593e0)
05-18 14:20:38.260 16681 16681 F DEBUG   :       #01 pc 00000000000d5b98  /vendor/lib64/hw/vulkan.adreno.so (qglinternal::vkSetDebugUtilsObjectNameEXT(VkDevice_T*, VkDebugUtilsObjectNameInfoEXT const*)+88) (BuildId: 47cd5cc030e2db5f8a699260174d46b3)
05-18 14:20:38.260 16681 16681 F DEBUG   :       #02 pc 0000000000010d24  /data/app/~~duGIuNh9BZ1GI8zY3NrpyQ==/com.google.android.gapid.arm64v8a-EtQIQXzJKfck95gBowWCgg==/lib/arm64/libvulkan_sample.so (main_impl()+11076)
05-18 14:20:38.260 16681 16681 F DEBUG   :       #03 pc 000000000000e1b0  /data/app/~~duGIuNh9BZ1GI8zY3NrpyQ==/com.google.android.gapid.arm64v8a-EtQIQXzJKfck95gBowWCgg==/lib/arm64/libvulkan_sample.so (android_main+248)
05-18 14:20:38.260 16681 16681 F DEBUG   :       #04 pc 0000000000026610  /data/app/~~duGIuNh9BZ1GI8zY3NrpyQ==/com.google.android.gapid.arm64v8a-EtQIQXzJKfck95gBowWCgg==/lib/arm64/libvulkan_sample.so (android_app_entry+308)
05-18 14:20:38.260 16681 16681 F DEBUG   :       #05 pc 00000000000f55c8  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208) (BuildId: 449f781894033dce6346794a1ee593e0)
05-18 14:20:38.260 16681 16681 F DEBUG   :       #06 pc 000000000008efbc  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+68) (BuildId: 449f781894033dce6346794a1ee593e0)
```