### PR TITLE
Update apk target sdk version to 34

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -56,7 +56,7 @@ Make sure the `JAVA_HOME` environment variable points to the JDK.
 ### Install Android SDK and NDK
 
 If you have Android Studio installed, use it to install:
-* SDK Platform: `Android 8.0 (Oreo) - API Level 26`
+* SDK Platform: `API Level 34`
 * SDK Tools: `NDK (Side by side) - 21.3.6528147`
 
 Otherwise you can use the basic Android command line tools:
@@ -68,7 +68,7 @@ Otherwise you can use the basic Android command line tools:
 
     ```
     cd <sdk-path>
-    cmdline-tools\latest\bin\sdkmanager.bat "platforms;android-26"
+    cmdline-tools\latest\bin\sdkmanager.bat "platforms;android-34"
     cmdline-tools\latest\bin\sdkmanager.bat "build-tools;30.0.3"
     cmdline-tools\latest\bin\sdkmanager.bat "ndk;21.3.6528147"
     ```
@@ -128,7 +128,7 @@ To fetch the required packages, using a console type:
 
 ```
 cd <sdk-path>
-tools/bin/sdkmanager "platforms;android-26" "build-tools;30.0.3"
+tools/bin/sdkmanager "platforms;android-34" "build-tools;30.0.3"
 ```
 
 If you do not have adb installed you can do so with:
@@ -224,7 +224,7 @@ To fetch the required packages, using a console type:
 
 ```
 cd <sdk-path>
-tools/bin/sdkmanager "platforms;android-26" "build-tools;30.0.3"
+tools/bin/sdkmanager "platforms;android-34" "build-tools;30.0.3"
 ```
 
 If you do not have adb installed you can do so with:

--- a/cmd/gapit/export_replay.go
+++ b/cmd/gapit/export_replay.go
@@ -40,7 +40,8 @@ import (
 
 // These versions must match the ones in gapidapk/android/apk/AndroidManifest.xml.in
 const minSdkVersion = 21
-const targetSdkVersion = 26
+
+const targetSdkVersion = 34
 
 type exportReplayVerb struct{ ExportReplayFlags }
 

--- a/gapidapk/android/apk/AndroidManifest.xml.in
+++ b/gapidapk/android/apk/AndroidManifest.xml.in
@@ -19,10 +19,14 @@
     android:versionCode="1"
     android:versionName="0.3 ({srchash})"
     >
+    
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <uses-sdk
         android:minSdkVersion="21"
-        android:targetSdkVersion="26" />
+
+        android:targetSdkVersion="34" />
     <application
         android:allowBackup="true"
         android:icon="@drawable/logo"
@@ -34,7 +38,8 @@
             android:name="com.android.graphics.developerdriver.enable"
             android:value="true" />
         <activity android:name="com.google.android.gapid.ReplayerActivity"
-                  android:label="GAPID - ${name}">
+                  android:label="GAPID - ${name}"
+                  android:exported="true">
             <meta-data android:name="android.app.lib_name"
                        android:value="gapir"/>
             <intent-filter>
@@ -44,7 +49,8 @@
         <activity android:name="com.google.android.gapid.VkSampleActivity"
                   android:label="GAPID - Vulkan Sample"
                   android:configChanges="orientation|screenSize"
-                  android:screenOrientation="portrait">
+                  android:screenOrientation="portrait"
+                  android:exported="true">
             <meta-data android:name="android.app.lib_name"
                        android:value="vulkan_sample" />
             <intent-filter>
@@ -53,6 +59,7 @@
         </activity>
         <service
             android:name="com.google.android.gapid.DeviceInfoService"
+            android:foregroundServiceType="dataSync"
             android:exported="true">
             <intent-filter>
                 <action android:name="com.google.android.gapid.action.SEND_DEV_INFO"/>
@@ -60,6 +67,7 @@
         </service>
         <service
             android:name="com.google.android.gapid.PackageInfoService"
+            android:foregroundServiceType="dataSync"
             android:exported="true">
             <intent-filter>
                 <action android:name="com.google.android.gapid.action.SEND_PKG_INFO"/>

--- a/gapidapk/android/app/src/main/java/com/google/android/gapid/GapidService.java
+++ b/gapidapk/android/app/src/main/java/com/google/android/gapid/GapidService.java
@@ -22,6 +22,10 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Intent;
 import android.os.Build;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
+
+import static android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC;
 
 /**
  * {@link IntentService} that can be run in the foreground. Newer versions of Android no longer
@@ -49,7 +53,7 @@ public abstract class GapidService extends IntentService {
         // gapidapk/android/app/src/main/BUILD.bazel
         .setSmallIcon(com.google.android.gapid.R.drawable.logo)
         // TODO: Show something if the user taps the notification?
-        .setContentIntent(PendingIntent.getActivity(this, 0, new Intent(), 0));
+        .setContentIntent(PendingIntent.getActivity(this, 0, new Intent(), PendingIntent.FLAG_IMMUTABLE));
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       NotificationChannel channel = new NotificationChannel(
@@ -60,8 +64,11 @@ public abstract class GapidService extends IntentService {
     } else {
       notification.setPriority(Notification.PRIORITY_LOW);
     }
-
-    startForeground(type.notificationId, notification.build());
+    if (VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE) {
+      startForeground(type.notificationId, notification.build(), FOREGROUND_SERVICE_TYPE_DATA_SYNC);
+    } else {
+      startForeground(type.notificationId, notification.build());
+    }
   }
 
   protected static enum Type {

--- a/kokoro/linux-test/test.sh
+++ b/kokoro/linux-test/test.sh
@@ -43,7 +43,7 @@ unzip -q android-ndk-r21d-linux-x86_64.zip
 export ANDROID_NDK_HOME=$PWD/android-ndk-r21d
 
 # Get recent build tools.
-echo y | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install 'build-tools;30.0.3' 'platforms;android-26'
+echo y | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install 'build-tools;30.0.3' 'platforms;android-34'
 
 # Get the JDK from our mirror.
 JDK_BUILD=zulu11.39.15-ca

--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -47,7 +47,7 @@ unzip -q android-ndk-r21d-linux-x86_64.zip
 export ANDROID_NDK_HOME=$PWD/android-ndk-r21d
 
 # Get recent build tools.
-echo y | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install 'build-tools;30.0.3' 'platforms;android-26'
+echo y | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install 'build-tools;30.0.3' 'platforms;android-34'
 
 # Get the JDK from our mirror.
 JDK_BUILD=zulu11.39.15-ca

--- a/kokoro/macos/build.sh
+++ b/kokoro/macos/build.sh
@@ -29,7 +29,7 @@ $CURL -O https://dl.google.com/android/repository/tools_r25.2.3-macosx.zip
 echo "593544d4ca7ab162705d0032fb0c0c88e75bd0f42412d09a1e8daa3394681dc6  tools_r25.2.3-macosx.zip" | shasum --check
 mkdir android
 unzip -q tools_r25.2.3-macosx.zip -d android
-echo y | ./android/tools/bin/sdkmanager build-tools\;30.0.3 platforms\;android-26
+echo y | ./android/tools/bin/sdkmanager build-tools\;30.0.3 platforms\;android-34
 $CURL -O https://dl.google.com/android/repository/android-ndk-r21d-darwin-x86_64.zip
 echo "5851115c6fc4cce26bc320295b52da240665d7ff89bda2f5d5af1887582f5c48  android-ndk-r21d-darwin-x86_64.zip" | shasum --check
 unzip -q android-ndk-r21d-darwin-x86_64.zip -d android

--- a/kokoro/presubmit/build.sh
+++ b/kokoro/presubmit/build.sh
@@ -42,7 +42,7 @@ sudo apt-get -y update
 sudo apt-get install -y clang-format-16
 
 # Get recent Android build tools.
-echo y | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install 'build-tools;30.0.3' 'platforms;android-26'
+echo y | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install 'build-tools;30.0.3' 'platforms;android-34'
 
 # Python Format tool
 pip install --root-user-action=ignore --user autopep8==1.6.0

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -53,7 +53,7 @@ copy /Y "%SRC%\kokoro\windows\android-sdk-license" "%ANDROID_HOME%\licenses\"
 
 REM Install Android SDK platform, build tools and NDK
 setlocal
-call %ANDROID_HOME%\tools\bin\sdkmanager.bat platforms;android-26 build-tools;30.0.3
+call %ANDROID_HOME%\tools\bin\sdkmanager.bat platforms;android-34 build-tools;30.0.3
 endlocal
 echo on
 

--- a/tools/build/rules/AndroidManifest.xml
+++ b/tools/build/rules/AndroidManifest.xml
@@ -19,6 +19,6 @@
 
     <uses-sdk
         android:minSdkVersion="21"
-        android:targetSdkVersion="26" />
+        android:targetSdkVersion="34" />
 
 </manifest>

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -335,7 +335,7 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
             native.android_sdk_repository,
             name = "androidsdk",
             locals = locals,
-            api_level = 26, # This is the target API
+            api_level = 34, # This is the target API
             build_tools_version = "30.0.3",
         )
 


### PR DESCRIPTION
Update APK target SDK version to 34

Add required permissions
Add activities required export=true
Add foreground service type

This allows to get rid of UI required actions during apk installation