### PR TITLE
Fix AGI perfetto emmiters to work with multiple threads

### DIFF
--- a/core/vulkan/perfetto_producer/perfetto_data_source.h
+++ b/core/vulkan/perfetto_producer/perfetto_data_source.h
@@ -23,6 +23,7 @@
 #include "core/vulkan/perfetto_producer/threadlocal_emitter_base.h"
 #include "gapil/runtime/cc/map.h"
 #include "gapil/runtime/cc/map.inc"
+#include "perfetto/tracing/core/data_source_config.h"
 #include "perfetto/tracing/core/data_source_descriptor.h"
 #include "perfetto/tracing/data_source.h"
 #include "perfetto/tracing/tracing.h"
@@ -66,6 +67,8 @@ class PerfettoProducerData {
   core::RecursiveSpinLock emitter_lock_;
   gapil::Map<ThreadlocalEmitterBase*, bool, false> emitters_;
   bool started_ = false;
+  bool have_data_source_config_ = false;
+  perfetto::DataSourceConfig data_source_config_;
 };
 }  // namespace core
 

--- a/core/vulkan/perfetto_producer/perfetto_data_source.inc
+++ b/core/vulkan/perfetto_producer/perfetto_data_source.inc
@@ -65,6 +65,7 @@ void PerfettoProducerData<T>::RegisterEmitter(ThreadlocalEmitterBase* v) {
     emitter_lock_.Lock();
     emitters_[v] = true;
     if (started_) {
+        v->SetupTracing(have_data_source_config_ ? &data_source_config_ : nullptr);
         v->StartTracing();
     }
     emitter_lock_.Unlock();
@@ -97,7 +98,12 @@ void PerfettoProducerData<T>::OnSetup(const typename perfetto::DataSourceBase::S
     emitter_lock_.Lock();
     started_ = true;
     for (auto& e : emitters_) {
-        e.first->SetupTracing(a);
+        e.first->SetupTracing(a.config);
+    }
+    have_data_source_config_ = false; 
+    if(a.config) {
+        have_data_source_config_ = true;
+        data_source_config_ = *a.config;
     }
     emitter_lock_.Unlock();
 }

--- a/core/vulkan/perfetto_producer/perfetto_data_source.inc
+++ b/core/vulkan/perfetto_producer/perfetto_data_source.inc
@@ -101,7 +101,7 @@ void PerfettoProducerData<T>::OnSetup(const typename perfetto::DataSourceBase::S
         e.first->SetupTracing(a.config);
     }
     have_data_source_config_ = false; 
-    if(a.config) {
+    if (a.config) {
         have_data_source_config_ = true;
         data_source_config_ = *a.config;
     }

--- a/core/vulkan/perfetto_producer/perfetto_threadlocal_emitter.h
+++ b/core/vulkan/perfetto_producer/perfetto_threadlocal_emitter.h
@@ -49,8 +49,7 @@ class ThreadlocalEmitter : ThreadlocalEmitterBase {
     reset_ = true;
     enabled_ = true;
   }
-  void SetupTracing(
-      const typename perfetto::DataSourceBase::SetupArgs&) override;
+  void SetupTracing(const typename perfetto::DataSourceConfig*) override;
   void StopTracing() override { enabled_ = false; }
   bool Enabled() { return enabled_; }
   bool CategoryEnabled(const char* category) {

--- a/core/vulkan/perfetto_producer/perfetto_threadlocal_emitter.inc
+++ b/core/vulkan/perfetto_producer/perfetto_threadlocal_emitter.inc
@@ -236,8 +236,7 @@ void ThreadlocalEmitter<T>::EmitProcessData() {
 
 template <typename T>
 void ThreadlocalEmitter<T>::SetupTracing(
-    const typename perfetto::DataSourceBase::SetupArgs& a) {
-  auto config = a.config;
+    const typename perfetto::DataSourceConfig* config) {
   if (config) {
     enabled_categories_.clear();
     std::istringstream f(config->legacy_config());

--- a/core/vulkan/perfetto_producer/threadlocal_emitter_base.h
+++ b/core/vulkan/perfetto_producer/threadlocal_emitter_base.h
@@ -23,8 +23,7 @@
 class ThreadlocalEmitterBase {
  public:
   virtual void StartTracing() = 0;
-  virtual void SetupTracing(
-      const typename perfetto::DataSourceBase::SetupArgs&) = 0;
+  virtual void SetupTracing(const typename perfetto::DataSourceConfig*) = 0;
   virtual void StopTracing() = 0;
 };
 

--- a/core/vulkan/vk_debug_marker_layer/cc/vk_api_emitter.h
+++ b/core/vulkan/vk_debug_marker_layer/cc/vk_api_emitter.h
@@ -32,8 +32,7 @@ class VkApiEmitter : ThreadlocalEmitterBase {
   ~VkApiEmitter();
 
   void StartTracing() override;
-  void SetupTracing(
-      const typename perfetto::DataSourceBase::SetupArgs&) override{};
+  void SetupTracing(const typename perfetto::DataSourceConfig*) override{};
   void StopTracing() override;
   void EmitDebugUtilsObjectName(uint64_t vk_device, int32_t object_type,
                                 uint64_t handle, const char* name);


### PR DESCRIPTION
Vulkan Cpu events were added to perfetto only for the first thread using Vulkan.