### PR TITLE
Rename option "Clear Package Cache" -> "Clear Package Storage"

### DIFF
--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -509,7 +509,7 @@ public class TracerDialog {
             optGroup, "Disable Buffering", trace.getWithoutBuffering());
         withoutBuffering.setEnabled(true);
         clearCache = createCheckbox(
-            optGroup, "Clear Package Cache", trace.getClearCache());
+            optGroup, "Clear Package Storage", trace.getClearCache());
         clearCache.setEnabled(false);
         includeUnsupportedExtensions = createCheckbox(optGroup, "Include Unsupported Extensions", false);
         includeUnsupportedExtensions.setEnabled(false);

--- a/version.bzl
+++ b/version.bzl
@@ -15,8 +15,8 @@
 # True source of AGI versions.
 # Increment these numbers immediately after releasing a new version.
 AGI_VERSION_MAJOR="3"
-AGI_VERSION_MINOR="3"
-AGI_VERSION_POINT="1"
+AGI_VERSION_MINOR="4"
+AGI_VERSION_POINT="0"
 
 # See bazel.rc. Can be overriden on the command line with:
 #   bazel build --define AGI_BUILD_NUMBER=<#> --define AGI_BUILD_SHA=<sha>


### PR DESCRIPTION
Option already cleans all package data, but was names as "clear cache"
